### PR TITLE
Fix FP rule MCP tool parameter mismatches

### DIFF
--- a/marketplace/plugins/lc-essentials/skills/detection-tuner/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/detection-tuner/SKILL.md
@@ -187,7 +187,7 @@ Create FP rules that are **specific enough** to suppress only the benign activit
 
 **Preferred approach - Multiple conditions (AND logic):**
 ```yaml
-data:
+detection:
   op: and
   rules:
     - op: is
@@ -204,7 +204,7 @@ data:
 **Avoid overly broad rules:**
 ```yaml
 # BAD - Too broad, will hide real threats
-data:
+detection:
   op: is
   path: cat
   value: suspicious_process
@@ -347,7 +347,7 @@ Display the complete FP rule with test results:
 
 **Rule Logic:**
 ```yaml
-data:
+detection:
   op: and
   rules:
     - op: is
@@ -395,7 +395,7 @@ parameters:
   oid: [organization-id]
   rule_name: "fp-suspicious-process-sccm-server-20251204"
   rule_content:
-    data:
+    detection:
       op: and
       rules:
         - op: is
@@ -457,7 +457,7 @@ The rule is now filtering detections.
 ### FP Rule Structure
 
 ```yaml
-data:
+detection:
   op: and  # or 'or'
   rules:
     - op: is

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/delete-fp-rule.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/delete-fp-rule.md
@@ -28,7 +28,7 @@ Before calling this skill, gather:
 
 **⚠️ IMPORTANT**: The Organization ID (OID) is a UUID (like `c1ffedc0-ffee-4a1e-b1a5-abc123def456`), **NOT** the organization name. If you don't have the OID, use the `list_user_orgs` skill first to get the OID from the organization name.
 - **oid**: Organization ID (required for all API calls)
-- **name**: Name of the FP rule to delete (must be exact match)
+- **rule_name**: Name of the FP rule to delete (must be exact match)
 
 ## How to Use
 
@@ -48,7 +48,7 @@ mcp__limacharlie__lc_call_tool(
   tool_name="delete_fp_rule",
   parameters={
     "oid": "[organization-id]",
-    "name": "[rule-name]"
+    "rule_name": "[rule-name]"
   }
 )
 ```
@@ -57,7 +57,7 @@ mcp__limacharlie__lc_call_tool(
 - Tool: `delete_fp_rule`
 - Required parameters:
   - `oid`: Organization ID
-  - `name`: FP rule name to delete
+  - `rule_name`: FP rule name to delete
 
 ### Step 3: Handle the Response
 
@@ -101,7 +101,7 @@ mcp__limacharlie__lc_call_tool(
   tool_name="delete_fp_rule",
   parameters={
     "oid": "c7e8f940-1234-5678-abcd-1234567890ab",
-    "name": "filter_dev_activity"
+    "rule_name": "filter_dev_activity"
   }
 )
 ```

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-fp-rule.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-fp-rule.md
@@ -28,7 +28,7 @@ Before calling this skill, gather:
 
 **⚠️ IMPORTANT**: The Organization ID (OID) is a UUID (like `c1ffedc0-ffee-4a1e-b1a5-abc123def456`), **NOT** the organization name. If you don't have the OID, use the `list_user_orgs` skill first to get the OID from the organization name.
 - **oid**: Organization ID (required for all API calls)
-- **name**: Name of the FP rule to retrieve (must be exact match)
+- **rule_name**: Name of the FP rule to retrieve (must be exact match)
 
 ## How to Use
 
@@ -47,7 +47,7 @@ mcp__limacharlie__lc_call_tool(
   tool_name="get_fp_rule",
   parameters={
     "oid": "[organization-id]",
-    "name": "[rule-name]"
+    "rule_name": "[rule-name]"
   }
 )
 ```
@@ -56,7 +56,7 @@ mcp__limacharlie__lc_call_tool(
 - Tool: `get_fp_rule`
 - Required parameters:
   - `oid`: Organization ID
-  - `name`: FP rule name
+  - `rule_name`: FP rule name
 
 ### Step 3: Handle the Response
 
@@ -111,7 +111,7 @@ mcp__limacharlie__lc_call_tool(
   tool_name="get_fp_rule",
   parameters={
     "oid": "c7e8f940-1234-5678-abcd-1234567890ab",
-    "name": "filter_safe_processes"
+    "rule_name": "filter_safe_processes"
   }
 )
 ```

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/set-fp-rule.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/set-fp-rule.md
@@ -29,8 +29,8 @@ Before calling this skill, gather:
 
 **⚠️ IMPORTANT**: The Organization ID (OID) is a UUID (like `c1ffedc0-ffee-4a1e-b1a5-abc123def456`), **NOT** the organization name. If you don't have the OID, use the `list_user_orgs` skill first to get the OID from the organization name.
 - **oid**: Organization ID (required for all API calls)
-- **name**: Name for the FP rule (unique identifier)
-- **pattern**: Rule configuration object containing the filter logic
+- **rule_name**: Name for the FP rule (unique identifier)
+- **rule_content**: Object containing a `detection` (or `detect`) key with the filter logic
 
 ### Filter Logic Structure
 
@@ -65,13 +65,15 @@ mcp__limacharlie__lc_call_tool(
   tool_name="set_fp_rule",
   parameters={
     "oid": "[organization-id]",
-    "name": "[rule-name]",
-    "pattern": {
-      "op": "and",
-      "rules": [
-        {"op": "is", "path": "detect/cat", "value": "SUSPICIOUS_EXECUTION"},
-        {"op": "contains", "path": "detect/event/FILE_PATH", "value": "/opt/safe_app/"}
-      ]
+    "rule_name": "[rule-name]",
+    "rule_content": {
+      "detection": {
+        "op": "and",
+        "rules": [
+          {"op": "is", "path": "cat", "value": "SUSPICIOUS_EXECUTION"},
+          {"op": "contains", "path": "detect/event/FILE_PATH", "value": "/opt/safe_app/"}
+        ]
+      }
     }
   }
 )
@@ -81,8 +83,8 @@ mcp__limacharlie__lc_call_tool(
 - Tool: `set_fp_rule`
 - Required parameters:
   - `oid`: Organization ID
-  - `name`: Rule name
-  - `pattern`: Filter logic object
+  - `rule_name`: Rule name
+  - `rule_content`: Object with `detection` (or `detect`) key containing filter logic
 
 ### Step 3: Handle the Response
 
@@ -125,13 +127,15 @@ mcp__limacharlie__lc_call_tool(
   tool_name="set_fp_rule",
   parameters={
     "oid": "c7e8f940-1234-5678-abcd-1234567890ab",
-    "name": "filter_monitoring_tool",
-    "pattern": {
-      "op": "and",
-      "rules": [
-        {"op": "is", "path": "detect/cat", "value": "SUSPICIOUS_EXECUTION"},
-        {"op": "contains", "path": "detect/event/FILE_PATH", "value": "C:\\Program Files\\MonitoringTool\\"}
-      ]
+    "rule_name": "filter_monitoring_tool",
+    "rule_content": {
+      "detection": {
+        "op": "and",
+        "rules": [
+          {"op": "is", "path": "cat", "value": "SUSPICIOUS_EXECUTION"},
+          {"op": "contains", "path": "detect/event/FILE_PATH", "value": "C:\\Program Files\\MonitoringTool\\"}
+        ]
+      }
     }
   }
 )
@@ -158,13 +162,15 @@ mcp__limacharlie__lc_call_tool(
   tool_name="set_fp_rule",
   parameters={
     "oid": "c7e8f940-1234-5678-abcd-1234567890ab",
-    "name": "filter_dev_activity",
-    "pattern": {
-      "op": "and",
-      "rules": [
-        {"op": "is", "path": "detect/cat", "value": "TOOL_USAGE"},
-        {"op": "contains", "path": "routing/hostname", "value": "dev-"}
-      ]
+    "rule_name": "filter_dev_activity",
+    "rule_content": {
+      "detection": {
+        "op": "and",
+        "rules": [
+          {"op": "is", "path": "cat", "value": "TOOL_USAGE"},
+          {"op": "contains", "path": "routing/hostname", "value": "dev-"}
+        ]
+      }
     }
   }
 )


### PR DESCRIPTION
## Summary
- Fix parameter names in FP rule documentation to match MCP server expectations
- `set-fp-rule.md`: Change `name` → `rule_name`, `pattern` → `rule_content` with `detection` key
- `get-fp-rule.md`: Change `name` → `rule_name`
- `delete-fp-rule.md`: Change `name` → `rule_name`
- `detection-tuner/SKILL.md`: Change `data:` → `detection:` in all rule_content examples

## Problem
The MCP server (`lc-mcp-server/internal/tools/rules/fp_rules.go`) expects these parameters:
- `set_fp_rule`: `rule_name`, `rule_content` (with `detect` or `detection` key inside)
- `get_fp_rule`: `rule_name`
- `delete_fp_rule`: `rule_name`

But the documentation was using incorrect parameter names (`name`, `pattern`, `data`), causing validation errors like:
```
Error: parameter validation failed: missing required parameter: rule_content
```

## Test plan
- [ ] Verify `set_fp_rule` calls work with new parameter structure
- [ ] Verify `get_fp_rule` calls work with `rule_name` parameter
- [ ] Verify `delete_fp_rule` calls work with `rule_name` parameter
- [ ] Test detection-tuner skill FP rule deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)