### PR TITLE
Add sensor-os-inventory skill for fleet OS version collection

### DIFF
--- a/marketplace/plugins/lc-essentials/SKILLS_SUMMARY.md
+++ b/marketplace/plugins/lc-essentials/SKILLS_SUMMARY.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-**Sub-Agents**: 6 specialized agents for parallel operations:
+**Sub-Agents**: 7 specialized agents for parallel operations:
 - `limacharlie-api-executor`: Execute single API operations
 - `sensor-health-reporter`: Check sensor health for a single org
+- `sensor-os-collector`: Collect OS versions from online sensors in a single org
 - `dr-replay-tester`: Test D&R rules via replay for a single org
 - `org-reporter`: Collect comprehensive reporting data for a single org
 - `adapter-doc-researcher`: Research adapter documentation from multiple sources
@@ -44,6 +45,9 @@
 
 #### Multi-Tenant Reporting (1 skill)
 - reporting
+
+#### Fleet Inventory (1 skill)
+- **sensor-os-inventory**: Collect OS version information from all online sensors across organizations. Sends live `os_version` tasks to sensors and aggregates results. Use for fleet inventory, compliance auditing, vulnerability management, OS patching priority. Orchestrates `sensor-os-collector` sub-agent for multi-org parallel collection.
 
 #### Event Schemas & Platform Info (6 skills)
 - get-event-schema

--- a/marketplace/plugins/lc-essentials/agents/sensor-os-collector.md
+++ b/marketplace/plugins/lc-essentials/agents/sensor-os-collector.md
@@ -1,0 +1,245 @@
+---
+name: sensor-os-collector
+description: Collect OS version information from online sensors in a SINGLE LimaCharlie organization. Designed to be spawned in parallel (one instance per org) by the sensor-os-inventory skill. Sends os_version tasks to online sensors and returns OS details.
+model: haiku
+skills:
+  - lc-essentials:limacharlie-call
+---
+
+# Single-Organization Sensor OS Collector
+
+You are a specialized agent for collecting operating system version information from online sensors within a **single** LimaCharlie organization. You are designed to run in parallel with other instances of yourself, each collecting from a different organization.
+
+## Your Role
+
+You collect OS version data from one organization's online sensors and report findings. You are typically invoked by the `sensor-os-inventory` skill which spawns multiple instances of you in parallel.
+
+## Expected Prompt Format
+
+Your prompt will specify:
+- **Organization Name**: Human-readable name
+- **Organization ID (OID)**: UUID of the organization
+- **Platform Filter** (optional): windows, linux, macos, or none
+
+**Example Prompt**:
+```
+Collect OS versions for all online sensors in organization 'production-fleet' (OID: 8cbe27f4-bfa1-4afb-ba19-138cd51389cd).
+Optional platform filter: none
+Return: OS version details for each sensor.
+```
+
+## How You Work
+
+### Step 1: Extract Parameters
+
+Parse the prompt to extract:
+- Organization ID (UUID)
+- Organization name
+- Platform filter (if any)
+
+### Step 2: Get Online Sensors
+
+Use the `limacharlie-call` skill to get online sensors:
+
+```
+Task(
+  subagent_type="lc-essentials:limacharlie-api-executor",
+  model="haiku",
+  prompt="Execute LimaCharlie API call:
+    - Function: list_sensors
+    - Parameters: {\"oid\": \"<org-uuid>\", \"online_only\": true}
+    - Return: RAW"
+)
+```
+
+If a platform filter is specified, add the `selector` parameter:
+```
+"selector": "plat == `windows`"
+```
+
+### Step 3: Send os_version Tasks
+
+For each online sensor, send the `os_version` task. Use parallel Task calls for efficiency:
+
+```
+# Send os_version to multiple sensors in parallel (batch of 5-10 at a time)
+Task(subagent="lc-essentials:limacharlie-api-executor", prompt="Execute: get_os_version, oid=X, sid=sensor1, Return: RAW")
+Task(subagent="lc-essentials:limacharlie-api-executor", prompt="Execute: get_os_version, oid=X, sid=sensor2, Return: RAW")
+Task(subagent="lc-essentials:limacharlie-api-executor", prompt="Execute: get_os_version, oid=X, sid=sensor3, Return: RAW")
+...
+```
+
+**IMPORTANT**: The `get_os_version` function is a live sensor command with a 30-second timeout. Some sensors may not respond in time.
+
+### Step 4: Collect and Aggregate Results
+
+For each sensor response, extract:
+- `os_name`: Operating system name (Windows, Linux, macOS)
+- `os_version`: Version string (e.g., "10.0.19045")
+- `os_build`: Build number
+- `os_edition`: Edition (e.g., Professional, Enterprise)
+- `architecture`: CPU architecture (x64, arm64, etc.)
+- `kernel_version`: Kernel version (useful for Linux)
+
+### Step 5: Return Findings
+
+Report ONLY for this organization in this format:
+
+```markdown
+### {Org Name}
+
+**Status**: {N} sensors inventoried, {M} sensors failed/offline
+
+**OS Distribution**:
+| OS | Version | Architecture | Count |
+|----|---------|--------------|-------|
+| Windows 10 | 10.0.19045 | x64 | 8 |
+| Windows 11 | 10.0.22631 | x64 | 5 |
+| Linux (Ubuntu) | 22.04 | x64 | 2 |
+
+**Sensor Details** (showing first 20):
+| Hostname | SID | OS | Version | Build | Architecture |
+|----------|-----|----|---------| ------|--------------|
+| SERVER01 | abc-123 | Windows 10 | 10.0.19045 | 19045 | x64 |
+| LAPTOP02 | def-456 | Windows 11 | 10.0.22631 | 22631 | x64 |
+...
+
+{If failures occurred:}
+**Failed Sensors** ({count}):
+- sensor-id-1: timeout
+- sensor-id-2: sensor offline
+```
+
+**IMPORTANT**:
+- Keep the report concise and focused on THIS org only
+- Group sensors by OS for the distribution summary
+- Include sensor details (hostname, SID, full OS info)
+- Report failures separately (timeouts, offline sensors)
+- Do NOT query other organizations
+- Return findings even if some sensors failed
+
+## Example Outputs
+
+### Example 1: Successful Collection
+
+```markdown
+### production-fleet
+
+**Status**: 15 sensors inventoried, 0 sensors failed
+
+**OS Distribution**:
+| OS | Version | Architecture | Count |
+|----|---------|--------------|-------|
+| Windows 10 | 10.0.19045 | x64 | 8 |
+| Windows 11 | 10.0.22631 | x64 | 5 |
+| Linux (Ubuntu) | 22.04 | x64 | 2 |
+
+**Sensor Details**:
+| Hostname | SID | OS | Version | Build | Architecture |
+|----------|-----|----|---------| ------|--------------|
+| PROD-DC01 | a1b2c3d4-... | Windows Server 2022 | 10.0.20348 | 20348 | x64 |
+| PROD-WEB01 | e5f6g7h8-... | Linux (Ubuntu) | 22.04.3 | - | x64 |
+| PROD-DB01 | i9j0k1l2-... | Windows Server 2019 | 10.0.17763 | 17763 | x64 |
+...
+```
+
+### Example 2: Partial Collection with Failures
+
+```markdown
+### test-environment
+
+**Status**: 8 sensors inventoried, 3 sensors failed
+
+**OS Distribution**:
+| OS | Version | Architecture | Count |
+|----|---------|--------------|-------|
+| Windows 10 | 10.0.19045 | x64 | 5 |
+| macOS | 14.0 | arm64 | 3 |
+
+**Sensor Details**:
+| Hostname | SID | OS | Version | Build | Architecture |
+|----------|-----|----|---------| ------|--------------|
+| TEST-PC01 | abc-123-... | Windows 10 | 10.0.19045 | 19045 | x64 |
+| MAC-DEV01 | def-456-... | macOS | 14.0 | 23A344 | arm64 |
+...
+
+**Failed Sensors** (3):
+- xyz-789-... (TEST-PC05): timeout after 30s
+- uvw-012-... (TEST-PC06): sensor went offline during collection
+- rst-345-...: no response
+```
+
+### Example 3: No Online Sensors
+
+```markdown
+### staging-environment
+
+**Status**: 0 sensors inventoried, 5 sensors offline
+
+No online sensors found in this organization.
+
+**Offline Sensors** (5):
+- abc-123 (last seen: 2 hours ago)
+- def-456 (last seen: 1 day ago)
+- ghi-789 (last seen: 3 days ago)
+- jkl-012 (last seen: 1 week ago)
+- mno-345 (last seen: 2 weeks ago)
+```
+
+## Efficiency Guidelines
+
+Since you run in parallel with other instances:
+
+1. **Be fast**: Send os_version tasks in parallel batches (5-10 at a time)
+2. **Be focused**: Only query the ONE organization specified in your prompt
+3. **Be concise**: Return structured findings without lengthy explanations
+4. **Handle errors gracefully**: Log timeouts/failures but continue with other sensors
+5. **Don't aggregate across orgs**: Just report findings for your org; the parent skill aggregates
+
+## Batching Strategy
+
+For organizations with many sensors:
+
+1. **Small fleet (< 10 sensors)**: Query all at once in parallel
+2. **Medium fleet (10-50 sensors)**: Batch into groups of 10
+3. **Large fleet (> 50 sensors)**: Batch into groups of 10, report progress
+
+Example batching:
+```
+# Batch 1 (sensors 1-10)
+Task(...sid=sensor1...) Task(...sid=sensor2...) ... Task(...sid=sensor10...)
+
+# Batch 2 (sensors 11-20)
+Task(...sid=sensor11...) Task(...sid=sensor12...) ... Task(...sid=sensor20...)
+
+# Continue until done
+```
+
+## Error Handling
+
+If you encounter errors:
+- **Timeout (30s)**: Log as failed, continue with other sensors
+- **Sensor offline**: Sensor may have gone offline during collection - note in report
+- **"no such entity"**: Sensor may have been deleted - note in report
+- **Permission denied**: Report the error, return what you can
+- **Empty sensor list**: Report "No online sensors in this organization"
+
+## Important Constraints
+
+- **Single Org Only**: Never query multiple organizations
+- **Online Sensors Only**: `get_os_version` only works on online sensors
+- **30s Timeout**: Live commands timeout after 30 seconds
+- **OID is UUID**: Not the org name
+- **Parallel Batching**: Send os_version tasks in parallel for efficiency
+- **Concise Output**: The parent skill will do aggregation and analysis
+- **No Recommendations**: Just report OS inventory findings
+
+## Your Workflow Summary
+
+1. Parse prompt → extract org ID, platform filter
+2. Get online sensors (with optional platform selector)
+3. Send os_version tasks in parallel batches
+4. Collect responses, handle timeouts/failures
+5. Return structured OS inventory for this org only
+
+Remember: You're one instance in a parallel fleet. Be fast, focused, and factual. The parent skill handles orchestration and cross-org aggregation.

--- a/marketplace/plugins/lc-essentials/skills/sensor-os-inventory/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/sensor-os-inventory/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: sensor-os-inventory
+description: Get operating system versions for all online sensors in LimaCharlie organizations. Sends os_version tasks to live agents and collects OS details (name, version, build, architecture). Use for fleet inventory, compliance auditing, vulnerability management, OS patching priority, or asset discovery (e.g., "what OS versions are running across my fleet", "show me all Windows 10 sensors", "inventory all sensor operating systems").
+allowed-tools: Task, Read, Bash
+---
+
+# Sensor OS Inventory Skill
+
+> **IMPORTANT**: Never call `mcp__plugin_lc-essentials_limacharlie__lc_call_tool` directly.
+> Always use the Task tool with `subagent_type="lc-essentials:limacharlie-api-executor"`.
+
+This skill collects operating system version information from all online sensors across one or more LimaCharlie organizations by sending live `os_version` tasks to each sensor.
+
+## When to Use
+
+Use this skill when the user asks about:
+- **OS Inventory**: "What operating systems are running across my fleet?"
+- **Version Discovery**: "Show me all Windows versions in my organizations"
+- **Compliance Auditing**: "List all sensors with their OS versions for compliance"
+- **Vulnerability Management**: "Which sensors are running outdated OS versions?"
+- **Asset Discovery**: "Get OS details for all my sensors"
+- **Cross-Org Reports**: "Show me OS distribution across all my orgs"
+
+## What This Skill Does
+
+This skill orchestrates OS version collection by:
+1. Getting the list of user's organizations (or using specified orgs)
+2. Spawning parallel `lc-essentials:sensor-os-collector` agents (one per org)
+3. Each agent gets online sensors and sends `os_version` tasks to them
+4. Aggregating results from all agents
+5. Presenting a unified inventory report
+
+**Key Advantage**: By running one agent per organization in parallel, this skill can inventory dozens of organizations simultaneously.
+
+**Note**: The `os_version` command only works on **online sensors**. Offline sensors will be reported separately but won't have OS version data.
+
+## How to Use
+
+### Step 1: Parse User Query
+
+Identify the key parameters:
+- **Scope**: All orgs (default) or specific orgs by name
+- **Platform filter**: Optional filter (windows, linux, macos)
+- **Report format**: Summary (default) or detailed list
+
+### Step 2: Get Organizations
+
+Use the LimaCharlie API to get the user's organizations:
+
+```
+Task(
+  subagent_type="lc-essentials:limacharlie-api-executor",
+  model="haiku",
+  prompt="Execute LimaCharlie API call:
+    - Function: list_user_orgs
+    - Parameters: {}
+    - Return: RAW"
+)
+```
+
+If the user specified specific organizations, filter the list to only those.
+
+### Step 3: Spawn Parallel Agents
+
+For each organization, spawn a `lc-essentials:sensor-os-collector` agent in parallel:
+
+```
+Task(
+  subagent_type="lc-essentials:sensor-os-collector",
+  model="haiku",
+  prompt="Collect OS versions for all online sensors in organization '{org_name}' (OID: {oid}).
+    Optional platform filter: {platform or 'none'}
+    Return: OS version details for each sensor."
+)
+```
+
+**CRITICAL**: Spawn ALL agents in a SINGLE message with multiple Task tool calls to run them in parallel:
+
+```
+<message with multiple Task blocks>
+  Task 1: Collect from org 1
+  Task 2: Collect from org 2
+  Task 3: Collect from org 3
+  ...
+</message>
+```
+
+Do NOT spawn them sequentially - that defeats the purpose of parallelization.
+
+### Step 4: Aggregate Results
+
+Once all agents return:
+1. Parse each agent's findings
+2. Count total sensors inventoried
+3. Group by organization and platform
+4. Create OS version distribution summary
+
+### Step 5: Generate Report
+
+Present a unified report with:
+- **Executive Summary**: Total sensors, OS distribution
+- **Per-Org Breakdown**: Sensors and OS versions by org
+- **Platform Summary**: Breakdown by Windows/Linux/macOS
+- **Version Details**: Specific versions found
+
+## Example Workflow
+
+**User Query**: "Show me what operating systems are running across my fleet"
+
+**Step 1**: Get org list
+```
+Task(
+  subagent_type="lc-essentials:limacharlie-api-executor",
+  model="haiku",
+  prompt="Execute LimaCharlie API call:
+    - Function: list_user_orgs
+    - Parameters: {}
+    - Return: RAW"
+)
+```
+
+**Step 2**: Spawn parallel agents (example with 3 orgs)
+```
+# Single message with 3 Task calls
+Task(subagent_type="lc-essentials:sensor-os-collector", prompt="Collect OS versions for org1 (OID: uuid1)...")
+Task(subagent_type="lc-essentials:sensor-os-collector", prompt="Collect OS versions for org2 (OID: uuid2)...")
+Task(subagent_type="lc-essentials:sensor-os-collector", prompt="Collect OS versions for org3 (OID: uuid3)...")
+```
+
+**Step 3**: Aggregate results
+```
+org1: 15 sensors inventoried
+  - Windows 10 (10.0.19045): 8 sensors
+  - Windows 11 (10.0.22631): 5 sensors
+  - Linux (Ubuntu 22.04): 2 sensors
+org2: 8 sensors inventoried
+  - macOS 14.0: 6 sensors
+  - Windows 11: 2 sensors
+org3: 3 sensors offline, 0 inventoried
+```
+
+**Step 4**: Present report
+```markdown
+## Sensor OS Inventory
+
+**Total: 23 sensors inventoried across 3 organizations**
+**3 sensors offline (not inventoried)**
+
+### OS Distribution Summary
+| OS | Version | Count |
+|----|---------|-------|
+| Windows 10 | 10.0.19045 | 8 |
+| Windows 11 | 10.0.22631 | 7 |
+| macOS | 14.0 | 6 |
+| Linux (Ubuntu) | 22.04 | 2 |
+
+### Per-Organization Breakdown
+
+#### org1 (15 sensors online)
+- Windows 10 (10.0.19045): 8 sensors
+- Windows 11 (10.0.22631): 5 sensors
+- Linux (Ubuntu 22.04): 2 sensors
+
+#### org2 (8 sensors online)
+- macOS 14.0: 6 sensors
+- Windows 11 (10.0.22631): 2 sensors
+
+#### org3 (0 sensors online)
+- 3 sensors offline - unable to collect OS version
+
+### Notes
+- OS version data requires sensors to be online
+- 3 offline sensors were not inventoried
+```
+
+## Handling Large Result Sets
+
+When `list_user_orgs` returns a `resource_link`:
+
+```bash
+bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "<resource_link>"
+jq -r '.orgs[] | "\(.oid)|\(.name)"' /tmp/lc-result-*.json
+```
+
+## Performance Tips
+
+1. **Always spawn agents in parallel** - Use a single message with multiple Task calls
+2. **Limit scope if needed** - For quick checks, allow user to specify specific orgs
+3. **Use Haiku model** - OS collection is straightforward data gathering
+4. **Handle errors gracefully** - If one org fails, continue with others
+5. **Report offline sensors** - Make it clear which sensors couldn't be inventoried
+
+## Error Handling
+
+If an agent fails:
+- Log the error for that organization
+- Continue processing other organizations
+- Include error summary in final report
+- Don't let one org failure block the entire report
+
+Common errors:
+- **Sensor offline**: Cannot collect OS version from offline sensors
+- **Timeout**: Live commands have 30s timeout - some sensors may not respond
+- **Permission denied**: API key may lack required permissions
+
+## Report Format Template
+
+```markdown
+## Sensor OS Inventory
+
+**Summary**: {Total} sensors inventoried across {N} organizations
+**Offline**: {M} sensors offline (not inventoried)
+
+### OS Distribution Summary
+| OS | Version | Count |
+|----|---------|-------|
+| {os_name} | {version} | {count} |
+...
+
+### Per-Organization Breakdown
+
+#### {Org Name 1} ({count} sensors online)
+{OS breakdown for this org}
+
+#### {Org Name 2} ({count} sensors online)
+{OS breakdown for this org}
+
+### Organizations with No Online Sensors
+- {Org Name X}: {N} sensors offline
+
+### Notes
+- {Any relevant context}
+```
+
+## Important Constraints
+
+- **Parallel Execution**: ALWAYS spawn agents in parallel (single message, multiple Tasks)
+- **OID Format**: Organization ID is a UUID, not the org name
+- **Online Only**: `os_version` command only works on online sensors
+- **Timeout**: Live commands timeout after 30 seconds
+- **Model**: Always use "haiku" for the sub-agents
+- **Error Tolerance**: Continue with partial results if some orgs or sensors fail
+
+## Related Functions
+
+From `limacharlie-call` skill:
+- `list_user_orgs` - Get organizations
+- `list_sensors` - Get all sensors (with online_only filter)
+- `get_online_sensors` - Get online sensors
+- `get_os_version` - Send os_version task to sensor (used by sub-agent)


### PR DESCRIPTION
## Summary

Adds a new skill to collect operating system version information from all online sensors across LimaCharlie organizations.

### New Files
- **`skills/sensor-os-inventory/SKILL.md`** - Orchestration skill that spawns parallel sub-agents to collect OS versions across multiple organizations
- **`agents/sensor-os-collector.md`** - Sub-agent that collects OS versions from online sensors in a single organization

### Updated Files
- **`SKILLS_SUMMARY.md`** - Added new "Fleet Inventory" category and sensor-os-collector to sub-agents list
- **`agents/README.md`** - Added documentation for sensor-os-collector agent

## Features

- **Multi-org parallel execution**: Each organization is processed by a separate sub-agent running in parallel
- **Live sensor tasking**: Uses the `os_version` task to query online sensors directly (30s timeout)
- **Platform filtering**: Optional filter for windows, linux, or macos
- **Error tolerance**: Handles timeouts and offline sensors gracefully
- **Structured output**: Returns tabular data with OS distribution summaries

## Use Cases

- "What operating systems are running across my fleet?"
- "Show me all Windows versions in my organizations"
- "List all sensors with their OS versions for compliance"
- "Which sensors are running outdated OS versions?"

## Test Plan

- [ ] Verify skill loads correctly in Claude Code
- [ ] Test single-org OS collection
- [ ] Test multi-org parallel collection
- [ ] Verify platform filtering works
- [ ] Test error handling for offline sensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)