### PR TITLE
Fix incorrect lookup URI syntax in documentation

### DIFF
--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-alphamountain.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-alphamountain.md
@@ -22,7 +22,7 @@ The following is an example rule that pulls domain names from DNS_REQUEST events
 event: DNS_REQUEST
 op: lookup
 path: event/DOMAIN_NAME
-resource: hive://lookup/alphamountain-category
+resource: lcr://api/alphamountain-category
 ```
 
 The data returned is in JSON format, and includes the API response and a threatYeti URL, which is appended by LimaCharlie. For example:

--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-echotrail.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-echotrail.md
@@ -16,7 +16,7 @@ The following detection and response rule utilizes a file name from a `NEW_PROCE
 event: NEW_PROCESS
 op: lookup
 path: event/FILE_PATH
-resource: hive://lookup/echotrail-insights
+resource: lcr://api/echotrail-insights
 ```
 
 EchoTrail's response data includes the following:

--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-hybrid-analysis.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-hybrid-analysis.md
@@ -21,7 +21,7 @@ The following D&R rule
 event: NEW_PROCESS
 op: lookup
 path: event/HASH
-resource: hive://lookup/hybrid-analysis-overview
+resource: lcr://api/hybrid-analysis-overview
 ```
 
 **Response Data:**
@@ -166,7 +166,7 @@ The Search lookup provides a basic lookup of a hash value. This look accepts one
 event: NEW_PROCESS
 op: lookup
 path: event/HASH
-resource: hive://lookup/hybrid-analysis-search
+resource: lcr://api/hybrid-analysis-search
 ```
 
 **Response Data:**

--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-ip-geolocation.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-ip-geolocation.md
@@ -9,7 +9,7 @@ With the `ip-geo` [add-on](https://app.limacharlie.io/add-ons/detail/ip-geo) sub
 ```
 event: CONNECTED
 op: lookup
-resource: hive://lookup/ip-geo
+resource: lcr://api/ip-geo
 path: routing/ext_ip
 metadata_rules:
   op: is

--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-pangea.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-pangea.md
@@ -45,7 +45,7 @@ The Domain Intel service allows you to retrieve intelligence about known domain 
 event: DNS_REQUEST
 op: lookup
 path: event/DOMAIN_NAME
-resource: hive://lookup/pangea-domain-reputation
+resource: lcr://api/pangea-domain-reputation
 ```
 
 ### API Response Data
@@ -72,7 +72,7 @@ The File Intel service enables you to submit a file's hash and get the file's at
 event: NEW_PROCESS
 op: lookup
 path: event/HASH
-resource: hive://lookup/pangea-file-reputation
+resource: lcr://api/pangea-file-reputation
 ```
 
 ### API Response Data
@@ -99,7 +99,7 @@ The IP Intel service allows you to retrieve security information about known IP 
 event: DNS_REQUEST
 op: lookup
 path: routing/ext_ip
-resource: hive://lookup/pangea-ip-reputation
+resource: lcr://api/pangea-ip-reputation
 ```
 
 ### API Response Data
@@ -124,7 +124,7 @@ The URL Intel service allows you to retrieve intelligence about known URLs, givi
 event: HTTP_REQUEST
 op: lookup
 path: event/URL
-resource: hive://lookup/pangea-url-reputation
+resource: lcr://api/pangea-url-reputation
 ```
 
 ### API Response Data
@@ -149,7 +149,7 @@ The User Intel service allows you to check a large repository of breach data to 
 event: USER_OBSERVED
 op: lookup
 path: event/USER_NAME
-resource: hive://lookup/pangea-user-reputation
+resource: lcr://api/pangea-user-reputation
 ```
 
 ### API Response Data

--- a/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-virustotal.md
+++ b/docs/limacharlie/doc/Add-Ons/API_Integrations/api-integrations-virustotal.md
@@ -12,7 +12,7 @@ With the `vt` add-on subscribed and a VirusTotal API Key configured in the Integ
 event: CODE_IDENTITY
 op: lookup
 path: event/HASH
-resource: hive://lookup/vt
+resource: lcr://api/vt
 metadata_rules:
   op: is greater than
   value: 1

--- a/docs/limacharlie/doc/Detection_and_Response/Reference/detection-logic-operators.md
+++ b/docs/limacharlie/doc/Detection_and_Response/Reference/detection-logic-operators.md
@@ -287,13 +287,13 @@ Looks up a value against a [lookup add-on](https://app.limacharlie.io/add-ons/ca
 event: DNS_REQUEST
 op: lookup
 path: event/DOMAIN_NAME
-resource: hive://lookups/malwaredomains
+resource: hive://lookup/malwaredomains
 case sensitive: false
 ```
 
 This rule will get the `event/DOMAIN_NAME` of a `DNS_REQUEST` event and check if it's a member of the `lookup` named `malwaredomains`. If it is, then the rule is a match.
 
-The value is supplied via the `path` parameter and the lookup is defined in the `resource` parameter. Resources are of the form `hive://lookups/RESOURCE_NAME`. In order to access a lookup, your Organization must be subscribed to it.
+The value is supplied via the `path` parameter and the lookup is defined in the `resource` parameter. Resources are of the form `hive://lookup/RESOURCE_NAME`. In order to access a lookup, your Organization must be subscribed to it.
 
 Supports the [file name](#file-name) and [sub domain](#sub-domain) transforms.
 


### PR DESCRIPTION
Corrected resource URIs for API-based lookups and regular lookups:

API-based lookups (11 instances):
- Changed from incorrect `hive://lookup/` to correct `lcr://api/`
- Affected integrations: VirusTotal, IP Geolocation, EchoTrail, AlphaMountain, Hybrid Analysis (2), and Pangea (5)

Regular lookups (2 instances):
- Changed from incorrect plural `hive://lookups/` to correct singular `hive://lookup/`
- Affected file: detection-logic-operators.md

These changes ensure documentation matches actual working syntax:
- API-based lookups use: lcr://api/NAME
- Regular lookups use: hive://lookup/NAME (singular, not plural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
