### PR TITLE
Remove graphic-output dependency from sensor-coverage skill

### DIFF
--- a/marketplace/plugins/lc-essentials/skills/sensor-coverage/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/sensor-coverage/SKILL.md
@@ -1061,38 +1061,11 @@ AskUserQuestion(
     "header": "Export",
     "options": [
       {"label": "Markdown", "description": "Human-readable text format"},
-      {"label": "JSON", "description": "Structured data for automation"},
-      {"label": "HTML Dashboard", "description": "Interactive visual dashboard"}
+      {"label": "JSON", "description": "Structured data for automation"}
     ],
     "multiSelect": false
   }]
 )
-```
-
-### HTML Dashboard Export
-
-For visual output, invoke the `graphic-output` skill:
-
-```
-Skill(skill="lc-essentials:graphic-output")
-```
-
-Provide structured data:
-```json
-{
-  "report_type": "sensor_coverage",
-  "title": "Sensor Coverage Report",
-  "mode": "single_org|multi_org",
-  "generated_at": "2025-12-05T16:35:00Z",
-  "coverage_summary": {...},
-  "telemetry_health": {...},
-  "compliance_status": {...},
-  "systemic_issues": [...],
-  "platform_health": {...},
-  "sla_compliance": {...},
-  "per_org_breakdown": [...],
-  "recommendations": [...]
-}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Removes the HTML Dashboard export option from the sensor-coverage skill
- Eliminates the dependency on the `graphic-output` skill
- Sensor-coverage now offers only Markdown and JSON export formats

## Changes
- Removed "HTML Dashboard" option from the export question
- Removed the "HTML Dashboard Export" section that invoked `Skill(skill="lc-essentials:graphic-output")`

## What still works
- Markdown export (unchanged)
- JSON export (unchanged)
- All sensor coverage analysis features (unchanged)
- Integration with other skills: sensor-health, reporting, timeline-creation, detection-engineering (unchanged)

## Test plan
- [ ] Verify sensor-coverage skill loads without errors
- [ ] Test export options show only Markdown and JSON
- [ ] Confirm JSON export still provides all structured data for external visualization tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)