### PR TITLE
Use CLAUDE_PLUGIN_ROOT for plugin script paths

### DIFF
--- a/marketplace/plugins/lc-essentials/CALLING_API.md
+++ b/marketplace/plugins/lc-essentials/CALLING_API.md
@@ -528,7 +528,7 @@ If you need to manually process large results (not recommended), follow this wor
 Run the analyze script with the `resource_link` URL directly:
 
 ```bash
-bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "https://storage.googleapis.com/lc-tmp-mcp-export/..."
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-lc-result.sh" "https://storage.googleapis.com/lc-tmp-mcp-export/..."
 ```
 
 Replace the URL with the actual `resource_link` value from the tool response.

--- a/marketplace/plugins/lc-essentials/agents/limacharlie-api-executor.md
+++ b/marketplace/plugins/lc-essentials/agents/limacharlie-api-executor.md
@@ -153,7 +153,7 @@ API returns a reference to download:
 Run the analyze script with the `resource_link`:
 
 ```bash
-bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "https://storage.googleapis.com/..."
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-lc-result.sh" "https://storage.googleapis.com/..."
 ```
 
 **IMPORTANT: curl auto-decompresses gzip**
@@ -303,7 +303,7 @@ Execute LimaCharlie API call:
 1. Parse prompt: function=`list_sensors`, Return=extraction instructions
 2. Call MCP tool
 3. Receive `resource_link` response
-4. Run `bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "<url>"`
+4. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-lc-result.sh" "<url>"`
 5. Review schema: `{"sensors":[{"sid":"string","hostname":"string","platform":"number",...}],"count":"number"}`
 6. Extract counts per Return instructions:
    ```bash

--- a/marketplace/plugins/lc-essentials/skills/reporting/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/reporting/SKILL.md
@@ -445,7 +445,7 @@ If API returns `resource_link` instead of inline data:
 **REQUIRED Workflow for resource_link:**
 ```bash
 # Step 1: Download and analyze schema (MANDATORY - do not skip)
-bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "https://storage.googleapis.com/..."
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-lc-result.sh" "https://storage.googleapis.com/..."
 
 # Output shows schema and file path:
 # (stdout) {"sensors": {"sensor-id": {"sid": "string", "hostname": "string", ...}}}

--- a/marketplace/plugins/lc-essentials/skills/sensor-health/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/sensor-health/SKILL.md
@@ -159,7 +159,7 @@ These sensors are connected but not generating events...
 When `list_user_orgs` returns a `resource_link`:
 
 ```bash
-bash ./marketplace/plugins/lc-essentials/scripts/analyze-lc-result.sh "<resource_link>"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/analyze-lc-result.sh" "<resource_link>"
 jq -r '.orgs[] | "\(.oid)|\(.name)"' /tmp/lc-result-*.json
 ```
 


### PR DESCRIPTION
## Summary
- Replace relative paths to analyze-lc-result.sh with CLAUDE_PLUGIN_ROOT variable
- Fixes script not found errors when user's working directory is not the repo root
- Claude Code automatically sets CLAUDE_PLUGIN_ROOT to the plugin's installation directory

## Changes
5 edits across 4 files:
- CALLING_API.md - Line 531
- agents/limacharlie-api-executor.md - Lines 156, 306
- skills/sensor-health/SKILL.md - Line 162
- skills/reporting/SKILL.md - Line 448

## Test plan
- [ ] Verify the plugin works when the current directory is outside the repo root
- [ ] Test analyze-lc-result.sh execution via plugin skill/agent

Generated with Claude Code