### PR TITLE
fix: update ext-cloud-cli docs to use 'tool' instead of 'cloud'

### DIFF
--- a/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-aws.md
+++ b/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-aws.md
@@ -13,7 +13,7 @@ The following example would execute in response to AWS telemetry that 1) met cer
   extension action: run
   extension name: ext-cloud-cli
   extension request:
-    cloud: '{{ "aws" }}'
+    tool: '{{ "aws" }}'
     command_tokens:
       - ec2
       - stop-instances

--- a/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-azure.md
+++ b/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-azure.md
@@ -13,7 +13,7 @@ The following example returns a list of virtual machines and their respective de
   extension action: run
   extension name: ext-cloud-cli
   extension request:
-    cloud: '{{ "az" }}'
+    tool: '{{ "az" }}'
     command_line: '{{ "vm list" }}'
     credentials: '{{ "hive://secret/secret-name" }}'
 ```

--- a/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-digitalocean.md
+++ b/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-digitalocean.md
@@ -13,7 +13,7 @@ The following example of a response action will enumerate a list of compute drop
   extension action: run
   extension name: ext-cloud-cli
   extension request:
-    cloud: '{{ "doctl" }}'
+    tool: '{{ "doctl" }}'
     command_line: '{{ "compute droplet list" }}'
     credentials: '{{ "hive://secret/secret-name" }}'
 ```

--- a/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-google-cloud.md
+++ b/docs/limacharlie/doc/Add-Ons/Extensions/Third-Party_Extensions/Cloud_CLI/ext-cloud-cli-google-cloud.md
@@ -13,7 +13,7 @@ The following example stops the specified GCP compute instance.
   extension action: run
   extension name: ext-cloud-cli
   extension request:
-    cloud: '{{ "gcloud" }}'
+    tool: '{{ "gcloud" }}'
     command_tokens:
       - compute
       - instances


### PR DESCRIPTION
## Summary
- Updates D&R rule examples in ext-cloud-cli documentation to use the correct `tool` field instead of the deprecated `cloud` field

## Background
The `cloud` field was renamed to `tool` when ext-cloud-cli migrated to the simplified CLI framework (in lc-extension PR #4). The documentation was never updated, which caused users to create incorrect configurations.

This was discovered while investigating a bug where request parameters were accidentally saved to the config Hive with the incorrect field name.

## Changes
- `ext-cloud-cli-aws.md`: `cloud: "aws"` → `tool: "aws"`
- `ext-cloud-cli-azure.md`: `cloud: "az"` → `tool: "az"`
- `ext-cloud-cli-digitalocean.md`: `cloud: "doctl"` → `tool: "doctl"`
- `ext-cloud-cli-google-cloud.md`: `cloud: "gcloud"` → `tool: "gcloud"`

## Test plan
- [ ] Verify the D&R rule examples work with the new field name

🤖 Generated with [Claude Code](https://claude.com/claude-code)