### PR TITLE
Add get_org_urls, who_am_i functions and improve sensor docs

### DIFF
--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/SKILL.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/SKILL.md
@@ -49,11 +49,18 @@ Task(subagent_type="lc-essentials:limacharlie-api-executor", prompt="...")
 - `list_user_orgs` - Get OID from org name (no parameters needed)
 
 ### Sensor Management
-- `list_sensors` - List all sensors with filtering
-- `get_sensor_info` - Detailed sensor info
-- `is_online` / `get_online_sensors` - Check online status
+- `list_sensors` - **Primary function** for finding sensors. Supports `selector` (bexpr filter) and `online_only` parameters. Use this to find sensors by platform, hostname, tags, etc.
+- `get_sensor_info` - Detailed info for a single sensor (when you already have the SID)
+- `is_online` - Check if a specific sensor is online
+- `get_online_sensors` - Returns only SIDs of online sensors (no filtering). Use `list_sensors` with `online_only: true` instead when you need to filter by platform/hostname/tags
 - `add_tag` / `remove_tag` - Sensor tagging
 - `isolate_network` / `rejoin_network` - Network isolation
+
+**Finding sensors by platform:** Always use `list_sensors` with a selector:
+```
+list_sensors(oid, selector="plat == windows", online_only=true)
+```
+Do NOT use `get_online_sensors` + loop through `get_sensor_info`—that wastes API calls.
 
 ### Threat Hunting
 

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-online-sensors.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-online-sensors.md
@@ -2,6 +2,8 @@
 
 Retrieve all sensors currently online and connected to the LimaCharlie platform.
 
+**⚠️ IMPORTANT:** This function returns only sensor IDs with **no filtering capability**. To find sensors by platform, hostname, tags, or other attributes, use `list_sensors` with a `selector` instead.
+
 ## Parameters
 
 | Name | Type | Required | Description |
@@ -18,7 +20,7 @@ Retrieve all sensors currently online and connected to the LimaCharlie platform.
 ```
 
 Returns an object with:
-- `sensors`: Array of online sensor IDs
+- `sensors`: Array of online sensor IDs (no metadata, no filtering)
 - `count`: Number of online sensors
 
 ## Example
@@ -29,8 +31,21 @@ lc_call_tool(tool_name="get_online_sensors", parameters={
 })
 ```
 
+## When to Use This vs list_sensors
+
+| Use Case | Recommended Function |
+|----------|---------------------|
+| Quick count of online sensors | `get_online_sensors` |
+| Find online Windows sensors | `list_sensors` with `selector: "plat == windows"`, `online_only: true` |
+| Find online sensors by hostname | `list_sensors` with `selector: "hostname contains \"web\""`, `online_only: true` |
+| Find online sensors with a tag | `list_sensors` with `selector: "\"prod\" in tags"`, `online_only: true` |
+| Get sensor details (hostname, IP, etc.) | `list_sensors` with `online_only: true` |
+
+**Anti-pattern:** Do NOT call `get_online_sensors` and then loop through with `get_sensor_info` to find sensors by platform. Use `list_sensors` with a selector instead—it's a single API call.
+
 ## Notes
 
-- Efficient single call to check all sensors
-- For individual sensor status, use `is_online`
-- For detailed sensor info with hostnames, use `list_sensors` with `online_only: true`
+- Returns only SIDs—no hostnames, platforms, or other metadata
+- Cannot filter by platform, tags, or other attributes
+- For individual sensor status check, use `is_online`
+- For filtered/detailed results, use `list_sensors` with `selector` and `online_only: true`

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-org-urls.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/get-org-urls.md
@@ -1,0 +1,36 @@
+# get_org_urls
+
+Get organization URLs including geo-dependent domains for webhooks, DNS, and API endpoints.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| oid | UUID | Yes | Organization ID ([Core Concepts](../../../CALLING_API.md#core-concepts)) |
+
+## Returns
+
+```json
+{
+  "hooks": "9157798c50af372c.hook.limacharlie.io",
+  "dns": "9157798c50af372c.dns.limacharlie.io",
+  "api": "api.limacharlie.io",
+  "ingestion": "lc.limacharlie.io"
+}
+```
+
+## Example
+
+```
+lc_call_tool(tool_name="get_org_urls", parameters={
+  "oid": "c7e8f940-1234-5678-abcd-1234567890ab"
+})
+```
+
+## Notes
+
+- Read-only operation
+- The `hooks` domain is geo-dependent and required for constructing webhook URLs
+- Webhook URL format: `https://{hooks}/{oid}/{webhook_name}/{secret}`
+- URLs vary by organization location (USA, Canada, Europe, etc.)
+- Related: `set_cloud_sensor` (for creating webhook cloud sensors)

--- a/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/who-am-i.md
+++ b/marketplace/plugins/lc-essentials/skills/limacharlie-call/functions/who-am-i.md
@@ -1,0 +1,39 @@
+# who_am_i
+
+Get the current API identity and permissions for the authenticated user or API key.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| oid | UUID | Yes | Organization ID ([Core Concepts](../../../CALLING_API.md#core-concepts)) |
+
+## Returns
+
+```json
+{
+  "ident": "user@example.com",
+  "orgs": ["c7e8f940-1234-5678-abcd-1234567890ab", "d8f9a041-2345-6789-bcde-2345678901bc"],
+  "perms": ["sensor.list", "sensor.task", "dr.list"],
+  "user_perms": {
+    "c7e8f940-1234-5678-abcd-1234567890ab": ["org.get", "sensor.list"]
+  }
+}
+```
+
+## Example
+
+```
+lc_call_tool(tool_name="who_am_i", parameters={
+  "oid": "c7e8f940-1234-5678-abcd-1234567890ab"
+})
+```
+
+## Notes
+
+- Returns the identity (`ident`) of the authenticated API key or user
+- The `ident` field is useful for identifying which API key/user is making requests
+- `orgs` lists all organizations the identity has access to
+- `perms` lists global permissions
+- `user_perms` lists per-organization permissions (if applicable)
+- Read-only operation


### PR DESCRIPTION
## Summary
- Add `get_org_urls` function documentation (returns geo-dependent webhook/DNS/API URLs)
- Add `who_am_i` function documentation (returns API identity and permissions)
- Improve `get_online_sensors` docs with anti-pattern warnings
- Update SKILL.md sensor management section with best practices

## Test plan
- [ ] Verify new function docs render correctly
- [ ] Confirm SKILL.md changes are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)