### PR TITLE
Adjusted doc site navigation to match the current doc360 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,10 +38,6 @@ theme:
     - navigation.instant
     - navigation.instant.prefetch
     - navigation.tracking
-    - navigation.tabs
-    - navigation.tabs.sticky
-    - navigation.sections
-    - navigation.expand
     - navigation.path
     - navigation.indexes
     - navigation.top
@@ -49,8 +45,7 @@ theme:
 
     # Table of contents
     - toc.follow
-    - toc.integrate
-
+    
     # Search
     - search.suggest
     - search.highlight
@@ -192,8 +187,10 @@ nav:
     - Go SDK: go-sdk/README.md
     - Python SDK: python-sdk/README.md
 
+  - Tutorials:
+    - limacharlie/doc/Tutorials/index.md
+
   - FAQ:
     - limacharlie/doc/FAQ/index.md
 
-  - Tutorials:
-    - limacharlie/doc/Tutorials/index.md
+  


### PR DESCRIPTION
- [x] Get rid of top strip bar and bring main TOC nav to the left panel
- [x] Match other useful navigation patterns from current documentation

Before: 
<img width="1514" height="810" alt="image" src="https://github.com/user-attachments/assets/d67083f3-b414-4a9d-b031-26169a292fc3" />


After: 
<img width="1514" height="810" alt="image" src="https://github.com/user-attachments/assets/1b9eea33-f5ec-4d04-bbbf-9b2afa287e6c" />

