### PR TITLE
docs: Add IPv4/IPv6 address operators and fix IP classification documentation

### DIFF
--- a/docs/limacharlie/doc/Detection_and_Response/Reference/detection-logic-operators.md
+++ b/docs/limacharlie/doc/Detection_and_Response/Reference/detection-logic-operators.md
@@ -356,16 +356,24 @@ cidr: 10.16.1.0/24
 
 ### is private address
 
-The `is private address` checks if an IP address at the path is a private address
-as defined by [RFC 1918](https://en.wikipedia.org/wiki/Private_network).
+The `is private address` operator checks if an IP address at the path is a private/non-routable address. Supports both IPv4 and IPv6.
 
-Matches addresses in these ranges:
+**IPv4 ranges matched:**
 
-- `10.0.0.0/8`
-- `172.16.0.0/12`
-- `192.168.0.0/16`
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `10.0.0.0/8` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `172.16.0.0/12` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `192.168.0.0/16` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `100.64.0.0/10` | CGNAT/Shared Address Space | [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) |
 
-Note: This operator does **not** match loopback (`127.0.0.0/8`) or link-local (`169.254.0.0/16`) addresses. Use the `cidr` operator if you need to match those specifically.
+**IPv6 ranges matched:**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `fc00::/7` | Unique Local Address (ULA) | [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193) |
+
+Note: This operator does **not** match loopback (`127.0.0.0/8`, `::1`) or link-local (`169.254.0.0/16`, `fe80::/10`) addresses. Use `cidr` if you need to match those specifically.
 
 Example rule:
 
@@ -375,25 +383,122 @@ op: is private address
 path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
 ```
 
+### is private ipv4 address
+
+The `is private ipv4 address` operator checks if an IP address at the path is a private IPv4 address. Returns false for IPv6 addresses.
+
+**Ranges matched:**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `10.0.0.0/8` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `172.16.0.0/12` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `192.168.0.0/16` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `100.64.0.0/10` | CGNAT/Shared Address Space | [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) |
+
+Example rule:
+
+```yaml
+event: NETWORK_CONNECTIONS
+op: is private ipv4 address
+path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
+```
+
+### is private ipv6 address
+
+The `is private ipv6 address` operator checks if an IP address at the path is a private IPv6 address (ULA). Returns false for IPv4 addresses.
+
+**Ranges matched:**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `fc00::/7` | Unique Local Address (ULA) | [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193) |
+
+Example rule:
+
+```yaml
+event: NETWORK_CONNECTIONS
+op: is private ipv6 address
+path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
+```
+
 ### is public address
 
-The `is public address` checks if an IP address at the path is a publicly routable address.
+The `is public address` operator checks if an IP address at the path is a publicly routable unicast address. Supports both IPv4 and IPv6.
 
-The following address ranges are **excluded** (will NOT match as public):
+**IPv4 ranges excluded (will NOT match as public):**
 
-| Range | Description |
-|-------|-------------|
-| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | Private addresses ([RFC 1918](https://en.wikipedia.org/wiki/Private_network)) |
-| `127.0.0.0/8` | Loopback addresses |
-| `169.254.0.0/16` | Link-local addresses |
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `100.64.0.0/10` | CGNAT/Shared Address Space | [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) |
+| `127.0.0.0/8` | Loopback | [RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122) |
+| `169.254.0.0/16` | Link-Local | [RFC 3927](https://datatracker.ietf.org/doc/html/rfc3927) |
+| `224.0.0.0/4` | Multicast | [RFC 5771](https://datatracker.ietf.org/doc/html/rfc5771) |
+| `0.0.0.0` | Unspecified | [RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122) |
 
-Note: Multicast addresses (`224.0.0.0/4`) are considered public as they can traverse the internet.
+**IPv6 ranges excluded (will NOT match as public):**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `fc00::/7` | Unique Local Address (ULA) | [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193) |
+| `::1` | Loopback | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `fe80::/10` | Link-Local | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `ff00::/8` | Multicast | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `fec0::/10` | Site-Local (deprecated) | [RFC 3879](https://datatracker.ietf.org/doc/html/rfc3879) |
+| `::` | Unspecified | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
 
 Example rule:
 
 ```yaml
 event: NETWORK_CONNECTIONS
 op: is public address
+path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
+```
+
+### is public ipv4 address
+
+The `is public ipv4 address` operator checks if an IP address at the path is a publicly routable IPv4 address. Returns false for IPv6 addresses.
+
+**Ranges excluded (will NOT match as public):**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | Private | [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) |
+| `100.64.0.0/10` | CGNAT/Shared Address Space | [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) |
+| `127.0.0.0/8` | Loopback | [RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122) |
+| `169.254.0.0/16` | Link-Local | [RFC 3927](https://datatracker.ietf.org/doc/html/rfc3927) |
+| `224.0.0.0/4` | Multicast | [RFC 5771](https://datatracker.ietf.org/doc/html/rfc5771) |
+| `0.0.0.0` | Unspecified | [RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122) |
+
+Example rule:
+
+```yaml
+event: NETWORK_CONNECTIONS
+op: is public ipv4 address
+path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
+```
+
+### is public ipv6 address
+
+The `is public ipv6 address` operator checks if an IP address at the path is a publicly routable IPv6 address. Returns false for IPv4 addresses.
+
+**Ranges excluded (will NOT match as public):**
+
+| Range | Description | RFC |
+|-------|-------------|-----|
+| `fc00::/7` | Unique Local Address (ULA) | [RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193) |
+| `::1` | Loopback | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `fe80::/10` | Link-Local | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `ff00::/8` | Multicast | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+| `fec0::/10` | Site-Local (deprecated) | [RFC 3879](https://datatracker.ietf.org/doc/html/rfc3879) |
+| `::` | Unspecified | [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291) |
+
+Example rule:
+
+```yaml
+event: NETWORK_CONNECTIONS
+op: is public ipv6 address
 path: event/NETWORK_ACTIVITY/SOURCE/IP_ADDRESS
 ```
 


### PR DESCRIPTION
## Details

Documentation updates for IP address classification operators following changes in dr-engine.

Based on top of changes from #84.

## Changes

### New Operators Documented

| Operator | Description |
|----------|-------------|
| `is public ipv4 address` | Matches only publicly routable IPv4 addresses |
| `is public ipv6 address` | Matches only publicly routable IPv6 addresses |
| `is private ipv4 address` | Matches RFC1918 + CGNAT IPv4 addresses |
| `is private ipv6 address` | Matches ULA (fc00::/7) IPv6 addresses |

### Updated Operators

| Operator | Changes |
|----------|---------|
| `is private address` | Added CGNAT (100.64.0.0/10), added IPv6 ULA support, added RFC references |
| `is public address` | Added CGNAT exclusion, fixed multicast handling, added full IPv6 support, added RFC references |

### Documentation Corrections (Breaking Behavior)

| Previous Documentation | Corrected Documentation |
|------------------------|------------------------|
| Multicast (224.0.0.0/4) "considered public as they can traverse the internet" | Multicast is now correctly **excluded** from public (not routable unicast) |
| No mention of CGNAT | CGNAT (100.64.0.0/10) now excluded from public, included in private |
| No IPv6 documentation | Full IPv6 support documented with RFC references |

## RFC References Added

- RFC 1918 (IPv4 Private)
- RFC 6598 (CGNAT)
- RFC 1122 (Loopback, Unspecified)
- RFC 3927 (Link-Local)
- RFC 5771 (Multicast)
- RFC 4193 (IPv6 ULA)
- RFC 4291 (IPv6 Loopback, Link-Local, Multicast)
- RFC 3879 (Deprecated Site-Local)