### PR TITLE
Clean up docs: fix broken links, improve light-mode styling, remove use cases nav

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,3 @@ Please be respectful and professional in all interactions. We're building docume
 - Email [support@limacharlie.io](mailto:support@limacharlie.io)
 - Open an issue on GitHub
 
-## License
-
-By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,3 @@ LimaCharlie is a SecOps Cloud Platform providing:
 - **Web Console**: https://app.limacharlie.io
 - **Community**: https://community.limacharlie.io
 
-## License
-
-Apache License 2.0 - See [LICENSE](LICENSE)

--- a/docs/6-developer-guide/sdks/go-sdk.md
+++ b/docs/6-developer-guide/sdks/go-sdk.md
@@ -1746,10 +1746,6 @@ firehose --listen_interface 0.0.0.0:4444 --data_type event -n my-firehose --use-
 - **Community Support**: [community.limacharlie.io](https://community.limacharlie.io)
 - **Commercial Support**: support@limacharlie.io
 
-## License
-
-The LimaCharlie Go SDK is licensed under the Apache License 2.0. See the LICENSE file in the repository for full details.
-
 ---
 
 ## See Also

--- a/docs/7-administration/index.md
+++ b/docs/7-administration/index.md
@@ -10,6 +10,6 @@ Organization configuration and management.
 
 ## See Also
 
-- [User Access](access)
+- [User Access](access/user-access.md)
 - [API Keys](access/api-keys.md)
-- [Billing](billing)
+- [Billing](billing/options.md)

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -22,6 +22,9 @@
   --md-accent-fg-color: #2563EB;
   --md-accent-fg-color--transparent: #2563EB1a;
 
+  /* Links - explicit color for light mode visibility */
+  --md-typeset-a-color: #2563EB;
+
   /* CTA pink for buttons */
   --lc-cta-color: #E91E63;
   --lc-cta-color--hover: #BE185D;
@@ -56,6 +59,27 @@
 
   /* Links with blue accent */
   --md-typeset-a-color: #60A5FA;
+}
+
+/* Light mode link underlines for better visibility */
+[data-md-color-scheme="default"] .md-typeset a {
+  text-decoration: underline;
+  text-decoration-color: rgba(37, 99, 235, 0.4);
+  text-underline-offset: 0.15em;
+}
+
+[data-md-color-scheme="default"] .md-typeset a:hover {
+  text-decoration-color: rgba(37, 99, 235, 1);
+}
+
+/* Exclude nav, header, footer, and button links from underline */
+[data-md-color-scheme="default"] .md-nav a,
+[data-md-color-scheme="default"] .md-header a,
+[data-md-color-scheme="default"] .md-footer a,
+[data-md-color-scheme="default"] .md-button,
+[data-md-color-scheme="default"] .md-tabs a,
+[data-md-color-scheme="default"] .md-source {
+  text-decoration: none;
 }
 
 /* Custom heading styles */

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,14 +96,3 @@ LimaCharlie is the **SecOps Cloud Platform** delivering security operations for 
 - [:material-email: Support](mailto:support@limacharlie.io)
 
 </div>
-
-## About This Documentation
-
-This documentation is open source and available on [GitHub](https://github.com/refractionPOINT/documentation). It includes:
-
-- **267 Documentation Pages**: Comprehensive platform documentation
-- **SDK References**: Complete Go and Python SDK documentation
-- **Code Examples**: Ready-to-use examples for common tasks
-- **Integration Guides**: Step-by-step tutorials for third-party integrations
-
-Licensed under the [Apache License 2.0](https://github.com/refractionPOINT/documentation/blob/master/LICENSE).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,7 @@ extra:
 extra_css:
   - assets/stylesheets/extra.css
 
-copyright: Copyright &copy; 2018-2025 refractionPOINT - Licensed under Apache 2.0
+copyright: Copyright &copy; 2018-2025 refractionPOINT
 
 nav:
   - Home: index.md
@@ -123,30 +123,6 @@ nav:
       - What is LimaCharlie?: 1-getting-started/what-is-limacharlie.md
       - Quickstart: 1-getting-started/quickstart.md
       - Core Concepts: 1-getting-started/core-concepts.md
-      - Use Cases:
-          - EDR: 1-getting-started/use-cases/edr.md
-          - Cloud Security: 1-getting-started/use-cases/cloud-security.md
-          - SIEM Alternative: 1-getting-started/use-cases/cost-effective-siem.md
-          - MSSP/MSP/MDR: 1-getting-started/use-cases/mssp-msp-mdr.md
-          - Incident Response: 1-getting-started/use-cases/incident-response.md
-          - Threat Hunting: 1-getting-started/use-cases/threat-hunting.md
-          - DevOps Security: 1-getting-started/use-cases/devops-security.md
-          - FIM: 1-getting-started/use-cases/fim.md
-          - Purple Teaming: 1-getting-started/use-cases/purple-teaming.md
-          - Investigation Guide: 1-getting-started/use-cases/investigation-guide.md
-          - Adversary Techniques: 1-getting-started/use-cases/adversary-techniques.md
-          - Building Products: 1-getting-started/use-cases/building-products.md
-          - ChromeOS Support: 1-getting-started/use-cases/chromeos-support.md
-          - CTI Capabilities: 1-getting-started/use-cases/cti-capabilities.md
-          - Enterprises: 1-getting-started/use-cases/enterprises.md
-          - M&A Due Diligence: 1-getting-started/use-cases/ma-due-diligence.md
-          - Network Monitoring: 1-getting-started/use-cases/network-monitoring.md
-          - Observability Pipeline: 1-getting-started/use-cases/observability-pipeline.md
-          - SecOps Development: 1-getting-started/use-cases/secops-development.md
-          - Sleeper Mode: 1-getting-started/use-cases/sleeper-mode.md
-          - SOAR Automation: 1-getting-started/use-cases/soar-automation.md
-          - Table Top Exercises: 1-getting-started/use-cases/table-top-exercises.md
-          - WEL Monitoring: 1-getting-started/use-cases/wel-monitoring.md
       - Tutorials:
           - Overview: 1-getting-started/tutorials/index.md
 


### PR DESCRIPTION
## Summary

- **Fix broken links** on Platform Management page: User Access and Billing links pointed to directories without index files
- **Improve light-mode link visibility**: add explicit link color (`#2563EB`) and subtle underline so hyperlinks stand out from body text without hovering
- **Remove Use Cases** from Getting Started navigation (use case files remain in repo)
- **Remove "About This Documentation"** section from home page
- **Remove Apache License 2.0** references across all files (footer, README, CONTRIBUTING, Go SDK)

## Test plan

- [ ] Verify light-mode links are visually distinct from surrounding text
- [ ] Verify dark-mode links are unaffected
- [ ] Verify nav/header/footer/button links do not get underlines
- [ ] Confirm Billing and User Access links on Platform Management page resolve correctly
- [ ] Confirm use case docs are still accessible directly by URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)