### PR TITLE
docs: expand latency FAQ with routing.latency explanation

### DIFF
--- a/docs/8-reference/faq/general.md
+++ b/docs/8-reference/faq/general.md
@@ -68,9 +68,9 @@ LimaCharlie makes it easy to add a detection & response rule as soon as new vari
 
 ## What latency can I expect in LimaCharlie?
 
-LimaCharlie Detection & Response (D&R) engine has very low latency and you can expect that responses are almost instantaneous (e.g. 100ms).
+The D&R engine processes events in real-time with sub-100ms latency. Batch outputs (S3, SFTP, GCS) have configurable timing; live outputs (Syslog) deliver immediately.
 
-You may notice some latency as it relates to outputs. Some of our outputs are done in batches, such as Amazon S3, SFTP, Google Cloud Storage. You can configure the maximum size and maximum time for these outputs. We also offer live outputs, such as Syslog.
+If you are seeing high `routing.latency` values on detections, note that this field measures end-to-end time from event origin to detection creation, not D&R processing time. See [Understanding Latency](../latency.md) for a full explanation of what contributes to this value and how to diagnose it.
 
 ## How can I integrate LimaCharlie with my existing SIEM?
 

--- a/docs/8-reference/latency.md
+++ b/docs/8-reference/latency.md
@@ -1,0 +1,56 @@
+# Understanding Latency
+
+## D&R Engine Latency
+
+The LimaCharlie Detection & Response (D&R) engine processes events in real-time with very low latency. You can expect D&R rule evaluation to complete in under 100ms in typical conditions.
+
+There is no long-term backlog queue — events are processed in real-time as they arrive. If a sensor generates data at an unsustainable rate (thousands of events per second over an extended period), the platform will eventually emit a **queue drop** event rather than silently falling behind.
+
+## Output Latency
+
+Some outputs are delivered in batches (e.g., Amazon S3, SFTP, Google Cloud Storage), where you can configure the maximum batch size and time window. Live outputs such as Syslog deliver data immediately.
+
+## Understanding `routing.latency`
+
+Detections include a `routing.latency` field, which is the delta between `routing.event_time` and `gen_time` (detection creation time), expressed in milliseconds. This value represents the **total end-to-end time** from when the event originally occurred to when LimaCharlie created the detection — it is **not** a measure of D&R engine processing time.
+
+The `routing.event_time` is the timestamp of the original event as reported by the source. This means `routing.latency` includes all delays that occur **before** the event reaches LimaCharlie, such as:
+
+- Time spent in third-party pipelines (e.g., Microsoft O365, AWS CloudTrail)
+- Time between when an OS records an event internally and when it becomes available to the sensor (e.g., macOS Unified Logs, Windows Event Logs)
+- Network transit time from the sensor to the LimaCharlie cloud
+
+## Common Causes of High `routing.latency`
+
+### External Data Sources (USP/Adapters)
+
+When ingesting data from external platforms via adapters, the source platform controls when events become available. For example, Microsoft 365 events can be delayed anywhere from minutes to several hours in Microsoft's own pipeline before LimaCharlie can pull them. LimaCharlie has no control over these upstream delays.
+
+### Sensor Sleep/Wake Cycles
+
+If a laptop goes to sleep and wakes up hours later, events generated before sleep are transmitted only after the sensor reconnects. An event from 12 hours ago that arrives after wake-up will show a `routing.latency` of 12+ hours, even though the D&R engine processed it instantly upon receipt.
+
+### Network Interruptions
+
+If a sensor loses internet connectivity, it buffers events locally and transmits them when the connection is restored. This can produce a burst of events with high `routing.latency` values.
+
+### OS-Level Delays
+
+Operating systems do not always emit internal events immediately. macOS and Windows may delay writing certain events to their respective log systems (Unified Logs, Event Logs), which means the sensor cannot transmit them until they are available.
+
+## How to Diagnose Latency
+
+To assess whether the LimaCharlie processing pipeline is healthy, **look at the minimum `routing.latency` value for a given sensor** rather than the maximum or average. Because events from a sensor are processed first-in-first-out in real-time, if you see some events processed in a few hundred milliseconds, the pipeline is working correctly. High latency on specific events alongside low latency on others indicates the delays are on the source side, not in the LimaCharlie pipeline.
+
+## What Can Affect D&R Processing Time
+
+While the D&R engine itself is sub-100ms, certain configurations can introduce additional processing time:
+
+- **Blocking D&R actions**: Rules that use `wait` or perform external lookups (e.g., VirusTotal queries) block processing while waiting for a response. Heavy use of these across many rules can introduce back-pressure.
+- **Blocking outputs**: Single-event webhook outputs that receive high volumes can create back-pressure if the destination is slow to respond.
+
+In practice, these factors typically add milliseconds to seconds, not minutes or hours.
+
+## Architecture
+
+LimaCharlie's infrastructure is multi-tenant. There is no per-organization queue — events are processed across hundreds of services where each sensor's events are handled independently. This means latency issues in one organization do not affect others.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -412,6 +412,7 @@ nav:
       - Error Codes: 8-reference/error-codes.md
       - Auth Resource Locator: 8-reference/authentication-resource-locator.md
       - YARA Modules: 8-reference/yara-modules.md
+      - Latency: 8-reference/latency.md
       - FAQ:
           - Overview: 8-reference/faq/index.md
           - General: 8-reference/faq/general.md


### PR DESCRIPTION
## Summary

- Expands the brief "What latency can I expect?" FAQ entry into a comprehensive reference covering D&R engine latency, the `routing.latency` field, common causes of high values, and diagnostic guidance
- Clarifies that `routing.latency` measures end-to-end time from event origin to detection creation, not D&R engine processing time
- Documents common causes: external data source delays (e.g., Microsoft O365), sensor sleep/wake cycles, network interruptions, OS-level log delays
- Adds practical diagnostic advice: check minimum latency per sensor to assess pipeline health
- Documents factors that can affect D&R processing time (blocking actions, blocking outputs)
- Describes multi-tenant architecture (no per-org queue, independent sensor processing)

## Test plan

- [ ] Verify the page renders correctly in mkdocs
- [ ] Review technical accuracy of latency explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)