### PR TITLE
docs: update AI plugin docs to reflect CLI-based approach

### DIFF
--- a/docs/6-developer-guide/index.md
+++ b/docs/6-developer-guide/index.md
@@ -10,11 +10,11 @@ Programmatic access to LimaCharlie:
 - [Go SDK](sdks/go-sdk.md) - Native Go implementation
 - [SDK Overview](sdks/index.md) - Getting started with SDKs
 
-## MCP Server
+## AI Assistants
 
-AI-native integration for Claude and other AI assistants:
+Connect AI assistants to LimaCharlie via the Claude Code Plugin or MCP:
 
-- [MCP Server Setup](mcp-server.md)
+- [Connecting AI Assistants](mcp-server.md)
 
 ## Building Extensions
 

--- a/docs/6-developer-guide/mcp-server.md
+++ b/docs/6-developer-guide/mcp-server.md
@@ -1,25 +1,28 @@
-# MCP Server
+# Connecting AI Assistants
 
-The Model Context Protocol (MCP) is a standardized protocol that enables AI agents to access and interact with external tools and resources. LimaCharlie provides an MCP server that allows AI assistants to query telemetry, investigate endpoints, manage configurations, and take response actions.
+LimaCharlie can be accessed by AI assistants in two ways:
+
+- **Claude Code Plugin** — Uses the `limacharlie` CLI for all operations, with pre-built skills and workflows (recommended)
+- **MCP Server** — A [Model Context Protocol](https://modelcontextprotocol.io/) endpoint for any MCP-compatible AI client
 
 ## Setup Options
 
-Choose the setup method based on your MCP client:
+Choose the setup method based on your AI client:
 
 | Method | Auth Type | Multi-Org |
 |--------|-----------|-----------|
-| **Option 1:** Claude Code Plugin | OAuth (browser login) | Yes |
+| **Option 1:** Claude Code Plugin | OAuth via CLI (browser login) | Yes |
 | **Option 2:** HTTP MCP with OAuth | OAuth (browser login) | Yes |
 | **Option 3:** HTTP MCP with JWT | User API Key → JWT | Yes |
 | **Option 3:** HTTP MCP with API Key | Org API Key | No |
 
-**Recommendation:** Use Option 1 if you're using Claude Code. If not, check whether your MCP client supports OAuth and use Option 2. Fall back to Option 3 (JWT or API key) only if OAuth isn't available in your client.
+**Recommendation:** Use Option 1 if you're using Claude Code — it provides the richest experience with pre-built skills and workflows, and uses the `limacharlie` CLI for all operations. If not using Claude Code, check whether your MCP client supports OAuth and use Option 2. Fall back to Option 3 (JWT or API key) only if OAuth isn't available in your client.
 
 ---
 
 ## Option 1: Claude Code Plugin (Recommended)
 
-The LimaCharlie plugin provides the richest experience with pre-built skills, workflows, and multi-org support.
+The LimaCharlie plugin provides the richest experience with pre-built skills, workflows, and multi-org support. Unlike Options 2–3, this plugin does **not** use an MCP server—it uses the `limacharlie` CLI for all API operations, which is automatically installed on session start.
 
 ### Installation
 
@@ -30,17 +33,33 @@ Run these commands in Claude Code:
 /plugin install lc-essentials@lc-marketplace
 ```
 
+The plugin automatically installs the `limacharlie` CLI when a session starts. If auto-installation fails, install it manually:
+
+```bash
+pipx install limacharlie   # preferred (isolated environment)
+uv tool install limacharlie # alternative
+pip install --user limacharlie # fallback
+```
+
 ### Authentication
 
-1. Run `/mcp` in Claude Code
-2. Select the LimaCharlie server
-3. Complete OAuth login in your browser when prompted
+Authenticate the CLI via OAuth:
 
-Your credentials persist across sessions automatically.
+```bash
+limacharlie auth login
+```
+
+This opens your browser for LimaCharlie OAuth. Credentials persist across sessions automatically.
 
 ### Verify Setup
 
-Ask Claude: *"List my LimaCharlie organizations"*
+Run the following to confirm authentication and list your organizations:
+
+```bash
+limacharlie org list --output yaml
+```
+
+Or ask Claude: *"List my LimaCharlie organizations"*
 
 ---
 
@@ -261,9 +280,11 @@ Once connected, AI assistants can:
 | Issue | Solution |
 |-------|----------|
 | "Unauthorized" error | Verify your API key and OID are correct. Ensure the API key has the required permissions for the operation — the error message will specify the missing privilege. |
-| Plugin not appearing | Restart Claude Code after installation. Run `/mcp` to check server status. |
+| Plugin not appearing | Restart Claude Code after installation. |
 | OAuth login fails | Clear browser cookies for limacharlie.io and try again. |
-| Tools not loading | Run `/mcp` to verify the server is connected and authenticated. |
+| CLI not found (plugin) | The plugin auto-installs the `limacharlie` CLI on session start. If it fails, install manually: `pipx install limacharlie` |
+| CLI not authenticated | Run `limacharlie auth login` to authenticate via browser OAuth. |
+| MCP tools not loading (Options 2–3) | Verify the MCP server URL and authentication headers are correct. |
 | "Missing privilege" on specific operations | The authenticated user or API key lacks the required permission. See [Permission Requirements](#permission-requirements) to identify which permissions to grant. |
 
 ---

--- a/docs/9-ai-sessions/index.md
+++ b/docs/9-ai-sessions/index.md
@@ -12,7 +12,7 @@ Automatically spawn AI sessions in response to detections, events, or any condit
 
 - **Automated incident triage**: When a detection fires, have Claude investigate the alert, gather context, and produce a summary report
 - **Threat hunting**: Automatically investigate suspicious activity patterns
-- **Enrichment**: Use Claude to correlate data from multiple sources via MCP servers
+- **Enrichment**: Use Claude to correlate data from multiple sources
 - **Response automation**: Generate recommendations or take automated actions
 
 [Learn more about D&R-Driven Sessions](dr-sessions.md)
@@ -43,7 +43,7 @@ AI Sessions runs fully-managed Claude Code instances in isolated cloud environme
 
 1. **Receives a prompt** with context (event data, detection details, or user input)
 2. **Executes autonomously** using Claude's tool capabilities (Bash, file operations, web fetch, etc.)
-3. **Connects to external data** via MCP servers (LimaCharlie API, threat intel, etc.)
+3. **Connects to external data** via the LimaCharlie CLI, MCP servers, or other configured tools
 4. **Returns results** either as a final summary or streamed in real-time
 
 ## Getting Started

--- a/docs/9-ai-sessions/user-sessions.md
+++ b/docs/9-ai-sessions/user-sessions.md
@@ -260,7 +260,7 @@ You: I need to investigate suspicious activity on sensor abc123.
 Claude: I'll investigate this sensor. Let me start by gathering some
         context about the sensor and recent events.
 
-        [Uses LimaCharlie MCP to query sensor info and events]
+        [Uses LimaCharlie tools to query sensor info and events]
 
         I found several suspicious indicators:
         1. A new process "update.exe" started from a temp directory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -373,7 +373,7 @@ nav:
           - Go SDK Regeneration: 6-developer-guide/sdks/go-sdk-regeneration.md
       - SDK Overview: 6-developer-guide/sdk-overview.md
       - CLI: 6-developer-guide/cli.md
-      - MCP Server: 6-developer-guide/mcp-server.md
+      - Connecting AI Assistants: 6-developer-guide/mcp-server.md
       - Pipeline: 6-developer-guide/pipeline.md
       - Building Extensions:
           - Getting Started: 6-developer-guide/extensions/building-extensions.md


### PR DESCRIPTION
## Summary

- Rewrites the Claude Code Plugin setup instructions (Option 1) to reflect the move from MCP server to `limacharlie` CLI
- Renames the page from "MCP Server" to "Connecting AI Assistants" since Option 1 no longer uses MCP
- Updates AI Sessions docs to remove hardcoded MCP references where the CLI or generic tooling is now used

## Test plan

- [ ] Verify mkdocs builds without errors
- [ ] Check all internal links still resolve (page file path unchanged, only title changed)
- [ ] Review that MCP Options 2–3 documentation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)