### PR TITLE
Add enable/disable docs for Hive records

### DIFF
--- a/docs/3-detection-response/false-positives.md
+++ b/docs/3-detection-response/false-positives.md
@@ -266,42 +266,57 @@ value: web-server-2
 === "REST API"
 
     ```bash
-    # Disable an FP rule (update metadata only):
+    # 1. Read current metadata to preserve tags, expiry, comment:
+    CURRENT=$(curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/fp/YOUR_OID/suppress-known-app/mtd" \
+      -H "Authorization: Bearer $LC_JWT")
+
+    # 2. Merge and update (set enabled to false, keep other fields):
     curl -s -X POST "https://api.limacharlie.io/v1/hive/fp/YOUR_OID/suppress-known-app/mtd" \
       -H "Authorization: Bearer $LC_JWT" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d 'usr_mtd={"enabled":false}'
+      -d 'usr_mtd={"enabled":false,"expiry":0,"tags":[],"comment":""}'
     ```
+
+    !!! warning
+        The API **replaces** `usr_mtd` entirely. Sending only `{"enabled":false}` will reset tags, expiry, and comment to their defaults. Always read the current metadata first and resend all fields.
 
 === "Python"
 
     ```python
-    from limacharlie.sdk.hive import Hive, HiveRecord
-
     hive = Hive(org, "fp")
-    # Disable:
-    hive.set(HiveRecord("suppress-known-app", enabled=False))
-    # Enable:
-    hive.set(HiveRecord("suppress-known-app", enabled=True))
+    # Read-modify-write to preserve other metadata:
+    record = hive.get_metadata("suppress-known-app")
+    record.enabled = False  # or True to re-enable
+    hive.set(record)
     ```
 
 === "Go"
 
     ```go
-    enabled := false
     hc := limacharlie.NewHiveClient(org)
+    // Read current metadata first to preserve tags, expiry, comment.
+    existing, _ := hc.GetMTD(limacharlie.HiveArgs{
+        HiveName:     "fp",
+        PartitionKey: org.GetOID(),
+        Key:          "suppress-known-app",
+    })
+    enabled := false
     hc.Add(limacharlie.HiveArgs{
         HiveName:     "fp",
         PartitionKey: org.GetOID(),
         Key:          "suppress-known-app",
         Enabled:      &enabled,
+        Tags:         existing.UsrMtd.Tags,
+        Expiry:       &existing.UsrMtd.Expiry,
+        Comment:      &existing.UsrMtd.Comment,
     })
     ```
 
 === "CLI"
 
     ```bash
-    # Disable an FP rule:
+    # Disable an FP rule (reads metadata first to preserve other fields):
     limacharlie fp disable --key suppress-known-app
     # Re-enable:
     limacharlie fp enable --key suppress-known-app

--- a/docs/3-detection-response/index.md
+++ b/docs/3-detection-response/index.md
@@ -197,42 +197,57 @@ Build custom detection logic with automated response actions.
 === "REST API"
 
     ```bash
-    # Disable a rule (update metadata only):
+    # 1. Read current metadata to preserve tags, expiry, comment:
+    CURRENT=$(curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/dr-general/YOUR_OID/my-rule/mtd" \
+      -H "Authorization: Bearer $LC_JWT")
+
+    # 2. Merge and update (set enabled to false, keep other fields):
     curl -s -X POST "https://api.limacharlie.io/v1/hive/dr-general/YOUR_OID/my-rule/mtd" \
       -H "Authorization: Bearer $LC_JWT" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d 'usr_mtd={"enabled":false}'
+      -d 'usr_mtd={"enabled":false,"expiry":0,"tags":["my-tag"],"comment":"kept"}'
     ```
+
+    !!! warning
+        The API **replaces** `usr_mtd` entirely. Sending only `{"enabled":false}` will reset tags, expiry, and comment to their defaults. Always read the current metadata first and resend all fields.
 
 === "Python"
 
     ```python
-    from limacharlie.sdk.hive import Hive, HiveRecord
-
     hive = Hive(org, "dr-general")
-    # Disable:
-    hive.set(HiveRecord("my-rule", enabled=False))
-    # Enable:
-    hive.set(HiveRecord("my-rule", enabled=True))
+    # Read-modify-write to preserve other metadata:
+    record = hive.get_metadata("my-rule")
+    record.enabled = False  # or True to re-enable
+    hive.set(record)
     ```
 
 === "Go"
 
     ```go
-    enabled := false
     hc := limacharlie.NewHiveClient(org)
+    // Read current metadata first to preserve tags, expiry, comment.
+    existing, _ := hc.GetMTD(limacharlie.HiveArgs{
+        HiveName:     "dr-general",
+        PartitionKey: org.GetOID(),
+        Key:          "my-rule",
+    })
+    enabled := false
     hc.Add(limacharlie.HiveArgs{
         HiveName:     "dr-general",
         PartitionKey: org.GetOID(),
         Key:          "my-rule",
         Enabled:      &enabled,
+        Tags:         existing.UsrMtd.Tags,
+        Expiry:       &existing.UsrMtd.Expiry,
+        Comment:      &existing.UsrMtd.Comment,
     })
     ```
 
 === "CLI"
 
     ```bash
-    # Disable a rule:
+    # Disable a rule (reads metadata first to preserve other fields):
     limacharlie dr disable --key my-rule
     # Re-enable:
     limacharlie dr enable --key my-rule

--- a/docs/7-administration/config-hive/dr-rules.md
+++ b/docs/7-administration/config-hive/dr-rules.md
@@ -283,42 +283,57 @@ The D&R rules hive is named `dr-general`. Managed rules use `dr-managed`.
 === "REST API"
 
     ```bash
-    # Disable a rule (update metadata only):
+    # 1. Read current metadata to preserve tags, expiry, comment:
+    CURRENT=$(curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/dr-general/YOUR_OID/my-rule/mtd" \
+      -H "Authorization: Bearer $LC_JWT")
+
+    # 2. Merge and update (set enabled to false, keep other fields):
     curl -s -X POST "https://api.limacharlie.io/v1/hive/dr-general/YOUR_OID/my-rule/mtd" \
       -H "Authorization: Bearer $LC_JWT" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d 'usr_mtd={"enabled":false}'
+      -d 'usr_mtd={"enabled":false,"expiry":0,"tags":["my-tag"],"comment":"kept"}'
     ```
+
+    !!! warning
+        The API **replaces** `usr_mtd` entirely. Sending only `{"enabled":false}` will reset tags, expiry, and comment to their defaults. Always read the current metadata first and resend all fields.
 
 === "Python"
 
     ```python
-    from limacharlie.sdk.hive import Hive, HiveRecord
-
     hive = Hive(org, "dr-general")
-    # Disable:
-    hive.set(HiveRecord("my-rule", enabled=False))
-    # Enable:
-    hive.set(HiveRecord("my-rule", enabled=True))
+    # Read-modify-write to preserve other metadata:
+    record = hive.get_metadata("my-rule")
+    record.enabled = False  # or True to re-enable
+    hive.set(record)
     ```
 
 === "Go"
 
     ```go
-    enabled := false
     hc := limacharlie.NewHiveClient(org)
+    // Read current metadata first to preserve tags, expiry, comment.
+    existing, _ := hc.GetMTD(limacharlie.HiveArgs{
+        HiveName:     "dr-general",
+        PartitionKey: org.GetOID(),
+        Key:          "my-rule",
+    })
+    enabled := false
     hc.Add(limacharlie.HiveArgs{
         HiveName:     "dr-general",
         PartitionKey: org.GetOID(),
         Key:          "my-rule",
         Enabled:      &enabled,
+        Tags:         existing.UsrMtd.Tags,
+        Expiry:       &existing.UsrMtd.Expiry,
+        Comment:      &existing.UsrMtd.Comment,
     })
     ```
 
 === "CLI"
 
     ```bash
-    # Disable a rule:
+    # Disable a rule (reads metadata first to preserve other fields):
     limacharlie dr disable --key my-rule
     # Re-enable:
     limacharlie dr enable --key my-rule

--- a/docs/7-administration/config-hive/lookups.md
+++ b/docs/7-administration/config-hive/lookups.md
@@ -338,42 +338,57 @@ Lookups support three data formats: `lookup_data` (key-value pairs), `newline_co
 === "REST API"
 
     ```bash
-    # Disable a lookup (update metadata only):
+    # 1. Read current metadata to preserve tags, expiry, comment:
+    CURRENT=$(curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/lookup/YOUR_OID/my-lookup/mtd" \
+      -H "Authorization: Bearer $LC_JWT")
+
+    # 2. Merge and update (set enabled to false, keep other fields):
     curl -s -X POST "https://api.limacharlie.io/v1/hive/lookup/YOUR_OID/my-lookup/mtd" \
       -H "Authorization: Bearer $LC_JWT" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d 'usr_mtd={"enabled":false}'
+      -d 'usr_mtd={"enabled":false,"expiry":0,"tags":[],"comment":""}'
     ```
+
+    !!! warning
+        The API **replaces** `usr_mtd` entirely. Sending only `{"enabled":false}` will reset tags, expiry, and comment to their defaults. Always read the current metadata first and resend all fields.
 
 === "Python"
 
     ```python
-    from limacharlie.sdk.hive import Hive, HiveRecord
-
     hive = Hive(org, "lookup")
-    # Disable:
-    hive.set(HiveRecord("my-lookup", enabled=False))
-    # Enable:
-    hive.set(HiveRecord("my-lookup", enabled=True))
+    # Read-modify-write to preserve other metadata:
+    record = hive.get_metadata("my-lookup")
+    record.enabled = False  # or True to re-enable
+    hive.set(record)
     ```
 
 === "Go"
 
     ```go
-    enabled := false
     hc := limacharlie.NewHiveClient(org)
+    // Read current metadata first to preserve tags, expiry, comment.
+    existing, _ := hc.GetMTD(limacharlie.HiveArgs{
+        HiveName:     "lookup",
+        PartitionKey: org.GetOID(),
+        Key:          "my-lookup",
+    })
+    enabled := false
     hc.Add(limacharlie.HiveArgs{
         HiveName:     "lookup",
         PartitionKey: org.GetOID(),
         Key:          "my-lookup",
         Enabled:      &enabled,
+        Tags:         existing.UsrMtd.Tags,
+        Expiry:       &existing.UsrMtd.Expiry,
+        Comment:      &existing.UsrMtd.Comment,
     })
     ```
 
 === "CLI"
 
     ```bash
-    # Disable a lookup:
+    # Disable a lookup (reads metadata first to preserve other fields):
     limacharlie lookup disable --key my-lookup
     # Re-enable:
     limacharlie lookup enable --key my-lookup

--- a/docs/7-administration/config-hive/secrets.md
+++ b/docs/7-administration/config-hive/secrets.md
@@ -301,42 +301,57 @@ Using a secret in combination with an output has very few steps:
 === "REST API"
 
     ```bash
-    # Disable a secret (update metadata only):
+    # 1. Read current metadata to preserve tags, expiry, comment:
+    CURRENT=$(curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/secret/YOUR_OID/my-secret/mtd" \
+      -H "Authorization: Bearer $LC_JWT")
+
+    # 2. Merge and update (set enabled to false, keep other fields):
     curl -s -X POST "https://api.limacharlie.io/v1/hive/secret/YOUR_OID/my-secret/mtd" \
       -H "Authorization: Bearer $LC_JWT" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d 'usr_mtd={"enabled":false}'
+      -d 'usr_mtd={"enabled":false,"expiry":0,"tags":[],"comment":""}'
     ```
+
+    !!! warning
+        The API **replaces** `usr_mtd` entirely. Sending only `{"enabled":false}` will reset tags, expiry, and comment to their defaults. Always read the current metadata first and resend all fields.
 
 === "Python"
 
     ```python
-    from limacharlie.sdk.hive import Hive, HiveRecord
-
     hive = Hive(org, "secret")
-    # Disable:
-    hive.set(HiveRecord("my-secret", enabled=False))
-    # Enable:
-    hive.set(HiveRecord("my-secret", enabled=True))
+    # Read-modify-write to preserve other metadata:
+    record = hive.get_metadata("my-secret")
+    record.enabled = False  # or True to re-enable
+    hive.set(record)
     ```
 
 === "Go"
 
     ```go
-    enabled := false
     hc := limacharlie.NewHiveClient(org)
+    // Read current metadata first to preserve tags, expiry, comment.
+    existing, _ := hc.GetMTD(limacharlie.HiveArgs{
+        HiveName:     "secret",
+        PartitionKey: org.GetOID(),
+        Key:          "my-secret",
+    })
+    enabled := false
     hc.Add(limacharlie.HiveArgs{
         HiveName:     "secret",
         PartitionKey: org.GetOID(),
         Key:          "my-secret",
         Enabled:      &enabled,
+        Tags:         existing.UsrMtd.Tags,
+        Expiry:       &existing.UsrMtd.Expiry,
+        Comment:      &existing.UsrMtd.Comment,
     })
     ```
 
 === "CLI"
 
     ```bash
-    # Disable a secret:
+    # Disable a secret (reads metadata first to preserve other fields):
     limacharlie secret disable --key my-secret
     # Re-enable:
     limacharlie secret enable --key my-secret


### PR DESCRIPTION
## Summary
- Adds "Enable / Disable" sections to the programmatic management docs for D&R rules, false positives, lookups, and secrets
- Each section includes REST API, Python SDK, Go SDK, and CLI examples
- Documents the new `limacharlie <noun> enable/disable --key <key>` CLI shortcut commands

## Pages updated
- `docs/3-detection-response/index.md` (D&R overview)
- `docs/3-detection-response/false-positives.md`
- `docs/7-administration/config-hive/dr-rules.md`
- `docs/7-administration/config-hive/lookups.md`
- `docs/7-administration/config-hive/secrets.md`

Companion to refractionPOINT/python-limacharlie#231

🤖 Generated with [Claude Code](https://claude.com/claude-code)