### PR TITLE
docs: Remove deprecated lc:usage tag, update sleeper wake-up instructions

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/sleeper.md
+++ b/docs/2-sensors-deployment/endpoint-agent/sleeper.md
@@ -6,17 +6,15 @@ LimaCharlie's usage-based billing enables incident responders to offer pre-deplo
 >
 > For more details on sleeper mode deployments, feel free to contact us at [answers@limacharlie.io](mailto:answers@limacharlie.io) or book a quick call with the engineering team to discuss your use case.
 
-Sleeper and Usage billing use the following metrics:
+Sleeper billing uses the following metrics:
 
 | Connected Time | Events Processed | Events Retained |
 | --- | --- | --- |
 | $0.10 per 30 days | $0.67 per 100,000 events | $0.17 per 100,000 events |
 
-Using sleeper and usage deployments is done via Sensor tagging. Applying the `lc:sleeper` Tag to a Sensor will stop LimaCharlie telemetry collection activity on the host. Within 10 minutes of the tag being applied, the sensor will enter sleeper mode and will be billed only for its "Connected Time" as outlined above. If the tag is removed, normal operations resume within 10 minutes.
+Using sleeper deployments is done via Sensor tagging. Applying the `lc:sleeper` Tag to a Sensor will stop LimaCharlie telemetry collection activity on the host. Within 10 minutes of the tag being applied, the sensor will enter sleeper mode and will be billed only for its "Connected Time" as outlined above. If the tag is removed, normal operations resume within 10 minutes.
 
-Applying the `lc:usage` tag will make the sensor operate normally as usual, but its connection will not count against the normal Sensor Quota. Instead it will be billed per time spend connected and number of events process/retained as outlined above.
-
-Using the "usage" and "sleeper" mode requires the organization in question to have billing enabled (a quota of at least 3 to be outside of the free tier).
+Using sleeper mode requires the organization in question to have billing enabled (a quota of at least 3 to be outside of the free tier).
 
 This means a sample scenario around pre-deploying in an enterprise could look something like this:
 
@@ -24,11 +22,8 @@ This means a sample scenario around pre-deploying in an enterprise could look so
 2. Set the Quota to 3 to enable billing.
 3. Create a new Installation Key, and set the `lc:sleeper` tag on the key.
 4. Enroll any number of EDR sensors. Charges will apply as specified above. For example, if you deploy 100 Sensors in sleeper mode, total monthly costs will be $10.
-5. Whenever you need to "wake up" and use some of the EDRs, you have 2 options:
-
-   1. Set the `lc:usage` tag on the Sensor(s) you need. Within 10 minutes, telemetry collection will resume and billed on direct usage.
-   2. Set the quota to the number of Sensor(s) you need, remove the `lc:sleeper` tag from the specific Sensors, and within 10 minutes they will be online, billed according to the quota.
-6. When you're done, just re-add the `lc:sleeper` tag.
+5. Whenever you need to "wake up" and use some of the EDRs, set the Quota to the number of Sensors you need (e.g. if you want to wake up 5 sensors, set the quota to at least 5), remove the `lc:sleeper` tag from the specific Sensors, and within 10 minutes they will be online, billed according to the quota.
+6. When you're done, just re-add the `lc:sleeper` tag and lower the Quota back down.
 
 Switching to sleeper mode does not change the binary on disk, however, the code running in memory does change. Whether putting an org into sleeper mode or changing versions, the binary on disk remains as-is.
 

--- a/docs/2-sensors-deployment/sensor-tags.md
+++ b/docs/2-sensors-deployment/sensor-tags.md
@@ -115,11 +115,7 @@ When you tag a sensor with lc:limit-update, the sensor will not update the versi
 
 ### lc:sleeper
 
-When you tag a sensor with *lc:sleeper*, the sensor will keep its connection to the LimaCharlie Cloud, but will disable all other functionality to avoid any impact on the system.
-
-### lc:usage
-
-When you tag a sensor with *lc:usage*, the sensor will work as usual, but its connection will not count against the normal sensor quota. Instead, the time the sensor spends connected will be billed separately per second, and so will events received by the sensor. For more details, see [Sleeper Deployments](../1-getting-started/use-cases/sleeper-mode.md).
+When you tag a sensor with *lc:sleeper*, the sensor will keep its connection to the LimaCharlie Cloud, but will disable all other functionality to avoid any impact on the system. To wake up sensors from sleeper mode, set your organization's Quota to accommodate the number of sensors you want to activate, then remove the `lc:sleeper` tag from those sensors. For more details, see [Sleeper Deployments](endpoint-agent/sleeper.md).
 
 Similar to agents, Sensors send telemetry to the LimaCharlie platform in the form of EDR telemetry or forwarded logs. Sensors are offered as a scalable, serverless solution for securely connecting endpoints of an organization to the cloud.
 


### PR DESCRIPTION
## Summary
- Removed all references to the deprecated `lc:usage` sensor tag
- Updated sleeper mode wake-up instructions: the primary method is now to set the Quota to the number of sensors needed and remove the `lc:sleeper` tag
- Updated sensor-tags.md to remove the `lc:usage` section and add wake-up guidance to the `lc:sleeper` section

## Test plan
- [ ] Verify sleeper.md renders correctly with updated steps
- [ ] Verify sensor-tags.md renders correctly without lc:usage section
- [ ] Confirm no remaining lc:usage references in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)