### PR TITLE
ci: optimize link checker with lychee and caching

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -34,32 +34,60 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install linkchecker
 
       - name: Build documentation
         run: mkdocs build
 
-      - name: Start local server
-        run: |
-          cd site
-          python -m http.server 8000 &
-          sleep 3
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-cache-${{ github.sha }}
+          restore-keys: |
+            lychee-cache-
 
-      - name: Check internal links
-        run: |
-          linkchecker http://localhost:8000 \
-            --check-extern \
-            --ignore-url "^https://app.limacharlie.io" \
-            --ignore-url "^https://community.limacharlie.io" \
-            --ignore-url "^mailto:" \
-            --no-warnings \
-            --output text \
-            2>&1 | tee linkcheck-results.txt
-        continue-on-error: true
+      # PRs: internal links only (fast, catches broken cross-references)
+      - name: Check internal links (PR)
+        if: github.event_name == 'pull_request'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --base './site'
+            --cache
+            --max-cache-age 1d
+            --exclude '^https?://'
+            --exclude '^mailto:'
+            ./site
+          fail: false
+          output: ./linkcheck-results.txt
+
+      # Push/schedule/manual: full check including external links
+      - name: Check all links
+        if: github.event_name != 'pull_request'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --base './site'
+            --cache
+            --max-cache-age 7d
+            --exclude '^https://app\.limacharlie\.io'
+            --exclude '^https://community\.limacharlie\.io'
+            --exclude '^mailto:'
+            ./site
+          fail: false
+          output: ./linkcheck-results.txt
 
       - name: Upload link check results
         uses: actions/upload-artifact@v4
@@ -70,35 +98,35 @@ jobs:
           retention-days: 7
 
       - name: Comment on PR with broken links
-        if: github.event_name == 'pull_request' && failure()
+        if: github.event_name == 'pull_request' && hashFiles('linkcheck-results.txt') != ''
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const results = fs.readFileSync('linkcheck-results.txt', 'utf8');
 
-            // Extract broken links
+            // Extract lines with errors
             const brokenLinks = results.split('\n')
-              .filter(line => line.includes('Error:') || line.includes('broken'))
-              .slice(0, 20)  // Limit to first 20
+              .filter(line => line.includes('[ERROR]') || line.includes('Failed'))
+              .slice(0, 20)
               .join('\n');
 
             if (brokenLinks) {
-              const body = `## ⚠️ Broken Links Detected
+              const body = `## Broken Links Detected
 
-              The link checker found some issues:
+            The link checker found some issues:
 
-              \`\`\`
-              ${brokenLinks}
-              \`\`\`
+            \`\`\`
+            ${brokenLinks}
+            \`\`\`
 
-              Please fix these broken links before merging.
+            Please fix these broken links before merging.
 
-              <details>
-              <summary>Full results</summary>
+            <details>
+            <summary>Full results</summary>
 
-              See the uploaded artifact for complete link check results.
-              </details>`;
+            See the uploaded artifact for complete link check results.
+            </details>`;
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Replace Python-based `linkchecker` with Rust-based `lychee` for significantly faster link checking
- Add lychee result caching between runs (7-day TTL for scheduled, 1-day for PRs) so previously-verified external URLs are skipped
- PRs now only check internal links (skips external HTTP calls entirely), while push/schedule/manual runs do full internal+external checks
- Add pip dependency caching to avoid reinstalling packages from scratch
- Remove local HTTP server step — lychee checks the built `./site` directory directly

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` to verify full link check works
- [ ] Open a test PR touching a docs file to verify internal-only check runs
- [ ] Verify lychee cache is populated after first run (check Actions cache)
- [ ] Confirm PR comment still posts when broken links are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)