### PR TITLE
docs: Fix search indexing for maxmind on IP Geolocation page

### DIFF
--- a/docs/5-integrations/api-integrations/ip-geolocation.md
+++ b/docs/5-integrations/api-integrations/ip-geolocation.md
@@ -79,4 +79,4 @@ The format of the metadata returned is documented [here](https://github.com/maxm
 }
 ```
 
-The geolocation data comes from GeoLite2 data created by [MaxMind](http://www.maxmind.com).
+The geolocation data comes from the maxmind GeoLite2 database. For more information, visit [maxmind.com](http://www.maxmind.com).


### PR DESCRIPTION
## Summary
- The MkDocs search separator includes a camelCase splitter (`(?!\b)(?=[A-Z][a-z])`), which tokenized "MaxMind" into "Max" + "Mind"
- Searching for "maxmind" on the docs site returned no results for the IP Geolocation page
- Updated the attribution line to use lowercase "maxmind" so it's indexed as a single token

## Test plan
- [ ] Build docs locally and verify searching "maxmind" returns the IP Geolocation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)