### PR TITLE
docs: Fix ASN example and add ip-asn integration page

### DIFF
--- a/docs/3-detection-response/behavioral-detection.md
+++ b/docs/3-detection-response/behavioral-detection.md
@@ -128,7 +128,7 @@ detect:
   event: USER_LOGIN
   op: lookup
   path: event/SOURCE_IP
-  resource: lcr://api/ip-geo
+  resource: lcr://api/ip-asn
 
 respond:
   - action: report
@@ -140,7 +140,7 @@ respond:
       keys:
         - 'first-asn'
         - '{{ .event.USER_NAME }}'
-        - '{{ .mtd.lcr___api_ip_geo.autonomous_system.number }}'
+        - '{{ .mtd.lcr___api_ip_asn.autonomous_system_number }}'
 ```
 
 **First time a threat-intel-matched hash appears on a host:**
@@ -170,6 +170,7 @@ respond:
 > The `.mtd` key name is derived from the lookup resource name with `/` and `:` replaced by `_`. For example:
 >
 > - `lcr://api/ip-geo` becomes `.mtd.lcr___api_ip_geo`
+> - `lcr://api/ip-asn` becomes `.mtd.lcr___api_ip_asn`
 > - `hive://lookup/my-list` becomes `.mtd.my_list`
 
 ### Combining First-Seen with Other Operators

--- a/docs/5-integrations/api-integrations/index.md
+++ b/docs/5-integrations/api-integrations/index.md
@@ -8,6 +8,7 @@ Connect to external threat intelligence and security services.
 - [EchoTrail](echotrail.md)
 - [GreyNoise](greynoise.md)
 - [Hybrid Analysis](hybrid-analysis.md)
+- [IP ASN](ip-asn.md)
 - [IP Geolocation](ip-geolocation.md)
 - [Pangea](pangea.md)
 - [VirusTotal](virustotal.md)

--- a/docs/5-integrations/api-integrations/ip-asn.md
+++ b/docs/5-integrations/api-integrations/ip-asn.md
@@ -1,0 +1,39 @@
+# IP ASN
+
+> No Subscription Required
+>
+> LimaCharlie provides access to this integration free of charge for all users, so no additional subscription is required.
+
+With the `ip-geo` [add-on](https://app.limacharlie.io/add-ons/detail/ip-geo) subscribed, the `ip-asn` resource can be used as an API-based lookup to resolve IP addresses to their Autonomous System Number (ASN) and organization.
+
+```yaml
+event: USER_LOGIN
+op: lookup
+resource: lcr://api/ip-asn
+path: event/SOURCE_IP
+metadata_rules:
+  op: is
+  value: 13335
+  path: autonomous_system_number
+```
+
+Step-by-step, this rule will do the following:
+
+* Upon seeing a `USER_LOGIN` event, retrieve the `event/SOURCE_IP` value and look it up via the `api/ip-asn` resource
+* Upon receiving a response from `api/ip-asn`, evaluate it using `metadata_rules` to see if the ASN matches 13335 (Cloudflare)
+
+The format of the metadata returned looks like this:
+
+```json
+{
+  "autonomous_system_number": 13335,
+  "autonomous_system_organization": "Cloudflare, Inc."
+}
+```
+
+The ASN data comes from the MaxMind GeoLite2-ASN database. For more information, visit [maxmind.com](http://www.maxmind.com).
+
+## See Also
+
+- [IP Geolocation](ip-geolocation.md) — country, city, and location data
+- [Behavioral Detection — First-Seen with Lookup Metadata](../../3-detection-response/behavioral-detection.md#first-seen-with-lookup-metadata) — using ASN in suppression keys

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -355,6 +355,7 @@ nav:
           - Hybrid Analysis: 5-integrations/api-integrations/hybrid-analysis.md
           - AlphaMountain: 5-integrations/api-integrations/alphamountain.md
           - EchoTrail: 5-integrations/api-integrations/echotrail.md
+          - IP ASN: 5-integrations/api-integrations/ip-asn.md
           - IP Geolocation: 5-integrations/api-integrations/ip-geolocation.md
           - Pangea: 5-integrations/api-integrations/pangea.md
       - Services:


### PR DESCRIPTION
## Summary

- **Fix behavioral-detection.md ASN example**: The example incorrectly used `lcr://api/ip-geo` with a non-existent `autonomous_system.number` nested path. ASN data comes from the separate `lcr://api/ip-asn` resource (backed by GeoLite2-ASN.mmdb) with flat field names `autonomous_system_number` and `autonomous_system_organization`.
- **Add ip-asn doc page**: The `lcr://api/ip-asn` resource was implemented (in `legion_endpoint-go/endpoint/analytics/ipasn.go`) but had no documentation page. Added `docs/5-integrations/api-integrations/ip-asn.md` with usage example and response format.
- **Update nav**: Added IP ASN to the api-integrations index page and mkdocs.yml nav.

## Test plan

- [ ] Verify the ip-asn.md page renders correctly in mkdocs
- [ ] Verify the fixed ASN example in behavioral-detection.md links resolve
- [ ] Confirm `lcr://api/ip-asn` returns `autonomous_system_number` / `autonomous_system_organization` in a live org

🤖 Generated with [Claude Code](https://claude.com/claude-code)