### PR TITLE
ci: upgrade actions/upload-artifact from v4 to v7

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -90,7 +90,7 @@ jobs:
           output: ./linkcheck-results.txt
 
       - name: Upload link check results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: linkcheck-results


### PR DESCRIPTION
## Details

Upgrade `actions/upload-artifact` from `@v4` to `@v7` (latest stable).

### Breaking changes across versions (none affect our usage)

- **v5**: Node 24 support, bumps `@actions/artifact` to v4.0.0
- **v6**: Requires Node 24 and Actions Runner >= v2.327.1
- **v7**: ESM migration (transparent to callers), adds optional `archive` parameter (not used)

## Blast radius / isolation

- **Affected**: CI artifact upload in `link-checker.yml` only
- **NOT affected**: Any documentation content, build, or deployment
## Related PRs

This is part of an org-wide upgrade of `actions/upload-artifact` from v4 to v7 (and `actions/download-artifact` where applicable):

- [devtools#30](https://github.com/refractionPOINT/devtools/pull/30) (also upgrades download-artifact to v8)
- [documentation#126](https://github.com/refractionPOINT/documentation/pull/126)
- [go-essentials#706](https://github.com/refractionPOINT/go-essentials/pull/706)
- [go-ironlegionprotocol#219](https://github.com/refractionPOINT/go-ironlegionprotocol/pull/219)
- [go-lctf#34](https://github.com/refractionPOINT/go-lctf/pull/34)
- [lc-extension#159](https://github.com/refractionPOINT/lc-extension/pull/159)
- [lc_api-go#714](https://github.com/refractionPOINT/lc_api-go/pull/714)
- [posthogbot#54](https://github.com/refractionPOINT/posthogbot/pull/54)
- [replay#382](https://github.com/refractionPOINT/replay/pull/382)

**Skipped** (no write access): lc_sensor