### PR TITLE
ci: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache Python dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache Python dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -51,7 +51,7 @@ jobs:
         run: mkdocs build
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .lycheecache
           key: lychee-cache-${{ github.sha }}


### PR DESCRIPTION
## Details

Upgrade `actions/cache` from `@v4` to `@v5` (latest stable) in `docs.yml` and `link-checker.yml`.

### Breaking changes (none affect our usage)

- **v5**: Node 24 runtime requirement, minimum Actions Runner v2.327.1. No input/output parameter changes.

Our usage (`path`, `key`, `restore-keys`) is unchanged and fully supported.

### Changelog / Diff

- [v4.3.0...v5.0.3 diff](https://github.com/actions/cache/compare/v4.3.0...v5.0.3)
- [v5.0.0 release notes](https://github.com/actions/cache/releases/tag/v5.0.0)

## Blast radius / isolation

- **Affected**: CI cache steps in `docs.yml` (pip cache) and `link-checker.yml` (pip cache, lychee cache)
- **NOT affected**: Any documentation content, build output, or deployment
## Related PRs

Part of an org-wide upgrade of `actions/cache` and `slackapi/slack-github-action`:

- [documentation#127](https://github.com/refractionPOINT/documentation/pull/127) - actions/cache v4->v5
- [lc_api-go#715](https://github.com/refractionPOINT/lc_api-go/pull/715) - actions/cache v4->v5 + slack-github-action v2.1.1->v3.0.1
- [replay#383](https://github.com/refractionPOINT/replay/pull/383) - slack-github-action v2.1.1->v3.0.1

**Skipped** (no write access): lc_sensor (actions/cache v4->v5)