### PR TITLE
Document file adapter poll option and audit all generic adapter docs

### DIFF
--- a/docs/2-sensors-deployment/adapters/types/file.md
+++ b/docs/2-sensors-deployment/adapters/types/file.md
@@ -17,9 +17,45 @@ Adapter type `file`:
 
 * `file_path`: simple file pattern like `./files_*.txt`
 * `no_follow`: if `true`, the file content will be sent, but additions to the file will not be reported
-* `inactivity_threshold`: the number of seconds after which an unmodified file becomes ignored
+* `inactivity_threshold`: the number of seconds after which an unmodified file becomes ignored (default: 86400, i.e. 24 hours)
+* `reactivation_threshold`: the number of seconds within which a previously inactive file must be modified to resume tailing (default: 60)
 * `backfill`: if `true`, a single pass at all the matching files will be made to ingest them, useful for historical ingestion
 * `serialize_files`: if `true`, files will be ingested one at a time, useful for very large number of files that could blow up memory
+* `poll`: if `true`, use polling instead of filesystem event notifications to detect file changes. See [Polling Mode](#polling-mode) below
+* `multi_line_json`: if `true`, the adapter will buffer lines and assemble complete JSON objects spanning multiple lines before sending them
+
+### Polling Mode
+
+By default, the file adapter relies on OS-level filesystem notifications (such as `inotify` on Linux or `kqueue` on BSD/macOS) to detect when new data is written to a file. While efficient, this mechanism can fail to detect changes in certain situations:
+
+* **Log rotation**: When a log management tool (e.g. `newsyslog`, `logrotate`) rotates a file, the original file descriptor may become stale. The filesystem notification watcher may remain attached to the old (now renamed or deleted) file and miss writes to the new file at the same path.
+* **Network and virtual filesystems**: NFS, CIFS/SMB, and some FUSE-based filesystems may not reliably deliver filesystem notifications.
+* **Platform-specific quirks**: Some operating systems or filesystem drivers have incomplete or inconsistent notification support.
+
+Setting `poll: true` switches the adapter to a polling-based approach that periodically checks the file for new content. This is slightly less efficient than event-driven notifications but is more reliable across different platforms and when log rotation is in use.
+
+The adapter also performs its own inode-based rotation detection — if a file's inode changes between poll cycles, the adapter automatically closes the old file handle and opens the new file. This works in conjunction with polling mode to provide reliable collection across rotations.
+
+**When to use `poll: true`:**
+
+* You are running on FreeBSD, OpenBSD, NetBSD, or Solaris
+* Your log files are rotated by tools like `newsyslog` or `logrotate`
+* The adapter stops collecting after a log rotation event
+* Your files reside on a network or virtual filesystem
+
+**Example:**
+
+```yaml
+file:
+  client_options:
+    identity:
+      oid: "your-organization-id"
+      installation_key: "your-installation-key"
+    platform: "text"
+    sensor_seed_key: "freebsd-syslogs"
+  file_path: "/var/log/messages"
+  poll: true
+```
 
 ### CLI Deployment
 

--- a/docs/2-sensors-deployment/log-collection-guide.md
+++ b/docs/2-sensors-deployment/log-collection-guide.md
@@ -11,7 +11,8 @@ The file adapter monitors log files for changes and streams new entries to LimaC
 #### Key Features:
 
 * Glob pattern support (/var/log/*.log)
-* Automatic log rotation handling
+* Automatic log rotation handling (with inode-based detection)
+* Polling mode for reliable collection on BSD, network filesystems, and across log rotations
 * Backfill support for historical data
 * Multi-line JSON parsing
 * Grok pattern parsing for structured log extraction
@@ -269,6 +270,7 @@ file:
 * **Set sensor_seed_key appropriately** - Use descriptive names that identify the log source for easier management.
 * **Monitor file permissions** - Ensure the adapter has read access to log files.
 * **Use backfill carefully** - Only enable for initial historical data collection to avoid duplicates.
+* **Enable polling when needed** - Set `poll: true` if the adapter stops collecting after log rotation, or when running on FreeBSD/BSD systems or network filesystems. See the [File Adapter documentation](adapters/types/file.md#polling-mode) for details.
 * **Implement proper field mapping** - Extract hostname, timestamps, and event types for better searchability.
 * **Pattern testing** - Test Grok patterns against sample log lines before deployment. Common patterns include %{COMMONAPACHELOG}, %{SYSLOGTIMESTAMP}, and %{NGINXACCESS}.
 
@@ -279,6 +281,7 @@ Common issues:
 * **File permission errors**: Check that the adapter process has read access to log files
 * **Parse failures**: Validate Grok patterns against actual log formats
 * **Missing logs**: Verify file paths and glob patterns
+* **Adapter stops collecting after log rotation**: Set `poll: true` in your file adapter configuration. This switches from filesystem event notifications to polling, which reliably detects new data after log rotation tools (e.g. `newsyslog`, `logrotate`) replace the file. This is especially common on FreeBSD and other BSD systems
 * **Connection issues**: Check network connectivity and authentication credentials
 
 Adapters serve as flexible data ingestion mechanisms for both on-premise and cloud environments.


### PR DESCRIPTION
## Summary

### File adapter: poll option and missing parameters
- Add documentation for `poll`, `reactivation_threshold`, `multi_line_json`, and `write_timeout_sec` config options that exist in the [adapter source](https://github.com/refractionPOINT/usp-adapters/blob/master/file/conf.go) but were missing from docs
- Add a **Polling Mode** section explaining when and why to use `poll: true` (log rotation, FreeBSD/BSD, network filesystems)
- Add default values for `inactivity_threshold` (86400s) and `reactivation_threshold` (60s)
- Update the Log Collection Guide with a polling best practice and troubleshooting entry

### Generic adapter audit (cross-referenced against usp-adapters source)
- **Syslog**: add missing `mutual_tls_cert` and `write_timeout_sec` options; fix YAML language hint and invalid `sensor_type` key; fix platform from `linux` to `text` in example
- **JSON**: expand thin page with file adapter option reference, `multi_line_json` example, and YAML config
- **Stdin**: add `write_timeout_sec`, YAML config example, and CLI usage examples
- **WEL**: add `write_timeout_sec`; fix YAML language hint and invalid `sensor_type` key; fix platform to `wel`
- **EVTX**: fix broken link (`index.md#usage` → `usage.md`); add `write_timeout_sec`, YAML config, and CLI example
- **Mac Unified Logging**: add `write_timeout_sec` and NSPredicate link; fix language hints and invalid `sensor_type` key
- **IMAP**: fix broken link; fix `attachent` typo; fix YAML language hint and invalid `sensor_type` key

## Test plan
- [ ] Verify MkDocs builds cleanly
- [ ] Confirm anchor link `file.md#polling-mode` resolves from the log collection guide
- [ ] Spot-check YAML examples parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)