### PR TITLE
Audit and fix all generic adapter documentation

### DIFF
--- a/docs/2-sensors-deployment/adapters/types/evtx.md
+++ b/docs/2-sensors-deployment/adapters/types/evtx.md
@@ -10,8 +10,37 @@ For real-time collection of Windows Event Logs, see the [Windows Event Logs](../
 
 Adapter Type: `evtx`
 
-* `client_options`: common configuration for adapter as defined [here](../index.md#usage).
+* `client_options`: common configuration for adapter as defined [here](../usage.md).
 * `file_path`: path to the `.evtx` file to ingest.
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
+
+### Configuration File Example
+
+```yaml
+evtx:
+  file_path: "C:\\Evidence\\Security.evtx"
+  client_options:
+    identity:
+      oid: "your-organization-id"
+      installation_key: "your-installation-key"
+    platform: "wel"
+    sensor_seed_key: "ir-evidence-01"
+    hostname: "compromised-host"
+```
+
+### CLI Deployment
+
+Adapter downloads can be found [here](../deployment.md).
+
+```bash
+/path/to/lc_adapter evtx \
+  file_path=/path/to/Security.evtx \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.identity.oid=$OID \
+  client_options.platform=wel \
+  client_options.sensor_seed_key=ir-evidence-01 \
+  client_options.hostname=compromised-host
+```
 
 ## API Doc
 

--- a/docs/2-sensors-deployment/adapters/types/file.md
+++ b/docs/2-sensors-deployment/adapters/types/file.md
@@ -23,6 +23,7 @@ Adapter type `file`:
 * `serialize_files`: if `true`, files will be ingested one at a time, useful for very large number of files that could blow up memory
 * `poll`: if `true`, use polling instead of filesystem event notifications to detect file changes. See [Polling Mode](#polling-mode) below
 * `multi_line_json`: if `true`, the adapter will buffer lines and assemble complete JSON objects spanning multiple lines before sending them
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600)
 
 ### Polling Mode
 

--- a/docs/2-sensors-deployment/adapters/types/imap.md
+++ b/docs/2-sensors-deployment/adapters/types/imap.md
@@ -8,24 +8,21 @@ This Adapter allows you to ingest emails as events from an IMAP server.
 
 Adapter Type: `imap`
 
-* `client_options`: common configuration for adapter as defined [here](../index.md#usage).
+* `client_options`: common configuration for adapter as defined [here](../usage.md).
 * `server`: the domain and port of the IMAP server, like `imap.gmail.com:993`.
 * `username`: the user name to log in to IMAP as.
 * `password`: the password for the above user name.
 * `inbox_name`: the name of the inbox to monitor.
 * `is_insecure`: do NOT connect using SSL.
 * `from_zero`: collect all existing emails in the inbox.
-* `include_attachments`: send attachment data to LimaCharlie, used to generate attachent hashes in the cloud.
+* `include_attachments`: send attachment data to LimaCharlie, used to generate attachment hashes in the cloud.
 * `max_body_size`: only send attachments below this many bytes to LimaCharlie.
 * `attachment_ingest_key`: if specified, an [Ingestion Key](../../../7-administration/access/api-keys.md) used to ingest attachment as Artifacts into LimaCharlie.
 * `attachment_retention_days`: the number of days to retain Artifact attachment for.
 
-### Infrastructure as Code Deployment
+### Configuration File Example
 
-```python
-# IMAP Specific Docs: https://docs.limacharlie.io/docs/adapter-types-imap
-
-sensor_type: "imap"
+```yaml
 imap:
   server: "imap.yourmailserver.com:993"
   username: "hive://secret/imap-username"

--- a/docs/2-sensors-deployment/adapters/types/json.md
+++ b/docs/2-sensors-deployment/adapters/types/json.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This Adapter allows you to ingest logs from a file as JSON.
+This Adapter allows you to ingest JSON-formatted logs from a file. It uses the [File](file.md) adapter with `client_options.platform` set to `json`.
+
+When ingesting JSON data, each line of the file is expected to contain a complete JSON object (one object per line). For JSON objects that span multiple lines, use the `multi_line_json: true` option.
 
 Adapter type: `file`
 
@@ -12,10 +14,45 @@ All adapters support the same `client_options`, which you should always specify 
 
 * `client_options.identity.oid`: the LimaCharlie Organization ID (OID) this adapter is used with.
 * `client_options.identity.installation_key`: the LimaCharlie Installation Key this adapter should use to identify with LimaCharlie.
-* `client_options.platform`: the type of data ingested through this adapter, like `text`, `json`, `gcp`, `carbon_black`, etc.
-* `client_options.sensor_seed_key`: an arbitrary name for this adapter which Sensor IDs (SID) are generated from, see below.
+* `client_options.platform`: set to `json` for JSON-formatted logs.
+* `client_options.sensor_seed_key`: an arbitrary name for this adapter which Sensor IDs (SID) are generated from.
 
-## Deployment
+Since this adapter uses the file adapter under the hood, all [File adapter options](file.md) are available, including `no_follow`, `backfill`, `poll`, `multi_line_json`, and others.
+
+### Configuration File Example
+
+```yaml
+file:
+  client_options:
+    identity:
+      oid: "your-organization-id"
+      installation_key: "your-installation-key"
+    platform: "json"
+    sensor_seed_key: "json-logs"
+    hostname: "app-server-01"
+    mapping:
+      event_type_path: "event_type"
+      event_time_path: "timestamp"
+  file_path: "/var/log/app/*.json"
+```
+
+For multi-line JSON (where a single JSON object spans multiple lines):
+
+```yaml
+file:
+  client_options:
+    identity:
+      oid: "your-organization-id"
+      installation_key: "your-installation-key"
+    platform: "json"
+    sensor_seed_key: "json-logs"
+    mapping:
+      event_type_path: "action"
+  file_path: "/var/log/app/events.json"
+  multi_line_json: true
+```
+
+## CLI Deployment
 
 Adapter downloads can be found [here](../deployment.md).
 

--- a/docs/2-sensors-deployment/adapters/types/mac-unified-logging.md
+++ b/docs/2-sensors-deployment/adapters/types/mac-unified-logging.md
@@ -15,7 +15,8 @@ All adapters support the same `client_options`, which you should always specify 
 
 **Optional Arguments:**
 
-* `predicate`: example, `predicate='subsystem=="com.apple.TimeMachine"'`
+* `predicate`: an [NSPredicate](https://developer.apple.com/documentation/foundation/nspredicate) filter string to limit which log entries are collected. Example: `predicate='subsystem=="com.apple.TimeMachine"'`
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
 ## CLI Deployment
 
@@ -31,30 +32,27 @@ client_options.sensor_seed_key=$SENSOR_NAME \
 client_options.hostname=$SENSOR_NAME
 ```
 
-### Infrastructure as Code Deployment
+### Configuration File Example
 
-```python
-# macOS Unified Logging Specific Docs: https://docs.limacharlie.io/docs/adapter-types-macos-unified-logging
-
-sensor_type: "mac_unified_logging"
-  mac_unified_logging:
-    client_options:
-      identity:
-        oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        installation_key: "YOUR_LC_INSTALLATION_KEY_MACOSUL"
-      hostname: "user-macbook-pro"
-      platform: "mac_unified_logging"
-      sensor_seed_key: "macos-unified-logging-sensor"
-    # Optional configuration
-    write_timeout_sec: 600                           # Default: 600 seconds
-    predicate: 'processImagePath endswith "/usr/sbin/sshd" OR subsystem == "com.apple.security"'
+```yaml
+mac_unified_logging:
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_MACOSUL"
+    hostname: "user-macbook-pro"
+    platform: "mac_unified_logging"
+    sensor_seed_key: "macos-unified-logging-sensor"
+  # Optional configuration
+  write_timeout_sec: 600                           # Default: 600 seconds
+  predicate: 'processImagePath endswith "/usr/sbin/sshd" OR subsystem == "com.apple.security"'
 ```
 
 ## Service Creation
 
 If you want this adapter to run as a service, you can run the following script to add a plist file to the endpoint **with your variables replaced**. Please note that this example also has an example predicate, so if you do not wish to use a predicate, remove that line.
 
-```python
+```bash
 sudo -i
 
 curl https://downloads.limacharlie.io/adapter/mac/64 -o /usr/local/bin/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/stdin.md
+++ b/docs/2-sensors-deployment/adapters/types/stdin.md
@@ -2,14 +2,52 @@
 
 ## Overview
 
-This Adapter allows you to ingest logs from the adapter stdin.
+This Adapter allows you to ingest data piped into the adapter's standard input. This is useful for integrating with tools or scripts that output log data to stdout, or for one-off ingestion of data from a command pipeline.
 
 ## Configurations
 
 Adapter Type: `stdin`
 
 * `client_options`: common configuration for adapter as defined [here](../usage.md).
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
-## API Doc
+### Configuration File Example
 
-None
+```yaml
+stdin:
+  client_options:
+    identity:
+      oid: "your-organization-id"
+      installation_key: "your-installation-key"
+    platform: "text"
+    sensor_seed_key: "stdin-collector"
+    hostname: "log-source-01"
+    mapping:
+      parsing_grok:
+        message: "%{SYSLOGTIMESTAMP:date} %{HOSTNAME:host} %{DATA:service}: %{GREEDYDATA:message}"
+      event_type_path: "service"
+```
+
+## CLI Deployment
+
+Adapter downloads can be found [here](../deployment.md).
+
+```bash
+# Pipe journalctl output into the adapter
+journalctl -f -q | /path/to/lc_adapter stdin \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.identity.oid=$OID \
+  client_options.platform=text \
+  client_options.sensor_seed_key=$SENSOR_NAME \
+  client_options.hostname=$SENSOR_NAME
+```
+
+```bash
+# Pipe a log file for one-time ingestion
+cat /var/log/auth.log | /path/to/lc_adapter stdin \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.identity.oid=$OID \
+  client_options.platform=text \
+  client_options.sensor_seed_key=$SENSOR_NAME \
+  client_options.hostname=$SENSOR_NAME
+```

--- a/docs/2-sensors-deployment/adapters/types/syslog.md
+++ b/docs/2-sensors-deployment/adapters/types/syslog.md
@@ -18,9 +18,11 @@ All Adapters have the same common client configuration options, found [here](../
 
 * `port`: port to listen for syslog from.
 * `iface`: the interface name to listen for new connections/packets from, defaults to all.
-* `is_udp`: if `true`, listen over UDP instead of TCP.
+* `is_udp`: if `true`, listen over UDP instead of TCP. Cannot be combined with SSL/TLS.
 * `ssl_cert`: path to a file with the SSL cert to use to receive logs over TCP.
 * `ssl_key`: path to a file with the SSL key to use to receive logs over TCP.
+* `mutual_tls_cert`: path to a CA certificate file for mutual TLS client authentication.
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
 ### Collecting Syslog via Docker
 
@@ -74,33 +76,30 @@ Syslog events are typically ingested as `text`, however often have specific stru
 
 The following example config file can be a starting point. However, you might need to modify the regex to match your specific message.
 
-```python
-# Syslog Specific Docs: https://docs.limacharlie.io/docs/adapter-types-syslog
-
-sensor_type: "syslog"
-  syslog:
-    port: 1514
-    iface: "0.0.0.0"
-    client_options:
-      identity:
-        oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        installation_key: "YOUR_LC_INSTALLATION_KEY_SYSLOG"
-      hostname: "syslog-adapter"
-      platform: "linux"
-      sensor_seed_key: "syslog-collector"
-      mapping:
-        parsing_grok:
-          message: "^<%{INT:pri}>%{SYSLOGTIMESTAMP:timestamp}\\s+%{HOSTNAME:hostname}\\s+%{WORD:tag}(?:\\[%{INT:pid}\\])?:\\s+%{GREEDYDATA:message}"
-        sensor_hostname_path: "hostname"
-        event_type_path: "tag"
-        event_time_path: "timestamp"
-        event_time_timezone: "America/New_York"  # Required if logs use local time (SYSLOGTIMESTAMP has no timezone)
-    # Optional syslog-specific configuration
-    is_udp: false                               # TCP (default) vs UDP
-    write_timeout_sec: 30                       # Write timeout
-    ssl_cert: "/certs/syslog_server.pem"       # Optional SSL cert
-    ssl_key: "/certs/syslog_server.key"        # Optional SSL key
-    mutual_tls_cert: "/certs/client_ca.pem"    # Optional mTLS
+```yaml
+syslog:
+  port: 1514
+  iface: "0.0.0.0"
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_SYSLOG"
+    hostname: "syslog-adapter"
+    platform: "text"
+    sensor_seed_key: "syslog-collector"
+    mapping:
+      parsing_grok:
+        message: "^<%{INT:pri}>%{SYSLOGTIMESTAMP:timestamp}\\s+%{HOSTNAME:hostname}\\s+%{WORD:tag}(?:\\[%{INT:pid}\\])?:\\s+%{GREEDYDATA:message}"
+      sensor_hostname_path: "hostname"
+      event_type_path: "tag"
+      event_time_path: "timestamp"
+      event_time_timezone: "America/New_York"  # Required if logs use local time (SYSLOGTIMESTAMP has no timezone)
+  # Optional syslog-specific configuration
+  is_udp: false                               # TCP (default) vs UDP
+  write_timeout_sec: 30                       # Write timeout
+  ssl_cert: "/certs/syslog_server.pem"       # Optional SSL cert
+  ssl_key: "/certs/syslog_server.key"        # Optional SSL key
+  mutual_tls_cert: "/certs/client_ca.pem"    # Optional mTLS
 ```
 
 #### Step 3: Configure syslog output to send messages to a local listener

--- a/docs/2-sensors-deployment/adapters/types/windows-event-log.md
+++ b/docs/2-sensors-deployment/adapters/types/windows-event-log.md
@@ -10,12 +10,11 @@ Adapter Type: `wel`
 
 * `client_options`: common configuration for adapter as defined [here](../usage.md).
 * `evt_sources`: a comma separated list of elements in the format `SOURCE:FILTER`, where `SOURCE` is an Event Source name like `Application`, `System` or `Security` and `FILTER` is an `XPath` filter value as described in the documentation linked below.
+* `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
-### Infrastructure as Code Deployment
+### Configuration File Example
 
-```python
-# Windows Event Log (WEL) Specific Docs: https://docs.limacharlie.io/docs/adapter-types-windows-event-log
-
+```yaml
 # Basic Event Sources:
 # evt_sources: "Security,System,Application"
 
@@ -25,16 +24,16 @@ Adapter Type: `wel`
 # File-Based Sources:
 # evt_sources: "C:\\Windows\\System32\\winevt\\Logs\\Security.evtx:'*[System[(EventID=4624)]]'"
 
-  wel:
-    evt_sources: "Security:'*[System[(Level=1 or Level=2 or Level=3)]]',System,Application"
-    client_options:
-      identity:
-        oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        installation_key: "YOUR_LC_INSTALLATION_KEY_WEL"
-      hostname: "prod-dc01.example.local"
-      platform: "windows"
-      sensor_seed_key: "wel-collector"
-    write_timeout_sec: 30
+wel:
+  evt_sources: "Security:'*[System[(Level=1 or Level=2 or Level=3)]]',System,Application"
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_WEL"
+    hostname: "prod-dc01.example.local"
+    platform: "wel"
+    sensor_seed_key: "wel-collector"
+  write_timeout_sec: 30
 ```
 
 ### XPath Filter Examples


### PR DESCRIPTION
## Summary

Cross-referenced each generic adapter's source code in [usp-adapters](https://github.com/refractionPOINT/usp-adapters) against the documentation to fill gaps and fix issues:

- **Syslog**: add missing `mutual_tls_cert` and `write_timeout_sec` options; fix YAML language hint; remove invalid `sensor_type` key; fix platform from `linux` to `text` in example
- **JSON**: expand thin page with file adapter option reference, `multi_line_json` example, and YAML config
- **Stdin**: add `write_timeout_sec`, YAML config example, and CLI usage examples with pipe patterns
- **WEL**: add `write_timeout_sec`; fix YAML language hint; remove invalid `sensor_type` key; fix platform to `wel`
- **EVTX**: fix broken link (`index.md#usage` → `usage.md`); add `write_timeout_sec`, YAML config, and CLI example
- **Mac Unified Logging**: add `write_timeout_sec` and NSPredicate link; fix YAML and bash language hints; remove invalid `sensor_type` key
- **IMAP**: fix broken link; fix `attachent` typo; fix YAML language hint; remove invalid `sensor_type` key
- **File**: add `write_timeout_sec`

## Test plan
- [ ] Verify MkDocs builds cleanly
- [ ] Spot-check YAML examples parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)