### PR TITLE
docs: Fix incorrect Insight unsubscribe behavior description

### DIFF
--- a/docs/8-reference/faq/account-management.md
+++ b/docs/8-reference/faq/account-management.md
@@ -12,7 +12,7 @@ Please navigate to the bottom of the Billing & Usage section of the organization
 
 ## Is There a Way to Wipe an Organization?
 
-You can wipe the data retention by disabling the `Insight` add on on the marketplace and re-enabling it again. Please note that unsubscribing from `Insight` will delete all telemetry stored for a selected organization, and this action cannot be undone.
+You can wipe the data retention by deleting the `Insight` add-on (using `DELETE /insight/{oid}`) and re-enabling it again. Please note that disabling `Insight` (unsubscribing from the marketplace) will only pause data collection but will **not** delete historical telemetry. To permanently delete all stored telemetry for a selected organization, you must explicitly issue a delete operation, and this action cannot be undone.
 
 To wipe the configuration, you can use Templates / Infrastructure as Code functionality with the `is_force` flag to remove everything. To learn more about the infrastructure as code, visit [Infrastructure Extension](../../5-integrations/extensions/limacharlie/infrastructure.md).
 


### PR DESCRIPTION
## Summary
- The FAQ incorrectly stated that unsubscribing from Insight deletes all stored telemetry
- In reality, disabling/unsubscribing only pauses data collection (removes outputs) but does **not** delete historical data
- Updated to clarify that an explicit delete operation (`DELETE /insight/{oid}`) is required to permanently wipe telemetry

**Context:** A customer reported still seeing old data after disabling Insight. Investigation confirmed this is the actual backend behavior — `disable_insight` only removes outputs while `delete_insight` performs the full data wipe.

## Test plan
- [ ] Review updated FAQ text for accuracy and clarity


🤖 Generated with [Claude Code](https://claude.com/claude-code)