### PR TITLE
ci: upgrade configure-pages, upload-pages-artifact, github-script

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,10 +34,10 @@ jobs:
         run: mkdocs build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./site
 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Comment on PR with broken links
         if: github.event_name == 'pull_request' && hashFiles('linkcheck-results.txt') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Details

Upgrade GitHub Actions in documentation CI workflows to resolve Node.js 20 deprecation warnings and update to latest versions:

| Action | Previous | Updated | Changelog |
|---|---|---|---|
| actions/checkout | v4 | v6 | [v4...v6 diff](https://github.com/actions/checkout/compare/v4...v6.0.2) |
| actions/configure-pages | v4 | v5 | [v4...v5 diff](https://github.com/actions/configure-pages/compare/v4...v5.0.0) |
| actions/upload-pages-artifact | v3 | v4 | [v3...v4 diff](https://github.com/actions/upload-pages-artifact/compare/v3...v4.0.0) |
| actions/github-script | v7 | v8 | [v7...v8 diff](https://github.com/actions/github-script/compare/v7...v8) |
| actions/upload-artifact | v4 | v7 | [v4...v7 diff](https://github.com/actions/upload-artifact/compare/v4...v7.0.0) |

### Breaking changes assessment

- **checkout v6**: Node 24 runtime only. No input changes.
- **configure-pages v5**: Drops Next.js < 13.3.0 support. N/A - we use mkdocs.
- **upload-pages-artifact v4**: Dotfiles excluded from artifact. N/A - no dotfiles in `./site`.
- **github-script v8**: Node 24 runtime. `require('fs')` still works.
- **upload-artifact v7**: Node 24, ESM migration. Standard params unchanged.

### Remaining Node.js 20 warning

`actions/deploy-pages@v4` has no Node 24 version yet (latest is v4.0.5). GitHub will force Node 24 starting June 2, 2026. We'll upgrade when a new version is released.

## Blast radius / isolation

- **Affected**: CI workflows `deploy-pages.yml`, `docs.yml`, and `link-checker.yml`
- **NOT affected**: Documentation content, build process

## Related PRs

Org-wide GHA upgrade batch.