### PR TITLE
ci: upgrade lychee-action, markdownlint, checkout, setup-python

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -61,7 +61,7 @@ jobs:
       # PRs: internal links only (fast, catches broken cross-references)
       - name: Check internal links (PR)
         if: github.event_name == 'pull_request'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
           args: >-
             --base './site'
@@ -76,7 +76,7 @@ jobs:
       # Push/schedule/manual: full check including external links
       - name: Check all links
         if: github.event_name != 'pull_request'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
           args: >-
             --base './site'
@@ -141,10 +141,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check markdown formatting
-        uses: DavidAnson/markdownlint-cli2-action@v16
+        uses: DavidAnson/markdownlint-cli2-action@v22
         with:
           globs: 'docs/**/*.md'
           config: |


### PR DESCRIPTION
## Details

Upgrade remaining GitHub Actions to address Node.js 20 deprecation and security advisories:

| Action | Previous | Updated | Changelog |
|---|---|---|---|
| lycheeverse/lychee-action | v2 (unpinned) | v2.8.0 SHA (`8646ba30...`) | [v2...v2.8.0 diff](https://github.com/lycheeverse/lychee-action/compare/v2...v2.8.0) |
| DavidAnson/markdownlint-cli2-action | v16 | v22 | [v16...v22 diff](https://github.com/DavidAnson/markdownlint-cli2-action/compare/v16...v22.0.0) |
| actions/checkout | v4 | v6 | [v4...v6 diff](https://github.com/actions/checkout/compare/v4...v6.0.2) |
| actions/setup-python | v5 | v6 | [v5...v6 diff](https://github.com/actions/setup-python/compare/v5...v6.2.0) |

### Security notes

- **lychee-action**: Addresses security advisory for arbitrary code injection. Now SHA-pinned.
- **markdownlint-cli2-action**: Was 6 major versions behind (v16 vs v22).

### Remaining: `actions/deploy-pages@v4` has no Node 24 version yet.

## Blast radius / isolation

- **Affected**: CI workflows `deploy-pages.yml`, `docs.yml`, `link-checker.yml`
- **NOT affected**: Documentation content or deployment targets