### PR TITLE
Fix SDK Overview and CLI pages for accuracy

### DIFF
--- a/docs/6-developer-guide/cli.md
+++ b/docs/6-developer-guide/cli.md
@@ -1,16 +1,24 @@
-# LimaCharlie CLI
+# CLI Extension
 
-LimaCharlie CLI Extension allows you to issue [LimaCharlie CLI commands](sdk-overview.md) using extension requests.
+The `limacharlie-cli` extension allows you to run [LimaCharlie CLI commands](sdk-overview.md#command-line-interface) from within D&R rule response actions. This is useful for automating infrastructure changes (syncing configs, managing rules, etc.) in response to detections.
 
-Repo - <https://github.com/refractionPOINT/python-limacharlie>
+!!! note
+    This page documents the `limacharlie-cli` **extension** for use in D&R rules. For the CLI tool itself, see the [Command Line Interface](sdk-overview.md#command-line-interface) section of the SDK Overview.
 
-You may use a rule to trigger a LimaCharlie CLI event. For example the following rule response actions:
+## Usage
+
+Trigger a CLI command as a D&R rule response action using `extension request`:
 
 ```yaml
 - action: extension request
   extension action: run
   extension name: limacharlie-cli
   extension request:
-    command_line: '{{ "limacharlie configs push --dry-run --oid" }}'
+    command_line: '{{ "limacharlie sync push --dry-run --oid YOUR_OID --config /path/to/config.yaml" }}'
     credentials: '{{ "hive://secret/secret-name" }}'
 ```
+
+Field descriptions:
+
+* `command_line`: the full CLI command to execute.
+* `credentials`: a reference to stored credentials in the [secrets manager](../7-administration/access/secrets.md), used to authenticate the CLI command.

--- a/docs/6-developer-guide/sdk-overview.md
+++ b/docs/6-developer-guide/sdk-overview.md
@@ -1,4 +1,18 @@
-#### Authentication
+# SDKs & CLI
+
+LimaCharlie provides a [Go SDK](#go-sdk), [Python SDK](#python-sdk), and a [command line interface](#command-line-interface) for interacting with the platform programmatically.
+
+## Go SDK
+
+* Repo — <https://github.com/refractionPOINT/go-limacharlie>
+
+### Installation
+
+```bash
+go get github.com/refractionPOINT/go-limacharlie/limacharlie
+```
+
+### Authentication
 
 You can use Client Options to declare your client/org, or you can use environment variables.
 
@@ -8,7 +22,7 @@ You can use Client Options to declare your client/org, or you can use environmen
 * `LC_API_KEY`: your LC API KEY
 * `LC_UID`: optional, your user ID
 
-```python
+```go
 package main
 
 import (
@@ -30,7 +44,7 @@ func main() {
 
 **Using Client Options:**
 
-```python
+```go
 package main
 
 import (
@@ -40,7 +54,7 @@ import (
 )
 
 func main() {
-    clientOptions = limacharlie.ClientOptions{
+    clientOptions := limacharlie.ClientOptions{
         OID: "MY_OID",
         APIKey: "MY_API_KEY",
         UID: "MY_UID",
@@ -54,7 +68,7 @@ func main() {
 
 #### Examples
 
-```python
+```go
 package main
 
 import (
@@ -140,7 +154,7 @@ func main() {
     }
 
     // Create installation key
-    key_request, _ := org.AddInstallationKey(InstallationKey{
+    key_request, _ := org.AddInstallationKey(limacharlie.InstallationKey{
 		Description: "my-test-key",
 		Tags:        []string{"tag", "another-tag"},
 	})
@@ -148,11 +162,11 @@ func main() {
 }
 ```
 
-## Python
+## Python SDK
 
-The Python library is a simple abstraction to the [LimaCharlie.io REST API](https://api.limacharlie.io/static/swagger/). The REST API currently supports many more functions. If it's missing a function available in the REST API that you would like to use, let us know at support@limacharlie.io.
+The Python library is a wrapper for the [LimaCharlie.io REST API](https://api.limacharlie.io/static/swagger/). If it's missing a function available in the REST API that you would like to use, let us know at support@limacharlie.io.
 
-* Repo - <https://github.com/refractionpoint/python-limacharlie>
+* Repo — <https://github.com/refractionPOINT/python-limacharlie>
 
 ### Getting Started
 
@@ -306,7 +320,7 @@ The `Artifacts` class is used to upload, list, and download artifacts. Import fr
 
 #### Payloads
 
-The `Payloads` can be used to manage various executable [payloads](../2-sensors-deployment/endpoint-agent/payloads.md) accessible to sensors.
+The `Payloads` can be used to manage various executable [payloads](../2-sensors-deployment/endpoint-agent/payloads.md) accessible to sensors. Import from `limacharlie.sdk.payloads`.
 
 #### Configs
 
@@ -387,12 +401,12 @@ Used to perform Organization-wide checks for specific indicators of compromise. 
 limacharlie spotcheck --help
 ```
 
-#### Search
+#### IOC Search
 
-Shortcut utility to perform IOC searches across all locally configured organizations.
+Search for Indicators of Compromise (domains, IPs, file hashes, etc.) across the Insight data lake.
 
 ```bash
-limacharlie search --help
+limacharlie ioc --help
 ```
 
 #### Extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,8 +372,8 @@ nav:
           - Overview: 6-developer-guide/sdks/index.md
           - Python SDK: 6-developer-guide/sdks/python-sdk.md
           - Go SDK: 6-developer-guide/sdks/go-sdk.md
-      - SDK Overview: 6-developer-guide/sdk-overview.md
-      - CLI: 6-developer-guide/cli.md
+      - SDKs & CLI: 6-developer-guide/sdk-overview.md
+      - CLI Extension: 6-developer-guide/cli.md
       - Connecting AI Assistants: 6-developer-guide/mcp-server.md
       - Building Extensions:
           - Getting Started: 6-developer-guide/extensions/building-extensions.md


### PR DESCRIPTION
## Summary

- **sdk-overview.md**: Added H1 heading and proper page structure (Go SDK / Python SDK / CLI sections). Fixed all Go code blocks that were incorrectly using `python` language hint. Added Go SDK repo link and `go get` installation instructions. Fixed Go syntax bug (`=` → `:=`) and missing `limacharlie.` package prefix on `InstallationKey`. Corrected duplicate "Search" CLI section — the second instance was about IOC search, not LCQL, so updated to reference `limacharlie ioc`. Standardized section heading for Python SDK.
- **cli.md**: Renamed from "LimaCharlie CLI" to "CLI Extension" to clearly distinguish this page (about the `limacharlie-cli` extension for D&R rules) from the actual CLI tool. Added explanatory note, usage context, and field descriptions. Fixed incomplete example command.
- **mkdocs.yml**: Updated nav titles to match new page headings.

All SDK examples verified against Go SDK source (`go-limacharlie` repo) and Python SDK v5.0.9 (`limacharlie.client.Client`, `limacharlie.sdk.*` import paths). CLI commands verified against `limacharlie --help` (v5.0.9).

## Test plan

- [ ] Verify Go code blocks render with correct syntax highlighting
- [ ] Verify internal anchor links work (Go SDK, Python SDK, CLI sections)
- [ ] Verify CLI Extension page note box renders correctly
- [ ] Confirm nav titles display correctly in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)