### PR TITLE
Restructure Developer Guide: remove SDK/CLI redundancy

### DIFF
--- a/docs/6-developer-guide/cli.md
+++ b/docs/6-developer-guide/cli.md
@@ -1,9 +1,9 @@
 # CLI Extension
 
-The `limacharlie-cli` extension allows you to run [LimaCharlie CLI commands](sdk-overview.md#command-line-interface) from within D&R rule response actions. This is useful for automating infrastructure changes (syncing configs, managing rules, etc.) in response to detections.
+The `limacharlie-cli` extension allows you to run [LimaCharlie CLI commands](sdk-overview.md) from within D&R rule response actions. This is useful for automating infrastructure changes (syncing configs, managing rules, etc.) in response to detections.
 
 !!! note
-    This page documents the `limacharlie-cli` **extension** for use in D&R rules. For the CLI tool itself, see the [Command Line Interface](sdk-overview.md#command-line-interface) section of the SDK Overview.
+    This page documents the `limacharlie-cli` **extension** for use in D&R rules. For the CLI tool itself, see the [Command Line Interface](sdk-overview.md) page.
 
 ## Usage
 

--- a/docs/6-developer-guide/index.md
+++ b/docs/6-developer-guide/index.md
@@ -10,6 +10,11 @@ Programmatic access to LimaCharlie:
 - [Go SDK](sdks/go-sdk.md) - Native Go implementation
 - [SDK Overview](sdks/index.md) - Getting started with SDKs
 
+## Command Line Interface
+
+- [CLI](sdk-overview.md) - Command line tool for managing LimaCharlie
+- [CLI Extension](cli.md) - Run CLI commands from D&R rule response actions
+
 ## AI Assistants
 
 Connect AI assistants to LimaCharlie via the Claude Code Plugin or MCP:
@@ -29,17 +34,7 @@ Create custom extensions for LimaCharlie:
 Manage LimaCharlie configuration as code:
 
 - [Git Sync Extension](../5-integrations/extensions/limacharlie/git-sync.md)
-- [Pipeline](pipeline.md)
 
 ## Developer Program
 
 - [Developer Grant Program](grant-program.md)
-
----
-
-## See Also
-
-- [Python SDK](sdks/python-sdk.md)
-- [Go SDK](sdks/go-sdk.md)
-- [Building Extensions](extensions/building-extensions.md)
-- [API Keys](../7-administration/access/api-keys.md)

--- a/docs/6-developer-guide/sdk-overview.md
+++ b/docs/6-developer-guide/sdk-overview.md
@@ -1,205 +1,20 @@
-# SDKs & CLI
+# Command Line Interface
 
-LimaCharlie provides a [Go SDK](#go-sdk), [Python SDK](#python-sdk), and a [command line interface](#command-line-interface) for interacting with the platform programmatically.
-
-## Go SDK
-
-* Repo — <https://github.com/refractionPOINT/go-limacharlie>
-
-### Installation
-
-```bash
-go get github.com/refractionPOINT/go-limacharlie/limacharlie
-```
-
-### Authentication
-
-You can use Client Options to declare your client/org, or you can use environment variables.
-
-**Using Environment Variables:**
-
-* `LC_OID`: Organization ID
-* `LC_API_KEY`: your LC API KEY
-* `LC_UID`: optional, your user ID
-
-```go
-package main
-
-import (
-	"fmt"
-
-	"github.com/refractionPOINT/go-limacharlie/limacharlie"
-)
-
-func main() {
-    client, err := limacharlie.NewClientFromLoader(limacharlie.ClientOptions{}, nil, &limacharlie.EnvironmentClientOptionLoader{})
-    if err != nil {
-        fmt.Println(err)
-    }
-
-    org, _ := limacharlie.NewOrganization(client)
-    fmt.Printf("Hello, this is %s", org.GetOID())
-}
-```
-
-**Using Client Options:**
-
-```go
-package main
-
-import (
-	"fmt"
-
-	"github.com/refractionPOINT/go-limacharlie/limacharlie"
-)
-
-func main() {
-    clientOptions := limacharlie.ClientOptions{
-        OID: "MY_OID",
-        APIKey: "MY_API_KEY",
-        UID: "MY_UID",
-    }
-    org, _ := limacharlie.NewOrganizationFromClientOptions(clientOptions, nil)
-    fmt.Printf("Hello, this is %s", org.GetOID())
-}
-```
-
-### SDK
-
-#### Examples
-
-```go
-package main
-
-import (
-	"fmt"
-
-	"github.com/refractionPOINT/go-limacharlie/limacharlie"
-)
-
-func main() {
-    client, err := limacharlie.NewClientFromLoader(limacharlie.ClientOptions{}, nil, &limacharlie.EnvironmentClientOptionLoader{})
-    if err != nil {
-        fmt.Println(err)
-    }
-
-    org, _ := limacharlie.NewOrganization(client)
-
-    // List all sensors
-    sensors, err := org.ListSensors()
-    if err != nil {
-        fmt.Println(err)
-    }
-    for sid, sensor := range sensors {
-        fmt.Printf("%s - %s", sid, sensor.Hostname)
-    }
-
-    // List D&R rules from Hive
-    hiveClient := limacharlie.NewHiveClient(org)
-    rules, _ := hiveClient.List(limacharlie.HiveArgs{
-        HiveName:     "dr-general",
-        PartitionKey:  org.GetOID(),
-    })
-    for rule_name, _ := range rules {
-        fmt.Println(rule_name)
-    }
-
-    // Add D&R rule to Hive
-    enabled := true
-    case_sensitive := false
-    if _, err := hiveClient.Add(limacharlie.HiveArgs{
-        HiveName:     "dr-general",
-        PartitionKey: org.GetOID(),
-        Key:          "test_rule_name",
-        Enabled:      &enabled,
-        Data: limacharlie.Dict{
-            "detect": limacharlie.Dict{
-                "event":            "NEW_PROCESS",
-                "op":               "is",
-                "path":             "event/COMMAND_LINE",
-                "value":            "whoami",
-                "case sensitive":   &case_sensitive,
-            },
-            "respond": []limacharlie.Dict{{
-                "action": "report",
-                "name":   "whoami detection",
-            }},
-        },
-    }); err != nil {
-        fmt.Println(err)
-    }
-
-    // List extensions
-    extensions, _ := org.Extensions()
-    for _, extension_name := range extensions {
-        fmt.Println(extension_name)
-    }
-
-    // Subscribe to extension
-    subscription_request := org.SubscribeToExtension("binlib")
-    if subscription_request != nil {
-        fmt.Println(subscription_request)
-    }
-
-    // List payloads
-    payloads, _ := org.Payloads()
-    for payload, _ := range payloads {
-        fmt.Println(payload)
-    }
-
-    // List installation keys
-    installation_keys, _ := org.InstallationKeys()
-    for _, key := range installation_keys {
-        fmt.Println(key.Description)
-    }
-
-    // Create installation key
-    key_request, _ := org.AddInstallationKey(limacharlie.InstallationKey{
-		Description: "my-test-key",
-		Tags:        []string{"tag", "another-tag"},
-	})
-
-}
-```
-
-## Python SDK
-
-The Python library is a wrapper for the [LimaCharlie.io REST API](https://api.limacharlie.io/static/swagger/). If it's missing a function available in the REST API that you would like to use, let us know at support@limacharlie.io.
-
-* Repo — <https://github.com/refractionPOINT/python-limacharlie>
-
-### Getting Started
-
-#### Installing
-
-##### PyPi (pip)
-
-The library and the CLI is available as a Python package on PyPi (<https://pypi.org/project/limacharlie/>). It can be installed using pip as shown below.
+The LimaCharlie CLI is installed as part of the [Python SDK](sdks/python-sdk.md) package.
 
 ```bash
 pip install limacharlie
 ```
 
-##### Docker Image
+The CLI uses a `limacharlie <noun> <verb>` command pattern. Every command supports `--help` for detailed usage and `--ai-help` for AI-optimized explanations. Run `limacharlie --help` to see all available commands.
 
-In addition to the PyPi distribution we also offer a pre-built Docker image on DockerHub (<https://hub.docker.com/r/refractionpoint/limacharlie>).
+## Authentication
 
-```bash
-docker run refractionpoint/limacharlie:latest whoami
-
-# Using a specific version (Docker image tag matches the library version)
-docker run refractionpoint/limacharlie:5.0.0 whoami
-
-# If you already have a credential file locally, you can mount it inside the Docker container
-docker run -v ${HOME}/.limacharlie:/root/.limacharlie:ro refractionpoint/limacharlie:latest whoami
-```
-
-#### Credentials
-
-Authenticating to use the SDK / CLI can be done in a few ways.
+Authenticating the CLI can be done in a few ways.
 
 **Option 1 - Logging In**
- The simplest is to login to an Organization using an [API key](../7-administration/access/api-keys.md).
+
+The simplest is to login to an Organization using an [API key](../7-administration/access/api-keys.md).
 
 Use `limacharlie auth login` to store credentials locally. You will need an `OID` (Organization ID) and an API key, and (optionally) a `UID` (User ID), all of which you can get from the Access Management --> REST API section of the web interface.
 
@@ -217,125 +32,29 @@ Setting a given organization in the current shell session can be done like this:
 limacharlie auth use-org my-dev-org
 ```
 
-You can also specify a `UID` (User ID) during login to use a *user* API key representing
- the total set of permissions that user has (see User Profile in the web interface).
+You can also specify a `UID` (User ID) during login to use a *user* API key representing the total set of permissions that user has (see User Profile in the web interface).
 
 **Option 2 - Environment Variables**
- You can use the `LC_OID` and `LC_API_KEY` and `LC_UID` environment variables to replace the values used logging in. The environment variables will be used if no other credentials are specified.
 
-### SDK
+You can use the `LC_OID` and `LC_API_KEY` and `LC_UID` environment variables to replace the values used logging in. The environment variables will be used if no other credentials are specified.
 
-The SDK is organized around two main objects: `Client` (handles authentication and HTTP) and `Organization` (provides access to all org-scoped operations).
+## Docker Image
 
-You can authenticate the `Client` using an `oid` and `api_key` directly, or use environment variables and config file credentials. If no credentials are provided, the `Client` resolves them from the environment (as configured via `limacharlie auth login`).
+The CLI is also available as a Docker image on DockerHub (<https://hub.docker.com/r/refractionpoint/limacharlie>).
 
-#### Importing
+```bash
+docker run refractionpoint/limacharlie:latest whoami
 
-```python
-from limacharlie.client import Client
-from limacharlie.sdk.organization import Organization
-from limacharlie.sdk.sensor import Sensor
+# Using a specific version (Docker image tag matches the library version)
+docker run refractionpoint/limacharlie:5.0.0 whoami
 
-YARA_SIG = 'https://raw.githubusercontent.com/Yara-Rules/rules/master/Malicious_Documents/Maldoc_PDF.yar'
-
-# Create an instance of the SDK.
-client = Client()
-org = Organization(client)
-
-# Get a list of all the sensors in the current Organization.
-all_sensors = list(org.list_sensors())
-
-# Select the first sensor.
-sensor = Sensor(org, all_sensors[0]["sid"])
-
-# Tag this sensor with a tag for 10 minutes.
-sensor.add_tag('suspicious', ttl=60 * 10)
-
-# Send a task to the sensor (unidirectionally, not expecting a response).
-sensor.task('os_processes')
-
-# Send a yara scan to that sensor for processes "evil.exe".
-sensor.task('yara_scan -e *evil.exe ' + YARA_SIG)
+# If you already have a credential file locally, you can mount it inside the Docker container
+docker run -v ${HOME}/.limacharlie:/root/.limacharlie:ro refractionpoint/limacharlie:latest whoami
 ```
 
-### Components
+## Commands
 
-#### Client
-
-The `Client` handles HTTP communication with the LimaCharlie API, including JWT generation/refresh, retry with exponential backoff, and rate limit awareness. Import from `limacharlie.client`.
-
-#### Organization
-
-The `Organization` is the main entry point for all org-scoped operations: listing sensors, managing rules, accessing hives, outputs, users, extensions, and more. Import from `limacharlie.sdk.organization`.
-
-#### Sensor
-
-A `Sensor` is created with `Sensor(org, sid)`.
-
-It supports `task`, `hostname`, `add_tag`, `remove_tag`, `get_tags`, `isolate`, `rejoin`, and more. This is the main way to interact with a specific sensor. Import from `limacharlie.sdk.sensor`.
-
-The `task` function sends a task to the sensor unidirectionally, meaning it does not
- receive the response from the sensor (if any).
-
-#### Firehose
-
-The `Firehose` is a TLS push-mode streaming listener. Under the hood it creates an Output on limacharlie.io pointing to itself and removes it on shutdown. Import from `limacharlie.sdk.firehose`.
-
-#### Spout
-
-Much like the `Firehose`, the `Spout` receives data from LimaCharlie.io, the difference
- is that the `Spout` does not require opening a local port to listen actively on. Instead
- it leverages `stream.limacharlie.io` to receive the data stream over HTTPS. Import from `limacharlie.sdk.spout`.
-
-#### Hive
-
-The `Hive` provides access to LimaCharlie's key-value configuration store. Used for D&R rules, secrets, playbooks, and more. Import from `limacharlie.sdk.hive`.
-
-#### Extensions
-
-The `Extensions` class manages extension subscriptions and requests.
-
-```python
-from limacharlie.client import Client
-from limacharlie.sdk.organization import Organization
-from limacharlie.sdk.extensions import Extensions
-
-client = Client()
-org = Organization(client)
-ext = Extensions(org)
-ext.subscribe('binlib')
-```
-
-#### Search
-
-The `Search` object allows you to execute LCQL queries, validate queries, estimate costs, and manage saved queries. Import from `limacharlie.sdk.search`.
-
-#### Replay
-
-The `Replay` object allows you to interact with [Replay](../5-integrations/services/replay.md) jobs managed by LimaCharlie. These allow you to re-run D&R Rules on historical data. Import from `limacharlie.sdk.replay`.
-
-#### Artifacts
-
-The `Artifacts` class is used to upload, list, and download artifacts. Import from `limacharlie.sdk.artifacts`.
-
-#### Payloads
-
-The `Payloads` can be used to manage various executable [payloads](../2-sensors-deployment/endpoint-agent/payloads.md) accessible to sensors. Import from `limacharlie.sdk.payloads`.
-
-#### Configs
-
-The `Configs` is used to retrieve an organization's configuration as a config file, or apply
- an existing config file to an organization. This is the concept of Infrastructure as Code. Import from `limacharlie.sdk.configs`.
-
-### Examples:
-
-* [Sample Configs](https://github.com/refractionPOINT/python-limacharlie/tree/master/limacharlie/sample_configs)
-
-### Command Line Interface
-
-The CLI uses a `limacharlie <noun> <verb>` command pattern. Every command supports `--help` for detailed usage and `--ai-help` for AI-optimized explanations.
-
-#### Search / Query
+### Search / Query
 
 [LimaCharlie Query Language (LCQL)](../4-data-queries/lcql-examples.md) provides a flexible, intuitive and interactive way to explore your data in LimaCharlie.
 
@@ -343,7 +62,7 @@ The CLI uses a `limacharlie <noun> <verb>` command pattern. Every command suppor
 limacharlie search --help
 ```
 
-#### ARLs
+### ARLs
 
 [Authenticated Resource Locators (ARLs)](../8-reference/authentication-resource-locator.md) describe a way to specify access to a remote resource, supporting many methods, including authentication data, and all that within a single string.
 
@@ -355,7 +74,7 @@ Testing an ARL before applying it somewhere can be helpful to shake out access o
 limacharlie arl get -a [github,Yara-Rules/rules/email]
 ```
 
-#### Streaming
+### Streaming
 
 Stream events, detections, or audit logs in real-time. Uses pull-mode spouts (HTTPS) or push-mode firehose listeners (TLS).
 
@@ -371,7 +90,7 @@ limacharlie stream detections
 limacharlie stream audit
 ```
 
-#### Sync (Infrastructure as Code)
+### Sync (Infrastructure as Code)
 
 The `pull` command will fetch the organization configuration and write it to a local YAML file.
 
@@ -389,11 +108,9 @@ All these capabilities are also supported directly by the `Configs` SDK class (`
 
 The Sync functionality supports all common useful configurations. Use the hive flags (`--hive-dr-general`, `--hive-fp`, `--outputs`, etc.) to control which resource types are synced. See `limacharlie sync --help` for all options.
 
-To understand better the config format, do a `pull` from your organization. Notice the use of the `include`
- statement. Using this statement you can combine multiple config files together, making
- it ideal for the management of complex rule sets and their versioning.
+To understand better the config format, do a `pull` from your organization. Notice the use of the `include` statement. Using this statement you can combine multiple config files together, making it ideal for the management of complex rule sets and their versioning.
 
-#### Spot Checks
+### Spot Checks
 
 Used to perform Organization-wide checks for specific indicators of compromise. Supports many types of IoCs like file names, directories, registry keys, file hashes and YARA signatures.
 
@@ -401,7 +118,7 @@ Used to perform Organization-wide checks for specific indicators of compromise. 
 limacharlie spotcheck --help
 ```
 
-#### IOC Search
+### IOC Search
 
 Search for Indicators of Compromise (domains, IPs, file hashes, etc.) across the Insight data lake.
 
@@ -409,39 +126,39 @@ Search for Indicators of Compromise (domains, IPs, file hashes, etc.) across the
 limacharlie ioc --help
 ```
 
-#### Extensions
+### Extensions
 
-Shortcut utility to manage extensions.
+Manage extension subscriptions.
 
 ```bash
 limacharlie extension --help
 ```
 
-#### Artifacts
+### Artifacts
 
-Shortcut utility to upload, list, and download Artifacts within LimaCharlie.
+Upload, list, and download Artifacts within LimaCharlie.
 
 ```bash
 limacharlie artifact --help
 ```
 
-#### Replay
+### Replay
 
-Shortcut utility to perform [Replay](../5-integrations/services/replay.md) jobs from the CLI.
+Perform [Replay](../5-integrations/services/replay.md) jobs from the CLI.
 
 ```bash
 limacharlie replay --help
 ```
 
-#### Detection & Response
+### Detection & Response
 
-Shortcut utility to manage Detection and Response rules over the CLI.
+Manage Detection and Response rules over the CLI.
 
 ```bash
 limacharlie dr --help
 ```
 
-#### Events & Detections
+### Events & Detections
 
 Print out to STDOUT events or detections matching the parameter.
 
@@ -450,7 +167,7 @@ limacharlie event --help
 limacharlie detection --help
 ```
 
-#### List Sensors
+### List Sensors
 
 Print out all basic sensor information for all sensors matching the [selector](../8-reference/sensor-selector-expressions.md).
 
@@ -458,7 +175,7 @@ Print out all basic sensor information for all sensors matching the [selector](.
 limacharlie sensor list --selector 'plat == windows'
 ```
 
-#### Add Users
+### Add Users
 
 Add single or multiple users to a LimaCharlie organization. Added users will be sent an email to confirm their address, enable the account and create a new password.
 

--- a/docs/6-developer-guide/sdks/index.md
+++ b/docs/6-developer-guide/sdks/index.md
@@ -2,108 +2,39 @@
 
 Programmatic access to LimaCharlie via official SDKs.
 
-## Overview
-
-LimaCharlie provides official SDKs for Go and Python, enabling complete programmatic control of the platform:
-
-- Sensor management and tasking
-- Detection rule deployment
-- Artifact collection and export
-- Organization administration
-- Real-time event streaming
-
 ## Available SDKs
-
-### [Go SDK](go-sdk.md)
-
-The Go SDK provides a comprehensive client library for building security automation, integrations, and custom tools.
-
-**Installation:**
-```bash
-go get github.com/refractionPOINT/go-limacharlie/limacharlie
-```
-
-**Key Features:**
-- Type-safe API client
-- Sensor management
-- Detection & Response rule management
-- Artifact collection
-- Real-time event streaming (Firehose)
-- Organization administration
 
 ### [Python SDK](python-sdk.md)
 
-The Python SDK offers a full-featured interface perfect for security automation, data analysis, and rapid prototyping.
+The Python SDK offers a full-featured interface for security automation, data analysis, and rapid prototyping. It also includes the [command line interface](../sdk-overview.md).
 
-**Installation:**
 ```bash
 pip install limacharlie
 ```
 
-**Key Features:**
-- Client + Organization architecture for all platform operations
-- Sensor tasking and management
-- Real-time streaming (Firehose/Spout)
-- Detection rule management via Hive
-- LCQL query support
-- Artifact and payload management
+* Repo — <https://github.com/refractionPOINT/python-limacharlie>
 
-## Quick Start Examples
+### [Go SDK](go-sdk.md)
 
-### Python
-```python
-from limacharlie.client import Client
-from limacharlie.sdk.organization import Organization
-from limacharlie.sdk.sensor import Sensor
+The Go SDK provides a type-safe client library for building security automation, integrations, and custom tools.
 
-# Initialize client and organization
-client = Client(oid='your-org-id', api_key='your-api-key')
-org = Organization(client)
-
-# List all sensors
-for sensor_info in org.list_sensors():
-    sensor = Sensor(org, sensor_info["sid"])
-    print(f"Sensor: {sensor.sid} - {sensor.hostname}")
+```bash
+go get github.com/refractionPOINT/go-limacharlie/limacharlie
 ```
 
-### Go
-```go
-import "github.com/refractionPOINT/go-limacharlie/limacharlie"
-
-// Initialize client
-client := limacharlie.NewClientFromLoader(
-    limacharlie.ClientOptions{
-        OID:    "your-org-id",
-        APIKey: "your-api-key",
-    },
-)
-
-// List sensors
-sensors, err := client.GetSensors()
-if err != nil {
-    log.Fatal(err)
-}
-```
-
-## Resources
-
-- [API Documentation](https://api.limacharlie.io/openapi)
-- [GitHub - Go SDK](https://github.com/refractionPOINT/go-limacharlie)
-- [GitHub - Python SDK](https://github.com/refractionPOINT/python-limacharlie)
-- [Community Slack](https://slack.limacharlie.io)
+* Repo — <https://github.com/refractionPOINT/go-limacharlie>
 
 ## Authentication
 
 Both SDKs support multiple authentication methods:
 
-1. **API Key**: Organization-level API key
-2. **JWT**: User-specific JWT tokens
-3. **Environment Variables**: Auto-load from `LC_OID` and `LC_API_KEY`
+1. **API Key**: Organization-level API key (`oid` + `api_key`)
+2. **Environment Variables**: Auto-load from `LC_OID` and `LC_API_KEY`
+3. **Config File**: Credentials stored in `~/.limacharlie` with named environments
 
-## Support
+See the individual SDK pages for detailed authentication examples.
 
-For SDK-specific questions:
+## Resources
 
-- File issues on the respective GitHub repositories
-- Join the [Community Slack](https://slack.limacharlie.io)
-- Email [support@limacharlie.io](mailto:support@limacharlie.io)
+- [REST API Documentation](https://api.limacharlie.io/static/swagger/)
+- [Community Slack](https://slack.limacharlie.io)

--- a/docs/6-developer-guide/sdks/python-sdk.md
+++ b/docs/6-developer-guide/sdks/python-sdk.md
@@ -528,11 +528,11 @@ client = Client()
 org = Organization(client)
 
 # Stream events
-spout = Spout(org, "my-spout", data_type="event", tag="production")
+spout = Spout(org, data_type="event", tag="production")
 
 try:
     while True:
-        data = spout.pull(timeout=5)
+        data = spout.get(timeout=5)
         if data is not None:
             print(data)
 finally:
@@ -574,14 +574,12 @@ from limacharlie.sdk.artifacts import Artifacts
 artifacts = Artifacts(org)
 
 # List artifacts
-for artifact in artifacts.list(sensor='SENSOR_ID', start=start_time, end=end_time):
+result = artifacts.list(sid='SENSOR_ID', start=start_time, end=end_time)
+for artifact in result.get('artifacts', []):
     print(artifact)
 
 # Get download URL for an artifact
-url = artifacts.get_download_url('ARTIFACT_ID')
-
-# Download an artifact to a local file
-artifacts.download('ARTIFACT_ID', '/path/to/output')
+url = artifacts.get_url('ARTIFACT_ID')
 ```
 
 ## Hive Operations
@@ -711,13 +709,13 @@ from limacharlie.sdk.configs import Configs
 configs = Configs(org)
 
 # Pull organization configuration to a local file
-configs.pull(config_file='lc_conf.yaml')
+configs.fetch_to_file(file_path='lc_conf.yaml')
 
-# Push configuration from a local file
-configs.push(config_file='lc_conf.yaml', dry_run=True)
+# Push configuration from a local file (dry run)
+configs.push_from_file(file_path='lc_conf.yaml', is_dry_run=True)
 
 # Push with force (remove resources not in config)
-configs.push(config_file='lc_conf.yaml', is_force=True)
+configs.push_from_file(file_path='lc_conf.yaml', is_force=True)
 ```
 
 ## Error Handling
@@ -859,11 +857,11 @@ client = Client()
 org = Organization(client)
 
 # Stream detections in real-time
-spout = Spout(org, "detection-monitor", data_type="detect")
+spout = Spout(org, data_type="detect")
 
 try:
     while True:
-        detection = spout.pull(timeout=10)
+        detection = spout.get(timeout=10)
         if detection is not None:
             routing = detection.get('routing', {})
             print(f"Detection: {detection.get('cat', 'unknown')}")

--- a/docs/7-administration/index.md
+++ b/docs/7-administration/index.md
@@ -4,7 +4,8 @@ Organization configuration and management.
 
 ## Documentation
 
-- [LimaCharlie SDK](../6-developer-guide/sdk-overview.md) - SDK and CLI tools
+- [LimaCharlie CLI](../6-developer-guide/sdk-overview.md) - Command line interface
+- [SDKs](../6-developer-guide/sdks/index.md) - Python and Go SDK documentation
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,7 +372,7 @@ nav:
           - Overview: 6-developer-guide/sdks/index.md
           - Python SDK: 6-developer-guide/sdks/python-sdk.md
           - Go SDK: 6-developer-guide/sdks/go-sdk.md
-      - SDKs & CLI: 6-developer-guide/sdk-overview.md
+      - Command Line Interface: 6-developer-guide/sdk-overview.md
       - CLI Extension: 6-developer-guide/cli.md
       - Connecting AI Assistants: 6-developer-guide/mcp-server.md
       - Building Extensions:


### PR DESCRIPTION
## Summary

- **sdk-overview.md → CLI reference**: Stripped all duplicate Go/Python SDK content (already covered in `sdks/python-sdk.md` and `sdks/go-sdk.md`). Page now serves solely as the CLI reference. Renamed to "Command Line Interface" in nav.
- **sdks/index.md**: Simplified from 110 lines to a concise landing page. Removed buggy quick-start examples (Go example called nonexistent `client.GetSensors()`).
- **sdks/python-sdk.md**: Fixed SDK method bugs verified against v5.0.9:
  - `Spout()`: removed nonexistent `name` parameter, fixed `pull()` → `get()`
  - `Artifacts`: fixed `get_download_url()` → `get_url()`, `list(sensor=)` → `list(sid=)`, removed nonexistent `download()` method
  - `Configs`: fixed `pull()` → `fetch_to_file()`, `push(config_file=, dry_run=)` → `push_from_file(file_path=, is_dry_run=)`
- **index.md**: Removed broken `pipeline.md` link (file was deleted in #136), added CLI entries
- **cli.md**: Updated cross-references for new page structure
- **mkdocs.yml**: Updated nav title

**Before** (confusing nav):
```
SDKs > Overview | Python SDK | Go SDK
SDKs & CLI          ← duplicates both SDK pages + has CLI docs
CLI Extension
```

**After** (clear nav):
```
SDKs > Overview | Python SDK | Go SDK
Command Line Interface    ← CLI docs only
CLI Extension
```

## Test plan

- [ ] Verify nav sidebar shows "Command Line Interface" instead of "SDKs & CLI"
- [ ] Verify CLI page has no SDK content, only CLI commands
- [ ] Verify sdks/index.md links work to Python and Go SDK pages
- [ ] Verify cross-references from cli.md and index.md resolve correctly
- [ ] Check that no broken links remain from removed content

🤖 Generated with [Claude Code](https://claude.com/claude-code)