### PR TITLE
Replace Community Slack references with Discourse forum

### DIFF
--- a/docs/4-data-queries/lcql-examples.md
+++ b/docs/4-data-queries/lcql-examples.md
@@ -4,7 +4,7 @@ LimaCharlie Query Language (LCQL) lets you write well-structured queries to sear
 
 Got a Unique Query?
 
-If you've written a unique query or have one you'd like to share with the community, please join us in the [LimaCharlie Community](https://community.limacharlie.io)!
+If you've written a unique query or have one you'd like to share with the community, please join us in the [LimaCharlie Community](https://community.limacharlie.com/)!
 
 ## General Queries
 

--- a/docs/6-developer-guide/extensions/building-extensions.md
+++ b/docs/6-developer-guide/extensions/building-extensions.md
@@ -2,7 +2,7 @@
 
 This section is a work in progress
 
-Feel free to reach out to us on our Community Slack if you'd like to learn more
+Feel free to reach out to us on the [community forum](https://community.limacharlie.com/) if you'd like to learn more
 
 ## Why Extensions?
 
@@ -127,7 +127,7 @@ Afterwards, we recommend you define the data_type and other optional fields furt
 
 The config schema is a description of what the extension's config should look like, when stored as a Hive record in the `extension_configuration` Hive for convenience.
 
-Not all extensions will have a configuration, feel free to reach out on the community slack if you need help determining whether or not your extension needs a configuration.
+Not all extensions will have a configuration, feel free to reach out on the [community forum](https://community.limacharlie.com/) if you need help determining whether or not your extension needs a configuration.
 
 At the core, the config schema is simply a list of fields.
 

--- a/docs/6-developer-guide/extensions/building-ui.md
+++ b/docs/6-developer-guide/extensions/building-ui.md
@@ -59,6 +59,6 @@ In the schema, it is possible to define several views to utilize a combination o
 
 Functionality for this field is set to be expanded in the future
 
-Please feel free to reach out to us on our community slack if you'd like to stay up to date on
+Please feel free to reach out to us on the [community forum](https://community.limacharlie.com/) if you'd like to stay up to date on
 
 Supported actions are tied to a request's (also called "actions") response. It allows the response data to be modified and passed along to a follow-up action. This may be useful when operating a dry run, or triggering a workflow.

--- a/docs/6-developer-guide/sdks/go-sdk.md
+++ b/docs/6-developer-guide/sdks/go-sdk.md
@@ -1743,7 +1743,7 @@ firehose --listen_interface 0.0.0.0:4444 --data_type event -n my-firehose --use-
 - **LimaCharlie Documentation**: [docs.limacharlie.io](https://docs.limacharlie.io)
 - **LCQL Query Language**: [docs.limacharlie.io/docs/query-language](https://docs.limacharlie.io/docs/query-language)
 - **Detection & Response Rules**: [docs.limacharlie.io/docs/detection-and-response](https://docs.limacharlie.io/docs/detection-and-response)
-- **Community Support**: [community.limacharlie.io](https://community.limacharlie.io)
+- **Community Support**: [community.limacharlie.com](https://community.limacharlie.com/)
 - **Commercial Support**: support@limacharlie.io
 
 ---

--- a/docs/6-developer-guide/sdks/index.md
+++ b/docs/6-developer-guide/sdks/index.md
@@ -37,4 +37,4 @@ See the individual SDK pages for detailed authentication examples.
 ## Resources
 
 - [REST API Documentation](https://api.limacharlie.io/static/swagger/)
-- [Community Slack](https://slack.limacharlie.io)
+- [Community Forum](https://community.limacharlie.com/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ LimaCharlie is the **SecOps Cloud Platform** delivering security operations for 
 
 <div class="grid" markdown>
 
-- [:fontawesome-solid-users: Join our Community](https://community.limacharlie.io/)
+- [:fontawesome-solid-users: Join our Community](https://community.limacharlie.com/)
 - [:fontawesome-brands-github: GitHub Repository](https://github.com/refractionPOINT)
 - [:fontawesome-solid-globe: LimaCharlie Platform](https://limacharlie.io)
 - [:fontawesome-solid-rocket: Web Console](https://app.limacharlie.io)


### PR DESCRIPTION
## Summary

The LimaCharlie Community Slack instance has been retired. This PR updates all references across the documentation to point to the Discourse forum at https://community.limacharlie.com/.

- `docs/index.md` — community.limacharlie.io → community.limacharlie.com
- `docs/4-data-queries/lcql-examples.md` — community.limacharlie.io → community.limacharlie.com
- `docs/6-developer-guide/sdks/index.md` — slack.limacharlie.io → community.limacharlie.com
- `docs/6-developer-guide/sdks/go-sdk.md` — community.limacharlie.io → community.limacharlie.com
- `docs/6-developer-guide/extensions/building-extensions.md` — "Community Slack" → community forum link (2 references)
- `docs/6-developer-guide/extensions/building-ui.md` — "community slack" → community forum link

Searched the entire docs tree for `community.limacharlie.io`, `slack.limacharlie.io`, and `community slack` (case-insensitive) — no remaining references.

## Test plan

- [ ] Verify all 7 updated links resolve to https://community.limacharlie.com/
- [ ] Grep confirms no remaining old references

🤖 Generated with [Claude Code](https://claude.com/claude-code)