### PR TITLE
Configure custom domain docs.limacharlie.io for GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.limacharlie.io

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LimaCharlie Documentation
-site_url: https://refractionpoint.github.io/documentation/
+site_url: https://docs.limacharlie.io/
 site_description: Official documentation for LimaCharlie SecOps Cloud Platform
 site_author: refractionPOINT
 repo_url: https://github.com/refractionPOINT/documentation


### PR DESCRIPTION
## Summary
- Add `CNAME` file with `docs.limacharlie.io` to enable GitHub Pages custom domain
- Update `site_url` in `mkdocs.yml` from `https://refractionpoint.github.io/documentation/` to `https://docs.limacharlie.io/`

## Additional steps required after merge
1. **Verify domain** in GitHub org settings (Settings > Pages > Verified domains)
2. **DNS change**: Update `docs.limacharlie.io` CNAME from `lb-cdmz1.document360.io` to `refractionpoint.github.io`
3. **Enable HTTPS** in repo Pages settings once DNS propagates
4. **Clean up redirects repo**: Simplify `doc.limacharlie.io` and `help.limacharlie.io` rules to catch-all redirects to `https://docs.limacharlie.io`

ref: https://github.com/refractionPOINT/tracking/issues/4080

## Test plan
- [ ] Verify GitHub Pages builds successfully after merge
- [ ] After DNS change, confirm `docs.limacharlie.io` serves the documentation site
- [ ] Confirm HTTPS is working