### PR TITLE
Reduce documentation font size

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -30,7 +30,7 @@
   --lc-cta-color--hover: #BE185D;
 
   /* Custom typography scale */
-  --md-typeset-font-size: 0.9rem;
+  --md-typeset-font-size: 0.8rem;
 }
 
 [data-md-color-scheme="slate"] {


### PR DESCRIPTION
## Summary

- Reduces `--md-typeset-font-size` from `0.9rem` to `0.8rem` (~89% of previous size)
- This matches the MkDocs Material default and improves information density

One-line change in `docs/assets/stylesheets/extra.css`.

## Test plan

- [ ] Preview the site and confirm body text is smaller but still readable
- [ ] Verify code blocks, headings, and tables scale proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)