### PR TITLE
Refine hero H1 size and weight

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -161,8 +161,8 @@ h1, h2, h3, h4, h5, h6,
 
 /* Enhanced hero section for index page */
 .md-typeset h1:first-of-type {
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: 1.8rem;
+  font-weight: 600;
   margin-bottom: 1rem;
   background: linear-gradient(135deg, #E91E63 0%, #2563EB 50%, #0D1B2A 100%);
   -webkit-background-clip: text;


### PR DESCRIPTION
## Summary
- Reduce hero H1 font size from 2rem to 1.8rem
- Lighten font weight from 700 to 600

🤖 Generated with [Claude Code](https://claude.com/claude-code)