### PR TITLE
Tone down search result styling

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -128,7 +128,8 @@ h1, h2, h3, h4, h5, h6,
 
 /* Search highlighting */
 .md-search-result__article--document .md-search-result__title {
-  color: var(--md-accent-fg-color);
+  color: var(--md-default-fg-color);
+  font-weight: 500;
 }
 
 /* Navigation hover effects */
@@ -233,6 +234,6 @@ h1, h2, h3, h4, h5, h6,
 /* Search result highlighting */
 .md-search-result mark {
   background-color: var(--md-accent-fg-color--transparent);
-  color: var(--md-accent-fg-color);
-  text-decoration: underline;
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- Search result titles: use default text color and lighter weight (500) instead of accent blue and bold
- Search match highlights: keep subtle background but inherit text color, remove underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)