### PR TITLE
Fix hero H1 gradient leaking into search results

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -160,8 +160,8 @@ h1, h2, h3, h4, h5, h6,
   box-shadow: 0 4px 8px rgba(233, 30, 99, 0.3);
 }
 
-/* Enhanced hero section for index page */
-.md-typeset h1:first-of-type {
+/* Enhanced hero section for index page - scoped to main content only */
+.md-content .md-typeset h1:first-of-type {
   font-size: 1.8rem;
   font-weight: 600;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- Scope the hero H1 gradient/weight styling to `.md-content .md-typeset` so it only applies to page content, not search result previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)