### PR TITLE
Fix broken docs.limacharlie.io links

### DIFF
--- a/docs/2-sensors-deployment/adapters/types/1password.md
+++ b/docs/2-sensors-deployment/adapters/types/1password.md
@@ -34,7 +34,7 @@ After providing an [Installation Key](../../installation-keys.md), provide the r
 LimaCharlie IaC Adapter can also be used to ingest 1Password events.
 
 ```python
-# 1Password Specific Docs: https://docs.limacharlie.io/docs/adapter-types-1password
+# 1Password Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/1password/
 
 sensor_type: "1password"
   1password:

--- a/docs/2-sensors-deployment/adapters/types/azure-event-hub.md
+++ b/docs/2-sensors-deployment/adapters/types/azure-event-hub.md
@@ -84,7 +84,7 @@ client_options.hostname=<HOSTNAME> \
 ### Infrastructure as Code Deployment
 
 ```python
-# Azure Event Hub Specific Docs: https://docs.limacharlie.io/docs/adapter-types-azure-event-hub
+# Azure Event Hub Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/azure-event-hub/
 
 sensor_type: "azure_event_hub"
   azure_event_hub:

--- a/docs/2-sensors-deployment/adapters/types/crowdstrike.md
+++ b/docs/2-sensors-deployment/adapters/types/crowdstrike.md
@@ -40,7 +40,7 @@ client_secret=$CLIENT_SECRET
 ### Infrastructure as Code Deployment
 
 ```python
-# CrowdStrike Falcon ("falconcloud") Specific Docs: https://docs.limacharlie.io/docs/adapter-types-crowdstrike
+# CrowdStrike Falcon ("falconcloud") Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/crowdstrike/
 
 sensor_type: "falconcloud"
   falconcloud:

--- a/docs/2-sensors-deployment/adapters/types/duo.md
+++ b/docs/2-sensors-deployment/adapters/types/duo.md
@@ -16,7 +16,7 @@ Adapter Type: `duo`
 ### Infrastructure as Code Deployment
 
 ```python
-# Duo Security Specific Docs: https://docs.limacharlie.io/docs/adapter-types-duo
+# Duo Security Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/duo/
 
 # For cloud sensor deployment, store credentials as hive secrets:
 #   integration_key: "hive://secret/duo-integration-key"

--- a/docs/2-sensors-deployment/adapters/types/google-cloud-pubsub.md
+++ b/docs/2-sensors-deployment/adapters/types/google-cloud-pubsub.md
@@ -40,7 +40,7 @@ Here's the breakdown of the above example:
 ### Infrastructure as Code Deployment
 
 ```python
-# Google Cloud Pub/Sub Specific Docs: https://docs.limacharlie.io/docs/adapter-types-google-cloud-pubsub
+# Google Cloud Pub/Sub Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/google-cloud-pubsub/
 
 sensor_type: "pubsub"
 pubsub:

--- a/docs/2-sensors-deployment/adapters/types/google-cloud-storage.md
+++ b/docs/2-sensors-deployment/adapters/types/google-cloud-storage.md
@@ -19,7 +19,7 @@ Adapter Type: `gcs`
 ### Infrastructure as Code Deployment
 
 ```python
-# Google Cloud Storage (GCS) Specific Docs: https://docs.limacharlie.io/docs/adapter-types-gcs
+# Google Cloud Storage (GCS) Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/google-cloud-storage/
 
 sensor_type: "gcs"
 gcs:

--- a/docs/2-sensors-deployment/adapters/types/it-glue.md
+++ b/docs/2-sensors-deployment/adapters/types/it-glue.md
@@ -22,7 +22,7 @@ Adapter Type: `itglue`
 ### Infrastructure as Code Deployment
 
 ```python
-# Adapter Documentation: https://docs.limacharlie.io/docs/adapter-types
+# Adapter Documentation: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/it-glue/
 # For Cloud Sensor configurations, use:
 #        token: "hive://secret/itglue-api-token"
 

--- a/docs/2-sensors-deployment/adapters/types/kubernetes-pods.md
+++ b/docs/2-sensors-deployment/adapters/types/kubernetes-pods.md
@@ -20,7 +20,7 @@ The following fields are required for configuration:
 ### Infrastructure as Code Deployment
 
 ```python
-# Kubernetes Pods Specific Docs: https://docs.limacharlie.io/docs/adapter-types-k8s-pods
+# Kubernetes Pods Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/kubernetes-pods/
 
 sensor_type: "k8_pods"
 k8s_pods:

--- a/docs/2-sensors-deployment/adapters/types/microsoft-365.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-365.md
@@ -39,7 +39,7 @@ Establishing a cloud-to-cloud connector between LimaCharlie and Office 365 requi
 ### Infrastructure as Code Deployment
 
 ```python
-# Office 365 Management Activity API Specific Docs: https://docs.limacharlie.io/docs/adapter-types-office-365-management-activity-api
+# Office 365 Management Activity API Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/microsoft-365/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   tenant_id: "hive://secret/o365-tenant-id"

--- a/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
@@ -90,7 +90,7 @@ client_options.hostname=msdefender \
 ### Infrastructure as Code Deployment
 
 ```python
-# Adapter Documentation: https://docs.limacharlie.io/docs/adapter-types
+# Adapter Documentation: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/microsoft-defender/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   tenant_id: "hive://secret/azure-tenant-id"

--- a/docs/2-sensors-deployment/adapters/types/mimecast.md
+++ b/docs/2-sensors-deployment/adapters/types/mimecast.md
@@ -39,7 +39,7 @@ client_id=$CLIENT_ID client_secret=$CLIENT_SECRET
 ### Infrastructure as Code Deployment
 
 ```python
-# Mimecast Specific Docs: https://docs.limacharlie.io/docs/adapter-types-mimecast
+# Mimecast Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/mimecast/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   client_id: "hive://secret/mimecast-client-id"

--- a/docs/2-sensors-deployment/adapters/types/okta.md
+++ b/docs/2-sensors-deployment/adapters/types/okta.md
@@ -38,7 +38,7 @@ apikey=$API_KEY url=$URL
 ### Infrastructure as Code Deployment
 
 ```python
-# Okta Specific Docs: https://docs.limacharlie.io/docs/adapter-types-okta
+# Okta Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/okta/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   apikey: "hive://secret/okta-api-token"

--- a/docs/2-sensors-deployment/adapters/types/pandadoc.md
+++ b/docs/2-sensors-deployment/adapters/types/pandadoc.md
@@ -38,7 +38,7 @@ api_key=$API_KEY
 ### Infrastructure as Code Deployment
 
 ```python
-# PandaDoc Specific Docs: https://docs.limacharlie.io/docs/adapter-types-pandadoc
+# PandaDoc Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/pandadoc/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   api_key: "hive://secret/pandadoc-api-key"

--- a/docs/2-sensors-deployment/adapters/types/s3.md
+++ b/docs/2-sensors-deployment/adapters/types/s3.md
@@ -44,7 +44,7 @@ Adapter Type: `s3`
 ### Infrastructure as Code Deployment
 
 ```python
-# AWS S3 Specific Docs: https://docs.limacharlie.io/docs/adapter-types-s3
+# AWS S3 Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/s3/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   access_key: "hive://secret/aws-access-key"

--- a/docs/2-sensors-deployment/adapters/types/sophos.md
+++ b/docs/2-sensors-deployment/adapters/types/sophos.md
@@ -75,7 +75,7 @@ Sophos documentation - <https://developer.sophos.com/getting-started-tenant>
 ### Infrastructure as Code Deployment
 
 ```python
-# Sophos Central Specific Docs: https://docs.limacharlie.io/docs/adapter-types-sophos-central
+# Sophos Central Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/sophos/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   clientid: "hive://secret/sophos-client-id"

--- a/docs/2-sensors-deployment/adapters/types/sqs.md
+++ b/docs/2-sensors-deployment/adapters/types/sqs.md
@@ -16,7 +16,7 @@ Adapter Type: `sqs`
 ### Infrastructure as Code Deployment
 
 ```python
-# AWS SQS Specific Docs: https://docs.limacharlie.io/docs/adapter-types-sqs
+# AWS SQS Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/sqs/
 
 sensor_type: "sqs"
 sqs:

--- a/docs/2-sensors-deployment/adapters/types/sublime-security.md
+++ b/docs/2-sensors-deployment/adapters/types/sublime-security.md
@@ -30,7 +30,7 @@ api_key=$API_KEY
 ### Infrastructure as Code Deployment
 
 ```python
-# Sublime Security Specific Docs: https://docs.limacharlie.io/docs/adapter-types-sublime-security
+# Sublime Security Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/sublime-security/
 # For cloud sensor deployment, store credentials as hive secrets:
 
 #   api_key: "hive://secret/sublime-api-key"

--- a/docs/2-sensors-deployment/adapters/types/zendesk.md
+++ b/docs/2-sensors-deployment/adapters/types/zendesk.md
@@ -42,7 +42,7 @@ zendesk_email=you@yourcompany.com
 ### Infrastructure as Code Deployment
 
 ```python
-# Zendesk Specific Docs: https://docs.limacharlie.io/docs/adapter-types-zendesk
+# Zendesk Specific Docs: https://docs.limacharlie.io/2-sensors-deployment/adapters/types/zendesk/
 # For cloud sensor deployment, store credentials as hive secrets:
 #   api_token: "hive://secret/zendesk-api-token"
 #   zendesk_email: "hive://secret/zendesk-email"

--- a/docs/5-integrations/extensions/limacharlie/artifact.md
+++ b/docs/5-integrations/extensions/limacharlie/artifact.md
@@ -31,6 +31,6 @@ Within the Artifact Collection page, you can configure:
 
 The following screenshot provides examples of capturing Windows Security and Sysmon Windows Event Logs via Artifact Collection. Rather than using an Adapter, capturing WEL events via the `wel://` pattern adds the corresponding events to the sensor telemetry, creating a real-time stream of Windows Event Log data. However, you can also specify the pattern to collect the specific `.evtx` files.
 
-More information on Artifact collections can be found [here](https://docs.limacharlie.io/docs/artifacts).
+More information on Artifact collections can be found [here](https://docs.limacharlie.io/5-integrations/extensions/limacharlie/artifact/).
 
 ![](../../../assets/images/artifact-3.png)

--- a/docs/6-developer-guide/sdks/go-sdk.md
+++ b/docs/6-developer-guide/sdks/go-sdk.md
@@ -1741,8 +1741,8 @@ firehose --listen_interface 0.0.0.0:4444 --data_type event -n my-firehose --use-
 - **GitHub Repository**: [github.com/refractionPOINT/go-limacharlie](https://github.com/refractionPOINT/go-limacharlie)
 - **API Documentation**: [api.limacharlie.io/openapi](https://api.limacharlie.io/openapi)
 - **LimaCharlie Documentation**: [docs.limacharlie.io](https://docs.limacharlie.io)
-- **LCQL Query Language**: [docs.limacharlie.io/docs/query-language](https://docs.limacharlie.io/docs/query-language)
-- **Detection & Response Rules**: [docs.limacharlie.io/docs/detection-and-response](https://docs.limacharlie.io/docs/detection-and-response)
+- **LCQL Query Language**: [docs.limacharlie.io/4-data-queries/lcql-examples](https://docs.limacharlie.io/4-data-queries/lcql-examples/)
+- **Detection & Response Rules**: [docs.limacharlie.io/3-detection-response](https://docs.limacharlie.io/3-detection-response/)
 - **Community Support**: [community.limacharlie.com](https://community.limacharlie.com/)
 - **Commercial Support**: support@limacharlie.io
 

--- a/docs/8-reference/detection-logic-operators.md
+++ b/docs/8-reference/detection-logic-operators.md
@@ -2,7 +2,7 @@
 
 Operators are used in the Detection part of a Detection & Response rule. Operators may also be accompanied by other available parameters, such as transforms, times, and others, referenced later in this page.
 
-> For more information on how to use operators, read [Detection & Response Rules](https://docs.limacharlie.io/docs/detection-and-response).
+> For more information on how to use operators, read [Detection & Response Rules](https://docs.limacharlie.io/3-detection-response/).
 
 ## Operators
 
@@ -303,7 +303,7 @@ The value is supplied via the `path` parameter and the lookup is defined in the 
 
 Supports the [file name](#file-name) and [sub domain](#sub-domain) transforms.
 
-> API-based lookups, like VirusTotal and IP Geolocation, work a little bit differently. For more information, see [Using API-based lookups](https://docs.limacharlie.io/docs/add-ons-api-integrations).
+> API-based lookups, like VirusTotal and IP Geolocation, work a little bit differently. For more information, see [Using API-based lookups](https://docs.limacharlie.io/5-integrations/api-integrations/).
 
 > You can create your own lookups and optionally publish them in the add-on marketplace. To learn more, see [Lookups](../7-administration/config-hive/lookups.md) and [Lookup Manager](../5-integrations/extensions/limacharlie/lookup-manager.md).
 


### PR DESCRIPTION
## Summary
- Updated 21 files with broken `docs.limacharlie.io` links from old `/docs/` URL scheme to new directory-based paths
- Fixed self-referencing URLs in 18 adapter type files, go-sdk.md, detection-logic-operators.md, and artifact.md
- All new URLs verified as returning HTTP 200

## Test plan
- [ ] Verify links resolve correctly on docs.limacharlie.io
- [ ] Confirm no remaining old `/docs/` URLs in changed files