### PR TITLE
Add Cloud CLI extension overview page

### DIFF
--- a/docs/5-integrations/extensions/cloud-cli/index.md
+++ b/docs/5-integrations/extensions/cloud-cli/index.md
@@ -1,0 +1,20 @@
+# Cloud CLI
+
+The Cloud CLI extension allows you to trigger actions within other tools such as AWS, GCP, Azure, and more based on events generated in LimaCharlie.
+
+It uses the native CLI tools for each platform, enabling you to automate responses directly from D&R rules.
+
+## Supported Platforms
+
+- [1Password](1password.md)
+- [AWS](aws.md)
+- [Azure](azure.md)
+- [DigitalOcean](digitalocean.md)
+- [GitHub](github.md)
+- [Google Cloud](google-cloud.md)
+- [Microsoft 365](microsoft365.md)
+- [Okta](okta.md)
+- [SDM](sdm.md)
+- [Sublime](sublime.md)
+- [Tailscale](tailscale.md)
+- [Vultr](vultr.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -336,6 +336,7 @@ nav:
           - Labs:
               - Playbook: 5-integrations/extensions/labs/playbook.md
           - Cloud CLI:
+              - Overview: 5-integrations/extensions/cloud-cli/index.md
               - 1Password: 5-integrations/extensions/cloud-cli/1password.md
               - AWS: 5-integrations/extensions/cloud-cli/aws.md
               - Azure: 5-integrations/extensions/cloud-cli/azure.md


### PR DESCRIPTION
## Summary
- Adds an index page for the Cloud CLI extension section (`/5-integrations/extensions/cloud-cli/`)
- Lists all 12 supported platforms with links to their individual doc pages
- Adds the overview page to the mkdocs.yml navigation

This provides a valid landing page URL for extension definitions that link to the Cloud CLI docs.

## Test plan
- [ ] Verify the page renders at `/5-integrations/extensions/cloud-cli/`
- [ ] Verify all platform links resolve correctly
- [ ] Verify nav sidebar shows the new Overview entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)