### PR TITLE
Add Telegram output documentation

### DIFF
--- a/docs/5-integrations/outputs/destinations/telegram.md
+++ b/docs/5-integrations/outputs/destinations/telegram.md
@@ -1,0 +1,30 @@
+# Telegram
+
+Output detections and audit (only) to a Telegram chat, group, or channel.
+
+* `bot_token`: the Telegram Bot API token obtained from @BotFather.
+* `chat_id`: the target chat, group, or channel ID to send messages to.
+* `parse_mode`: (optional) message formatting mode: `Markdown`, `MarkdownV2`, or `HTML`.
+* `message`: (optional) a template string for custom message formatting.
+
+Example:
+
+```
+bot_token: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+chat_id: -1001234567890
+parse_mode: Markdown
+```
+
+## Provisioning
+
+To use this Output, you need to create a Telegram Bot:
+
+1. Open Telegram and message [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts to name your bot
+3. Copy the bot token provided — this is the `bot_token` you need in LimaCharlie
+4. Add the bot to the chat, group, or channel where you want to receive messages
+5. For channels, add the bot as an administrator with "Post Messages" permission
+6. Get the `chat_id` for your target:
+    - For **private chats**: message the bot, then visit `https://api.telegram.org/bot<TOKEN>/getUpdates` to find your chat ID
+    - For **groups**: add the bot to the group, send a message, then check `getUpdates` for the group's chat ID (a negative number)
+    - For **public channels**: use `@channelusername` as the chat ID

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -366,6 +366,7 @@ nav:
               - Webhook: 5-integrations/outputs/destinations/webhook.md
               - Webhook Bulk: 5-integrations/outputs/destinations/webhook-bulk.md
               - Slack: 5-integrations/outputs/destinations/slack.md
+              - Telegram: 5-integrations/outputs/destinations/telegram.md
               - SMTP: 5-integrations/outputs/destinations/smtp.md
               - Apache Kafka: 5-integrations/outputs/destinations/apache-kafka.md
               - Azure Event Hub: 5-integrations/outputs/destinations/azure-event-hub.md


### PR DESCRIPTION
## Summary
- Adds documentation page for the new Telegram output destination
- Documents config fields: `bot_token`, `chat_id`, `parse_mode`, `message`
- Includes step-by-step provisioning guide for creating a Telegram bot via @BotFather
- Adds Telegram to the mkdocs nav under Outputs > Destinations

## Test plan
- [ ] Verify the docs page renders correctly with `mkdocs serve`
- [ ] Verify navigation link appears in the Destinations section

🤖 Generated with [Claude Code](https://claude.com/claude-code)