### PR TITLE
docs: clarify Insight default state and data retention on disable

### DIFF
--- a/docs/1-getting-started/core-concepts.md
+++ b/docs/1-getting-started/core-concepts.md
@@ -39,11 +39,11 @@ Detailed explanation in the [Detection & Response section](../3-detection-respon
 
 ## Insight
 
-Insight is our built-in data retention and search feature. It is included within our 2 sensor free tier as well.
+Insight is our built-in data retention and search feature. It is enabled by default and included within our 2 sensor free tier as well.
 
-When you enable Insight, we configure everything for you so that you get access to one year of your data for visualization and searching.
+We configure everything for you so that you get access to one year of your data for visualization and searching.
 
-You don't *have to* use the built-in data retention; you can forward data directly to your infrastructure if preferred. However, it is generally much simpler and a better experience to use Insight. If you prefer not to use Insight, go through the next section (Outputs).
+You don't *have to* use the built-in data retention; you can forward data directly to your infrastructure if preferred. However, it is generally much simpler and a better experience to use Insight. If you do disable Insight, any data already collected will remain stored and searchable for the original retention period. If you prefer not to use Insight, go through the next section (Outputs).
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- Clarify that Insight is enabled by default (not something users need to turn on)
- Note that disabling Insight does not affect already-collected data — it remains stored and searchable for the original retention period
- Remove "When you enable Insight" phrasing since it's on by default

## Test plan
- [ ] Verify page renders correctly in MkDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)