### PR TITLE
Add Telegram, Teams, and email channel docs for ext-feedback

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -1,0 +1,244 @@
+# Feedback
+
+The Feedback extension enables interactive feedback requests across external channels. It sends approval/denial prompts or questions to Slack channels or a built-in web UI, collects responses, and dispatches them to LimaCharlie subsystems (case notes via ext-cases, playbook triggers via ext-playbook).
+
+Designed for AI-driven and human-initiated workflows where operator approval or input is required before taking an automated action. For example, a D&R rule or playbook can ask a human "Should we isolate host compromised-01?" and wait for a response before proceeding.
+
+## Enabling the Extension
+
+Navigate to the [Feedback extension page](https://app.limacharlie.io/add-ons/extension-detail/ext-feedback) in the marketplace. Select the organization you wish to enable it for, and select **Subscribe**.
+
+On subscription, the extension automatically:
+
+1. Creates a webhook adapter for the organization
+2. Installs a D&R rule that routes feedback responses to the extension for processing
+
+No additional configuration is required. You can immediately start creating channels and sending feedback requests.
+
+## Concepts
+
+### Channels
+
+A **channel** defines how feedback requests are delivered to respondents. Each channel has a name and a type.
+
+| Channel Type | Description | Requirements |
+|-------------|-------------|--------------|
+| `default` | Built-in web UI. Returns a shareable URL that displays the question with response buttons. No external setup needed. | None |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with Approve/Deny or Acknowledge buttons. | A LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel` configured |
+
+### Feedback Types
+
+| Feedback Type | Buttons | Response Values |
+|--------------|---------|-----------------|
+| `simple_approval` | **Approve** and **Deny** | `approved` or `denied` |
+| `question` | **Acknowledge** | `acknowledged` |
+
+### Feedback Destinations
+
+When a respondent clicks a button, the extension dispatches the response to the configured destination:
+
+| Destination | Behavior |
+|-------------|----------|
+| `case` | Adds a note to the specified case via ext-cases. Requires a `case_id`. |
+| `playbook` | Triggers the specified playbook via ext-playbook with the response data. Requires a `playbook_name`. |
+
+### Response Content
+
+Each feedback request can include optional JSON data per choice. When the respondent selects a choice, the corresponding content is included in the dispatched response. This allows automation to carry structured payloads through the human decision point.
+
+For `simple_approval`, use `approved_content` and `denied_content`. For `question`, use `acknowledged_content`.
+
+## Channel Management
+
+### Create a Channel
+
+=== "CLI"
+    ```bash
+    # Default channel (web UI)
+    limacharlie extension request \
+      --name ext-feedback \
+      --action set_channel \
+      --data '{"name":"approvals","channel_type":"default"}'
+
+    # Slack channel (requires a Tailored Output with Slack credentials)
+    limacharlie extension request \
+      --name ext-feedback \
+      --action set_channel \
+      --data '{"name":"ops-slack","channel_type":"slack","output_name":"slack-ops"}'
+    ```
+
+=== "D&R Rule"
+    ```yaml
+    - action: extension request
+      extension name: ext-feedback
+      extension action: set_channel
+      extension request:
+        name: '{{ "approvals" }}'
+        channel_type: '{{ "default" }}'
+    ```
+
+### List Channels
+
+=== "CLI"
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action list_channels
+    ```
+
+### Delete a Channel
+
+=== "CLI"
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action delete_channel \
+      --data '{"name":"approvals"}'
+    ```
+
+## Sending Feedback Requests
+
+The `request_feedback` action sends a question to a channel and returns a `request_id`. When a respondent answers, the response is dispatched to the configured destination.
+
+### Simple Approval via Default Channel
+
+=== "CLI"
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action request_feedback \
+      --data '{
+        "channel": "approvals",
+        "question": "Should we isolate host compromised-01?",
+        "feedback_type": "simple_approval",
+        "feedback_destination": "case",
+        "case_id": "78",
+        "approved_content": "{\"action\": \"isolate\", \"sid\": \"sensor-abc\"}",
+        "denied_content": "{\"action\": \"skip\"}"
+      }'
+    ```
+
+The response includes:
+
+```json
+{
+  "request_id": "a1b2c3d4-...",
+  "url": "https://feedback-system.limacharlie.io/r/a1b2c3d4-..."
+}
+```
+
+The `url` is the shareable link to the web UI where the respondent can answer. For Slack channels, no URL is returned -- the message is sent directly to the Slack channel.
+
+### D&R Rule Example
+
+A D&R rule can request human approval before taking automated action. The response is dispatched to a playbook that performs the action.
+
+**Detection:**
+```yaml
+op: is
+event: NEW_PROCESS
+path: event/FILE_PATH
+value: /usr/bin/suspicious-tool
+```
+
+**Response:**
+```yaml
+- action: extension request
+  extension name: ext-feedback
+  extension action: request_feedback
+  extension request:
+    channel: '{{ "ops-slack" }}'
+    question: '{{ "Suspicious process detected on " }}{{ .routing.hostname }}{{ ". Isolate host?" }}'
+    feedback_type: '{{ "simple_approval" }}'
+    feedback_destination: '{{ "playbook" }}'
+    playbook_name: '{{ "isolate-host" }}'
+    approved_content:
+      action: '{{ "isolate" }}'
+      sid: routing.sid
+    denied_content:
+      action: '{{ "monitor" }}'
+      sid: routing.sid
+```
+
+### Playbook Example
+
+A playbook can request approval during execution:
+
+```python
+def main(lc, data):
+    import json
+
+    # Request human approval
+    response = lc.extension_request(
+        "ext-feedback",
+        "request_feedback",
+        {
+            "channel": "approvals",
+            "question": f"Isolate host {data.get('hostname', 'unknown')}?",
+            "feedback_type": "simple_approval",
+            "feedback_destination": "playbook",
+            "playbook_name": "handle-isolation-response",
+            "approved_content": json.dumps({"action": "isolate", "sid": data.get("sid")}),
+            "denied_content": json.dumps({"action": "skip"}),
+        },
+    )
+
+    # The response will trigger the handle-isolation-response playbook
+    # when the human responds.
+    return {"request_id": response.get("request_id")}
+```
+
+## Response Flow
+
+1. A feedback request is created and stored with a 7-day TTL
+2. The question is delivered via the configured channel (Slack message or web URL)
+3. The respondent clicks a button
+4. The response is routed through the organization's webhook adapter
+5. A D&R rule matches the response event and triggers the extension's `process_response` action
+6. The extension atomically claims the request (preventing duplicate processing) and dispatches the response to the configured destination
+
+Feedback requests expire after **7 days**. Expired requests show an error in the web UI and are rejected by the extension.
+
+Responses are protected against replay: once a response is processed, any duplicate deliveries (from webhook retries or replay) are rejected.
+
+## Slack Setup
+
+To use Slack channels:
+
+1. Create a Slack App with "Interactivity & Shortcuts" enabled
+2. Set the Request URL to the Slack callback endpoint: `https://feedback-system.limacharlie.io/callback/slack`
+3. Install the app to your Slack workspace and note the Bot User OAuth Token
+4. In LimaCharlie, create a [Tailored Output](../../../3-detection-response/outputs.md) with:
+    - `slack_api_token`: the Bot User OAuth Token
+    - `slack_channel`: the target channel (e.g. `#security-ops`)
+5. Create a feedback channel referencing the output name:
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action set_channel \
+      --data '{"name":"ops","channel_type":"slack","output_name":"my-slack-output"}'
+    ```
+
+## Actions Reference
+
+| Action | User-facing | Description |
+|--------|:-----------:|-------------|
+| `set_channel` | Yes | Create or update a feedback channel |
+| `delete_channel` | Yes | Delete a feedback channel |
+| `list_channels` | Yes | List all feedback channels for the organization |
+| `request_feedback` | Yes | Send a feedback request to a channel |
+| `process_response` | No | Internal: processes a response received via webhook |
+
+### request_feedback Parameters
+
+| Parameter | Required | Description |
+|-----------|:--------:|-------------|
+| `channel` | Yes | Name of the feedback channel |
+| `question` | Yes | The question or prompt to present |
+| `feedback_type` | Yes | `simple_approval` or `question` |
+| `feedback_destination` | Yes | `case` or `playbook` |
+| `case_id` | When destination is `case` | Case to add the response note to |
+| `playbook_name` | When destination is `playbook` | Playbook to trigger with the response |
+| `approved_content` | No | JSON data included when the respondent approves (simple_approval) |
+| `denied_content` | No | JSON data included when the respondent denies (simple_approval) |
+| `acknowledged_content` | No | JSON data included when the respondent acknowledges (question) |

--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -67,7 +67,7 @@ Channels are managed through the extension config, not via extension actions. Yo
     ```
 
 === "Infrastructure as Code"
-    Channels can be managed via [git-sync](../../../7-infrastructure-as-code/index.md) by including the extension config in your synced repository:
+    Channels can be managed via [git-sync](git-sync.md) by including the extension config in your synced repository:
     ```yaml
     # extension_config/ext-feedback
     channels:
@@ -87,7 +87,7 @@ Channels are managed through the extension config, not via extension actions. Yo
         output_name: my-smtp-output
     ```
 
-For all channel types except `web`, the `output_name` field references a LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) that holds the credentials for the channel.
+For all channel types except `web`, the `output_name` field references a LimaCharlie [Tailored Output](../../outputs/index.md) that holds the credentials for the channel.
 
 ## Sending Feedback Requests
 
@@ -235,7 +235,7 @@ To use Slack channels:
 1. Create a Slack App with "Interactivity & Shortcuts" enabled
 2. Set the Request URL to the Slack callback endpoint: `https://feedback-system.limacharlie.io/callback/slack`
 3. Install the app to your Slack workspace and note the Bot User OAuth Token
-4. In LimaCharlie, create a [Tailored Output](../../../3-detection-response/outputs.md) with:
+4. In LimaCharlie, create a [Tailored Output](../../outputs/index.md) with:
     - `slack_api_token`: the Bot User OAuth Token
     - `slack_channel`: the target channel (e.g. `#security-ops`)
 5. Add a Slack channel to your extension config referencing the output name (see [Channel Configuration](#channel-configuration)). For example, a channel with `name: "ops"`, `channel_type: "slack"`, and `output_name: "my-slack-output"`.
@@ -261,7 +261,7 @@ For more information, see the [Telegram Bot API documentation](https://core.tele
 
 ### Step 2: Create a Tailored Output
 
-In LimaCharlie, create a Telegram [Tailored Output](../../../3-detection-response/outputs.md) with:
+In LimaCharlie, create a Telegram [Tailored Output](../../outputs/index.md) with:
 
 - `bot_token`: the bot token from BotFather
 - `chat_id`: the target chat, group, or channel ID
@@ -315,7 +315,7 @@ For details, see [Create incoming webhooks with Workflows](https://support.micro
 
 ### Create the Tailored Output
 
-In LimaCharlie, create a Microsoft Teams [Tailored Output](../../../3-detection-response/outputs.md) with:
+In LimaCharlie, create a Microsoft Teams [Tailored Output](../../outputs/index.md) with:
 
 - `webhook_url`: the Teams webhook URL (from either option above)
 
@@ -340,7 +340,7 @@ To use email channels, you need an SMTP server and a LimaCharlie Tailored Output
 
 ### Create a Tailored Output
 
-In LimaCharlie, create an SMTP [Tailored Output](../../../3-detection-response/outputs.md) with:
+In LimaCharlie, create an SMTP [Tailored Output](../../outputs/index.md) with:
 
 - `dest_host`: SMTP server address, optionally with port (e.g. `smtp.example.com:587`). Defaults to port 587 if not specified.
 - `dest_email`: the recipient email address (e.g. `soc@example.com`)

--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -1,6 +1,6 @@
 # Feedback
 
-The Feedback extension enables interactive feedback requests across external channels. It sends approval/denial prompts, acknowledgement requests, or free-form questions to Slack channels or a built-in web UI, collects responses, and dispatches them to LimaCharlie subsystems (case notes via ext-cases, playbook triggers via ext-playbook).
+The Feedback extension enables interactive feedback requests across external channels. It sends approval/denial prompts, acknowledgement requests, or free-form questions to Slack, Telegram, Microsoft Teams, email, or a built-in web UI. It collects responses and dispatches them to LimaCharlie subsystems (case notes via ext-cases, playbook triggers via ext-playbook).
 
 Designed for AI-driven and human-initiated workflows where operator approval or input is required before taking an automated action. For example, a D&R rule or playbook can ask a human "Should we isolate host compromised-01?" and wait for a response before proceeding.
 
@@ -21,10 +21,13 @@ No additional configuration is required. You can immediately start configuring c
 
 A **channel** defines how feedback requests are delivered to respondents. Each channel has a name and a type. Channels are configured through the extension config (see [Channel Configuration](#channel-configuration)).
 
-| Channel Type | Description | Requirements |
-|-------------|-------------|--------------|
-| `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. No external setup needed. | None |
-| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. For question-type requests, a "Respond" button links to the web UI since Slack does not support inline text input. | A LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel` configured |
+| Channel Type | Description | In-Chat Buttons | Requirements |
+|-------------|-------------|:---------------:|--------------|
+| `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. | N/A | None |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A Slack [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel`. See [Slack Setup](#slack-setup). |
+| `telegram` | Sends a message with inline keyboard buttons to a Telegram chat via Bot API. | Yes | A Telegram [Tailored Output](../../../3-detection-response/outputs.md) with `bot_token` and `chat_id`. See [Telegram Setup](#telegram-setup). |
+| `ms_teams` | Sends an Adaptive Card to a Microsoft Teams channel via webhook. A button links to the web UI for response. | No (link to web UI) | A Microsoft Teams [Tailored Output](../../../3-detection-response/outputs.md) with `webhook_url`. See [Microsoft Teams Setup](#microsoft-teams-setup). |
+| `email` | Sends an HTML email with the question and a link to the web approval page. | No (link to web UI) | An SMTP [Tailored Output](../../../3-detection-response/outputs.md) with `dest_host`, `dest_email`, `from_email`, and SMTP credentials. See [Email Setup](#email-setup). |
 
 ### Feedback Types
 
@@ -59,7 +62,7 @@ Channels are managed through the extension config, not via extension actions. Yo
 
 === "CLI"
     ```bash
-    echo '{"data":{"channels":[{"name":"ops","channel_type":"web"},{"name":"slack-ops","channel_type":"slack","output_name":"my-slack-output"}]},"usr_mtd":{"enabled":true}}' | \
+    echo '{"data":{"channels":[{"name":"ops","channel_type":"web"},{"name":"slack-ops","channel_type":"slack","output_name":"my-slack-output"},{"name":"tg-ops","channel_type":"telegram","output_name":"my-telegram-output"},{"name":"teams-ops","channel_type":"ms_teams","output_name":"my-teams-output"},{"name":"email-ops","channel_type":"email","output_name":"my-smtp-output"}]},"usr_mtd":{"enabled":true}}' | \
       limacharlie hive set --hive-name extension_config --key ext-feedback
     ```
 
@@ -73,7 +76,18 @@ Channels are managed through the extension config, not via extension actions. Yo
       - name: slack-ops
         channel_type: slack
         output_name: my-slack-output
+      - name: tg-ops
+        channel_type: telegram
+        output_name: my-telegram-output
+      - name: teams-ops
+        channel_type: ms_teams
+        output_name: my-teams-output
+      - name: email-ops
+        channel_type: email
+        output_name: my-smtp-output
     ```
+
+For all channel types except `web`, the `output_name` field references a LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) that holds the credentials for the channel.
 
 ## Sending Feedback Requests
 
@@ -105,7 +119,7 @@ The response includes:
 }
 ```
 
-The `url` is the shareable link to the web UI where the respondent can answer. For Slack channels, no URL is returned -- the message is sent directly to the Slack channel.
+The `url` is the shareable link to the web UI where the respondent can answer. For Slack, Telegram, Microsoft Teams, and email channels, no URL is returned in the response -- the message is sent directly to the configured channel.
 
 ### Acknowledgement
 
@@ -228,6 +242,126 @@ To use Slack channels:
 
 !!! note
     For `request_question` feedback type, Slack shows a "Respond" button that links to the web UI, since Slack interactive messages do not support inline text input fields.
+
+## Telegram Setup
+
+To use Telegram channels, you need a Telegram bot and a LimaCharlie Tailored Output with its credentials.
+
+### Step 1: Create a Telegram Bot
+
+1. Open Telegram and start a conversation with [**@BotFather**](https://t.me/BotFather) ([Telegram Bot API documentation](https://core.telegram.org/bots#botfather))
+2. Send `/newbot` and follow the prompts to choose a name and username
+3. BotFather will respond with a **bot token** (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`). Save this token.
+4. Add the bot to the Telegram group or channel where you want feedback messages delivered
+5. Get the **chat ID** of the group or channel. You can do this by:
+    - Adding the bot to the group, sending a message, then checking `https://api.telegram.org/bot<TOKEN>/getUpdates` for the `chat.id` field
+    - For channels, the chat ID is typically a negative number like `-1001234567890`
+
+For more information, see the [Telegram Bot API documentation](https://core.telegram.org/bots/api).
+
+### Step 2: Create a Tailored Output
+
+In LimaCharlie, create a Telegram [Tailored Output](../../../3-detection-response/outputs.md) with:
+
+- `bot_token`: the bot token from BotFather
+- `chat_id`: the target chat, group, or channel ID
+
+### Step 3: Add a Telegram Channel
+
+Add a channel to your extension config referencing the output name:
+
+```yaml
+channels:
+  - name: tg-ops
+    channel_type: telegram
+    output_name: my-telegram-output
+```
+
+### How Telegram Responses Work
+
+For `simple_approval` and `acknowledgement` feedback types, Telegram messages include **inline keyboard buttons** (Approve/Deny or Acknowledge) that the respondent can tap directly in the chat. The response is processed immediately without leaving Telegram.
+
+For `request_question`, a "Respond" button links to the web UI since Telegram inline keyboards do not support text input.
+
+When a response is received, the original Telegram message is updated to show the choice and who responded.
+
+!!! note
+    The extension automatically registers a webhook with the Telegram bot (using [`setWebhook`](https://core.telegram.org/bots/api#setwebhook)) to receive button-click callbacks. If the bot is also used for other webhook-based integrations, the ext-feedback webhook registration will override the existing one. Use a dedicated bot for ext-feedback if this is a concern.
+
+## Microsoft Teams Setup
+
+To use Microsoft Teams channels, you need a Teams webhook URL and a LimaCharlie Tailored Output.
+
+### Option A: Incoming Webhook (simple)
+
+1. In Microsoft Teams, navigate to the channel where you want feedback messages
+2. Click the channel name, then **Connectors** (or **Manage channel** > **Connectors**)
+3. Find **Incoming Webhook** and click **Configure**
+4. Give the webhook a name (e.g. "LimaCharlie Feedback") and click **Create**
+5. Copy the webhook URL
+
+For details, see [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) in the Microsoft documentation.
+
+### Option B: Power Automate Workflow (recommended)
+
+Microsoft is transitioning from Office 365 Connectors to Power Automate Workflows. To create a workflow-based webhook:
+
+1. In the Teams channel, click **+** (Add a tab) or go to the channel settings
+2. Select **Workflows** and choose the **Post to a channel when a webhook request is received** template
+3. Follow the setup wizard to create the workflow
+4. Copy the workflow webhook URL
+
+For details, see [Create incoming webhooks with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498).
+
+### Create the Tailored Output
+
+In LimaCharlie, create a Microsoft Teams [Tailored Output](../../../3-detection-response/outputs.md) with:
+
+- `webhook_url`: the Teams webhook URL (from either option above)
+
+### Add a Teams Channel
+
+Add a channel to your extension config referencing the output name:
+
+```yaml
+channels:
+  - name: teams-ops
+    channel_type: ms_teams
+    output_name: my-teams-output
+```
+
+### How Teams Responses Work
+
+Feedback requests are delivered as [Adaptive Cards](https://learn.microsoft.com/en-us/adaptive-cards/) in the Teams channel. The card displays the question and a button that opens the web approval page in a browser. Responses are collected through the web UI.
+
+## Email Setup
+
+To use email channels, you need an SMTP server and a LimaCharlie Tailored Output with its credentials.
+
+### Create a Tailored Output
+
+In LimaCharlie, create an SMTP [Tailored Output](../../../3-detection-response/outputs.md) with:
+
+- `dest_host`: SMTP server address, optionally with port (e.g. `smtp.example.com:587`). Defaults to port 587 if not specified.
+- `dest_email`: the recipient email address (e.g. `soc@example.com`)
+- `from_email`: the sender email address (e.g. `limacharlie@example.com`)
+- `username` (optional): SMTP authentication username
+- `password` (optional): SMTP authentication password
+
+### Add an Email Channel
+
+Add a channel to your extension config referencing the output name:
+
+```yaml
+channels:
+  - name: email-ops
+    channel_type: email
+    output_name: my-smtp-output
+```
+
+### How Email Responses Work
+
+The extension sends an HTML email containing the feedback question and a **Respond** button that links to the web approval page. Responses are collected through the web UI.
 
 ## Actions Reference
 

--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -290,26 +290,20 @@ When a response is received, the original Telegram message is updated to show th
 
 ## Microsoft Teams Setup
 
-To use Microsoft Teams channels, you need a Teams webhook URL and a LimaCharlie Tailored Output.
+To use Microsoft Teams channels, you need a Teams Workflow webhook URL and a LimaCharlie Tailored Output.
 
-### Option A: Incoming Webhook (simple)
+!!! warning "Incoming Webhooks retired"
+    Microsoft retired Office 365 Connectors (including Incoming Webhooks) from Teams. You must use a Power Automate Workflow as described below.
+
+### Create a Workflow Webhook
 
 1. In Microsoft Teams, navigate to the channel where you want feedback messages
-2. Click the channel name, then **Connectors** (or **Manage channel** > **Connectors**)
-3. Find **Incoming Webhook** and click **Configure**
-4. Give the webhook a name (e.g. "LimaCharlie Feedback") and click **Create**
-5. Copy the webhook URL
-
-For details, see [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) in the Microsoft documentation.
-
-### Option B: Power Automate Workflow (recommended)
-
-Microsoft is transitioning from Office 365 Connectors to Power Automate Workflows. To create a workflow-based webhook:
-
-1. In the Teams channel, click **+** (Add a tab) or go to the channel settings
-2. Select **Workflows** and choose the **Post to a channel when a webhook request is received** template
-3. Follow the setup wizard to create the workflow
-4. Copy the workflow webhook URL
+2. Click **...** (More options) next to the channel name
+3. Select **Workflows**
+4. Search for and select the **Send webhook alerts to a channel** template
+5. Give the workflow a name (e.g. "LimaCharlie Feedback") and authenticate your account
+6. Click **Next**, confirm the Team and Channel, then click **Add workflow**
+7. Copy the webhook URL from the confirmation dialog
 
 For details, see [Create incoming webhooks with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498).
 

--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -24,10 +24,10 @@ A **channel** defines how feedback requests are delivered to respondents. Each c
 | Channel Type | Description | In-Chat Buttons | Requirements |
 |-------------|-------------|:---------------:|--------------|
 | `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. | N/A | None |
-| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A Slack [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel`. See [Slack Setup](#slack-setup). |
-| `telegram` | Sends a message with inline keyboard buttons to a Telegram chat via Bot API. | Yes | A Telegram [Tailored Output](../../../3-detection-response/outputs.md) with `bot_token` and `chat_id`. See [Telegram Setup](#telegram-setup). |
-| `ms_teams` | Sends an Adaptive Card to a Microsoft Teams channel via webhook. A button links to the web UI for response. | No (link to web UI) | A Microsoft Teams [Tailored Output](../../../3-detection-response/outputs.md) with `webhook_url`. See [Microsoft Teams Setup](#microsoft-teams-setup). |
-| `email` | Sends an HTML email with the question and a link to the web approval page. | No (link to web UI) | An SMTP [Tailored Output](../../../3-detection-response/outputs.md) with `dest_host`, `dest_email`, `from_email`, and SMTP credentials. See [Email Setup](#email-setup). |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A [Slack Tailored Output](../../outputs/destinations/slack.md) with `slack_api_token` and `slack_channel`. See [Slack Setup](#slack-setup). |
+| `telegram` | Sends a message with inline keyboard buttons to a Telegram chat via Bot API. | Yes | A [Telegram Tailored Output](../../outputs/destinations/telegram.md) with `bot_token` and `chat_id`. See [Telegram Setup](#telegram-setup). |
+| `ms_teams` | Sends an Adaptive Card to a Microsoft Teams channel via webhook. A button links to the web UI for response. | No (link to web UI) | A [Microsoft Teams Tailored Output](../../outputs/destinations/ms-teams.md) with `webhook_url`. See [Microsoft Teams Setup](#microsoft-teams-setup). |
+| `email` | Sends an HTML email with the question and a link to the web approval page. | No (link to web UI) | An [SMTP Tailored Output](../../outputs/destinations/smtp.md) with `dest_host`, `dest_email`, `from_email`, and SMTP credentials. See [Email Setup](#email-setup). |
 
 ### Feedback Types
 

--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -1,6 +1,6 @@
 # Feedback
 
-The Feedback extension enables interactive feedback requests across external channels. It sends approval/denial prompts or questions to Slack channels or a built-in web UI, collects responses, and dispatches them to LimaCharlie subsystems (case notes via ext-cases, playbook triggers via ext-playbook).
+The Feedback extension enables interactive feedback requests across external channels. It sends approval/denial prompts, acknowledgement requests, or free-form questions to Slack channels or a built-in web UI, collects responses, and dispatches them to LimaCharlie subsystems (case notes via ext-cases, playbook triggers via ext-playbook).
 
 Designed for AI-driven and human-initiated workflows where operator approval or input is required before taking an automated action. For example, a D&R rule or playbook can ask a human "Should we isolate host compromised-01?" and wait for a response before proceeding.
 
@@ -13,29 +13,32 @@ On subscription, the extension automatically:
 1. Creates a webhook adapter for the organization
 2. Installs a D&R rule that routes feedback responses to the extension for processing
 
-No additional configuration is required. You can immediately start creating channels and sending feedback requests.
+No additional configuration is required. You can immediately start configuring channels and sending feedback requests.
 
 ## Concepts
 
 ### Channels
 
-A **channel** defines how feedback requests are delivered to respondents. Each channel has a name and a type.
+A **channel** defines how feedback requests are delivered to respondents. Each channel has a name and a type. Channels are configured through the extension config (see [Channel Configuration](#channel-configuration)).
 
 | Channel Type | Description | Requirements |
 |-------------|-------------|--------------|
-| `default` | Built-in web UI. Returns a shareable URL that displays the question with response buttons. No external setup needed. | None |
-| `slack` | Sends an interactive Block Kit message to a Slack channel with Approve/Deny or Acknowledge buttons. | A LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel` configured |
+| `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. No external setup needed. | None |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. For question-type requests, a "Respond" button links to the web UI since Slack does not support inline text input. | A LimaCharlie [Tailored Output](../../../3-detection-response/outputs.md) with `slack_api_token` and `slack_channel` configured |
 
 ### Feedback Types
 
-| Feedback Type | Buttons | Response Values |
-|--------------|---------|-----------------|
-| `simple_approval` | **Approve** and **Deny** | `approved` or `denied` |
-| `question` | **Acknowledge** | `acknowledged` |
+Each feedback type has a dedicated action:
+
+| Feedback Type | Action | UI | Response Values |
+|--------------|--------|-----|-----------------|
+| `simple_approval` | `request_simple_approval` | **Approve** and **Deny** buttons | `approved` or `denied` |
+| `acknowledgement` | `request_acknowledgement` | **Acknowledge** button | `acknowledged` |
+| `question` | `request_question` | Free-form text input | `answered` + free-form `text` |
 
 ### Feedback Destinations
 
-When a respondent clicks a button, the extension dispatches the response to the configured destination:
+When a respondent answers, the extension dispatches the response to the configured destination:
 
 | Destination | Behavior |
 |-------------|----------|
@@ -46,71 +49,46 @@ When a respondent clicks a button, the extension dispatches the response to the 
 
 Each feedback request can include optional JSON data per choice. When the respondent selects a choice, the corresponding content is included in the dispatched response. This allows automation to carry structured payloads through the human decision point.
 
-For `simple_approval`, use `approved_content` and `denied_content`. For `question`, use `acknowledged_content`.
+- For `request_simple_approval`, use `approved_content` and `denied_content`.
+- For `request_acknowledgement`, use `acknowledged_content`.
+- For `request_question`, no content fields are available -- the respondent's free-form text IS the response.
 
-## Channel Management
+## Channel Configuration
 
-### Create a Channel
+Channels are managed through the extension config, not via extension actions. You can configure channels through the LimaCharlie web UI (extension settings page), via the CLI, or through infrastructure-as-code with git-sync.
 
 === "CLI"
     ```bash
-    # Default channel (web UI)
-    limacharlie extension request \
-      --name ext-feedback \
-      --action set_channel \
-      --data '{"name":"approvals","channel_type":"default"}'
-
-    # Slack channel (requires a Tailored Output with Slack credentials)
-    limacharlie extension request \
-      --name ext-feedback \
-      --action set_channel \
-      --data '{"name":"ops-slack","channel_type":"slack","output_name":"slack-ops"}'
+    echo '{"data":{"channels":[{"name":"ops","channel_type":"web"},{"name":"slack-ops","channel_type":"slack","output_name":"my-slack-output"}]},"usr_mtd":{"enabled":true}}' | \
+      limacharlie hive set --hive-name extension_config --key ext-feedback
     ```
 
-=== "D&R Rule"
+=== "Infrastructure as Code"
+    Channels can be managed via [git-sync](../../../7-infrastructure-as-code/index.md) by including the extension config in your synced repository:
     ```yaml
-    - action: extension request
-      extension name: ext-feedback
-      extension action: set_channel
-      extension request:
-        name: '{{ "approvals" }}'
-        channel_type: '{{ "default" }}'
-    ```
-
-### List Channels
-
-=== "CLI"
-    ```bash
-    limacharlie extension request \
-      --name ext-feedback \
-      --action list_channels
-    ```
-
-### Delete a Channel
-
-=== "CLI"
-    ```bash
-    limacharlie extension request \
-      --name ext-feedback \
-      --action delete_channel \
-      --data '{"name":"approvals"}'
+    # extension_config/ext-feedback
+    channels:
+      - name: ops
+        channel_type: web
+      - name: slack-ops
+        channel_type: slack
+        output_name: my-slack-output
     ```
 
 ## Sending Feedback Requests
 
-The `request_feedback` action sends a question to a channel and returns a `request_id`. When a respondent answers, the response is dispatched to the configured destination.
+### Simple Approval
 
-### Simple Approval via Default Channel
+The `request_simple_approval` action sends a question with Approve/Deny buttons.
 
 === "CLI"
     ```bash
     limacharlie extension request \
       --name ext-feedback \
-      --action request_feedback \
+      --action request_simple_approval \
       --data '{
-        "channel": "approvals",
+        "channel": "ops",
         "question": "Should we isolate host compromised-01?",
-        "feedback_type": "simple_approval",
         "feedback_destination": "case",
         "case_id": "78",
         "approved_content": "{\"action\": \"isolate\", \"sid\": \"sensor-abc\"}",
@@ -129,6 +107,43 @@ The response includes:
 
 The `url` is the shareable link to the web UI where the respondent can answer. For Slack channels, no URL is returned -- the message is sent directly to the Slack channel.
 
+### Acknowledgement
+
+The `request_acknowledgement` action sends a question with an Acknowledge button.
+
+=== "CLI"
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action request_acknowledgement \
+      --data '{
+        "channel": "ops",
+        "question": "Alert: Ransomware detected on file-server-02. Please acknowledge.",
+        "feedback_destination": "case",
+        "case_id": "92",
+        "acknowledged_content": "{\"status\": \"seen\"}"
+      }'
+    ```
+
+### Question (Free-Form Text)
+
+The `request_question` action sends a question with a text input field. The respondent types a free-form answer.
+
+=== "CLI"
+    ```bash
+    limacharlie extension request \
+      --name ext-feedback \
+      --action request_question \
+      --data '{
+        "channel": "ops",
+        "question": "What is the root cause of alert X?",
+        "feedback_destination": "playbook",
+        "playbook_name": "handle-root-cause"
+      }'
+    ```
+
+The response event includes `choice: "answered"` and a `text` field with the respondent's answer.
+
 ### D&R Rule Example
 
 A D&R rule can request human approval before taking automated action. The response is dispatched to a playbook that performs the action.
@@ -145,11 +160,10 @@ value: /usr/bin/suspicious-tool
 ```yaml
 - action: extension request
   extension name: ext-feedback
-  extension action: request_feedback
+  extension action: request_simple_approval
   extension request:
     channel: '{{ "ops-slack" }}'
     question: '{{ "Suspicious process detected on " }}{{ .routing.hostname }}{{ ". Isolate host?" }}'
-    feedback_type: '{{ "simple_approval" }}'
     feedback_destination: '{{ "playbook" }}'
     playbook_name: '{{ "isolate-host" }}'
     approved_content:
@@ -171,11 +185,10 @@ def main(lc, data):
     # Request human approval
     response = lc.extension_request(
         "ext-feedback",
-        "request_feedback",
+        "request_simple_approval",
         {
-            "channel": "approvals",
+            "channel": "ops",
             "question": f"Isolate host {data.get('hostname', 'unknown')}?",
-            "feedback_type": "simple_approval",
             "feedback_destination": "playbook",
             "playbook_name": "handle-isolation-response",
             "approved_content": json.dumps({"action": "isolate", "sid": data.get("sid")}),
@@ -192,8 +205,8 @@ def main(lc, data):
 
 1. A feedback request is created and stored with a 7-day TTL
 2. The question is delivered via the configured channel (Slack message or web URL)
-3. The respondent clicks a button
-4. The response is routed through the organization's webhook adapter
+3. The respondent clicks a button or submits a text response
+4. The response is routed through the organization's webhook adapter (authenticated via `lc-secret` header)
 5. A D&R rule matches the response event and triggers the extension's `process_response` action
 6. The extension atomically claims the request (preventing duplicate processing) and dispatches the response to the configured destination
 
@@ -211,34 +224,49 @@ To use Slack channels:
 4. In LimaCharlie, create a [Tailored Output](../../../3-detection-response/outputs.md) with:
     - `slack_api_token`: the Bot User OAuth Token
     - `slack_channel`: the target channel (e.g. `#security-ops`)
-5. Create a feedback channel referencing the output name:
-    ```bash
-    limacharlie extension request \
-      --name ext-feedback \
-      --action set_channel \
-      --data '{"name":"ops","channel_type":"slack","output_name":"my-slack-output"}'
-    ```
+5. Add a Slack channel to your extension config referencing the output name (see [Channel Configuration](#channel-configuration)). For example, a channel with `name: "ops"`, `channel_type: "slack"`, and `output_name: "my-slack-output"`.
+
+!!! note
+    For `request_question` feedback type, Slack shows a "Respond" button that links to the web UI, since Slack interactive messages do not support inline text input fields.
 
 ## Actions Reference
 
 | Action | User-facing | Description |
 |--------|:-----------:|-------------|
-| `set_channel` | Yes | Create or update a feedback channel |
-| `delete_channel` | Yes | Delete a feedback channel |
-| `list_channels` | Yes | List all feedback channels for the organization |
-| `request_feedback` | Yes | Send a feedback request to a channel |
+| `request_simple_approval` | Yes | Send a feedback request with Approve/Deny buttons |
+| `request_acknowledgement` | Yes | Send a feedback request with an Acknowledge button |
+| `request_question` | Yes | Send a question with a free-form text input |
 | `process_response` | No | Internal: processes a response received via webhook |
 
-### request_feedback Parameters
+### request_simple_approval Parameters
 
 | Parameter | Required | Description |
 |-----------|:--------:|-------------|
 | `channel` | Yes | Name of the feedback channel |
 | `question` | Yes | The question or prompt to present |
-| `feedback_type` | Yes | `simple_approval` or `question` |
 | `feedback_destination` | Yes | `case` or `playbook` |
 | `case_id` | When destination is `case` | Case to add the response note to |
 | `playbook_name` | When destination is `playbook` | Playbook to trigger with the response |
-| `approved_content` | No | JSON data included when the respondent approves (simple_approval) |
-| `denied_content` | No | JSON data included when the respondent denies (simple_approval) |
-| `acknowledged_content` | No | JSON data included when the respondent acknowledges (question) |
+| `approved_content` | No | JSON data included when the respondent approves |
+| `denied_content` | No | JSON data included when the respondent denies |
+
+### request_acknowledgement Parameters
+
+| Parameter | Required | Description |
+|-----------|:--------:|-------------|
+| `channel` | Yes | Name of the feedback channel |
+| `question` | Yes | The question or prompt to present |
+| `feedback_destination` | Yes | `case` or `playbook` |
+| `case_id` | When destination is `case` | Case to add the response note to |
+| `playbook_name` | When destination is `playbook` | Playbook to trigger with the response |
+| `acknowledged_content` | No | JSON data included when the respondent acknowledges |
+
+### request_question Parameters
+
+| Parameter | Required | Description |
+|-----------|:--------:|-------------|
+| `channel` | Yes | Name of the feedback channel |
+| `question` | Yes | The question or prompt to present |
+| `feedback_destination` | Yes | `case` or `playbook` |
+| `case_id` | When destination is `case` | Case to add the response note to |
+| `playbook_name` | When destination is `playbook` | Playbook to trigger with the response |

--- a/docs/5-integrations/outputs/destinations/ms-teams.md
+++ b/docs/5-integrations/outputs/destinations/ms-teams.md
@@ -4,36 +4,34 @@ Output detections and audit (only) to a Microsoft Teams channel via webhook.
 
 Messages are delivered as [Adaptive Cards](https://learn.microsoft.com/en-us/adaptive-cards/).
 
-* `webhook_url`: the Microsoft Teams webhook URL (Incoming Webhook or Power Automate Workflow).
+* `webhook_url`: the Microsoft Teams Workflow webhook URL.
 * `message`: (optional) a template string for custom message formatting.
 
 Example:
 
 ```
-webhook_url: https://xxxxx.webhook.office.com/webhookb2/...
+webhook_url: https://<environment-id>.<region>.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/...
 ```
 
 ## Provisioning
 
-You can connect LimaCharlie to a Teams channel using either an Incoming Webhook or a Power Automate Workflow.
+LimaCharlie connects to a Teams channel using a **Power Automate Workflow** webhook.
 
-### Option A: Incoming Webhook
+!!! warning "Incoming Webhooks retired"
+    Microsoft retired Office 365 Connectors (including Incoming Webhooks) from Teams. The old `webhook.office.com` URLs no longer work. You must use a Power Automate Workflow as described below.
+
+### Create a Workflow webhook
 
 1. In Microsoft Teams, navigate to the target channel
-2. Click the channel name, then **Connectors** (or **Manage channel** > **Connectors**)
-3. Find **Incoming Webhook** and click **Configure**
-4. Give the webhook a name (e.g. "LimaCharlie") and optionally upload an icon
-5. Click **Create** and copy the webhook URL — this is the `webhook_url` you need in LimaCharlie
-
-For details, see [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) in the Microsoft documentation.
-
-### Option B: Power Automate Workflow (recommended)
-
-Microsoft is transitioning from Office 365 Connectors to Power Automate Workflows for incoming webhooks.
-
-1. In the Teams channel, click **+** or go to channel settings
-2. Select **Workflows** and choose the **Post to a channel when a webhook request is received** template
-3. Follow the setup wizard to create the workflow
-4. Copy the workflow webhook URL — this is the `webhook_url` you need in LimaCharlie
+2. Click **...** (More options) next to the channel name
+3. Select **Workflows**
+4. Search for and select the **Send webhook alerts to a channel** template
+5. Give the workflow a name (e.g. "LimaCharlie") and authenticate your account
+6. Click **Next**, confirm the Team and Channel, then click **Add workflow**
+7. Copy the webhook URL from the confirmation dialog — this is the `webhook_url` you need in LimaCharlie
 
 For details, see [Create incoming webhooks with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498).
+
+!!! note "Workflow limitations"
+    - Workflows post via **Flow bot**, which only works in **public channels**. For shared channels, open the workflow in Power Automate and change "Post As" from Flow bot to User.
+    - Workflows are linked to the user who created them. If that user leaves the organization the workflow stops working. Add co-owners in Power Automate to avoid this.

--- a/docs/5-integrations/outputs/destinations/ms-teams.md
+++ b/docs/5-integrations/outputs/destinations/ms-teams.md
@@ -1,0 +1,39 @@
+# Microsoft Teams
+
+Output detections and audit (only) to a Microsoft Teams channel via webhook.
+
+Messages are delivered as [Adaptive Cards](https://learn.microsoft.com/en-us/adaptive-cards/).
+
+* `webhook_url`: the Microsoft Teams webhook URL (Incoming Webhook or Power Automate Workflow).
+* `message`: (optional) a template string for custom message formatting.
+
+Example:
+
+```
+webhook_url: https://xxxxx.webhook.office.com/webhookb2/...
+```
+
+## Provisioning
+
+You can connect LimaCharlie to a Teams channel using either an Incoming Webhook or a Power Automate Workflow.
+
+### Option A: Incoming Webhook
+
+1. In Microsoft Teams, navigate to the target channel
+2. Click the channel name, then **Connectors** (or **Manage channel** > **Connectors**)
+3. Find **Incoming Webhook** and click **Configure**
+4. Give the webhook a name (e.g. "LimaCharlie") and optionally upload an icon
+5. Click **Create** and copy the webhook URL — this is the `webhook_url` you need in LimaCharlie
+
+For details, see [Create Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) in the Microsoft documentation.
+
+### Option B: Power Automate Workflow (recommended)
+
+Microsoft is transitioning from Office 365 Connectors to Power Automate Workflows for incoming webhooks.
+
+1. In the Teams channel, click **+** or go to channel settings
+2. Select **Workflows** and choose the **Post to a channel when a webhook request is received** template
+3. Follow the setup wizard to create the workflow
+4. Copy the workflow webhook URL — this is the `webhook_url` you need in LimaCharlie
+
+For details, see [Create incoming webhooks with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,7 @@ nav:
               - Webhook Bulk: 5-integrations/outputs/destinations/webhook-bulk.md
               - Slack: 5-integrations/outputs/destinations/slack.md
               - Telegram: 5-integrations/outputs/destinations/telegram.md
+              - Microsoft Teams: 5-integrations/outputs/destinations/ms-teams.md
               - SMTP: 5-integrations/outputs/destinations/smtp.md
               - Apache Kafka: 5-integrations/outputs/destinations/apache-kafka.md
               - Azure Event Hub: 5-integrations/outputs/destinations/azure-event-hub.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -397,6 +397,7 @@ nav:
               - Payload Manager: 5-integrations/extensions/limacharlie/payload-manager.md
               - Sensor Cull: 5-integrations/extensions/limacharlie/sensor-cull.md
               - Cases: 5-integrations/extensions/limacharlie/cases.md
+              - Feedback: 5-integrations/extensions/limacharlie/feedback.md
           - Third Party:
               - Overview: 5-integrations/extensions/third-party/index.md
               - Velociraptor: 5-integrations/extensions/third-party/velociraptor.md


### PR DESCRIPTION
## Summary
- Add complete setup instructions for **Telegram**, **Microsoft Teams**, and **email** feedback channels
- Update channels table with all five channel types and their capabilities (in-chat buttons vs web UI link)
- Update channel configuration examples (CLI + Infrastructure as Code) to show all types
- Include links to official documentation:
  - [Telegram Bot API](https://core.telegram.org/bots/api)
  - [Telegram BotFather](https://core.telegram.org/bots#botfather)
  - [Teams Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook)
  - [Power Automate Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498)

## Test plan
- [ ] Verify docs render correctly with mkdocs
- [ ] Verify all external links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)