### PR TITLE
docs: add slack_webhook_url parameter for ext-feedback interactivity

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -24,7 +24,7 @@ A **channel** defines how feedback requests are delivered to respondents. Each c
 | Channel Type | Description | In-Chat Buttons | Requirements |
 |-------------|-------------|:---------------:|--------------|
 | `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. | N/A | None |
-| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A [Slack Tailored Output](../../outputs/destinations/slack.md) with `slack_api_token` and `slack_channel`. See [Slack Setup](#slack-setup). |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A [Slack Tailored Output](../../outputs/destinations/slack.md) with `slack_api_token`, `slack_channel`, and `slack_webhook_url`. See [Slack Setup](#slack-setup). |
 | `telegram` | Sends a message with inline keyboard buttons to a Telegram chat via Bot API. | Yes | A [Telegram Tailored Output](../../outputs/destinations/telegram.md) with `bot_token` and `chat_id`. See [Telegram Setup](#telegram-setup). |
 | `ms_teams` | Sends an Adaptive Card to a Microsoft Teams channel via webhook. A button links to the web UI for response. | No (link to web UI) | A [Microsoft Teams Tailored Output](../../outputs/destinations/ms-teams.md) with `webhook_url`. See [Microsoft Teams Setup](#microsoft-teams-setup). |
 | `email` | Sends an HTML email with the question and a link to the web approval page. | No (link to web UI) | An [SMTP Tailored Output](../../outputs/destinations/smtp.md) with `dest_host`, `dest_email`, `from_email`, and SMTP credentials. See [Email Setup](#email-setup). |
@@ -235,9 +235,10 @@ To use Slack channels:
 1. Create a Slack App with "Interactivity & Shortcuts" enabled
 2. Set the Request URL to the Slack callback endpoint: `https://feedback-system.limacharlie.io/callback/slack`
 3. Install the app to your Slack workspace and note the Bot User OAuth Token
-4. In LimaCharlie, create a [Tailored Output](../../outputs/index.md) with:
+4. In LimaCharlie, create a [Slack Tailored Output](../../outputs/destinations/slack.md) with:
     - `slack_api_token`: the Bot User OAuth Token
     - `slack_channel`: the target channel (e.g. `#security-ops`)
+    - `slack_webhook_url`: `https://feedback-system.limacharlie.io/callback/slack`
 5. Add a Slack channel to your extension config referencing the output name (see [Channel Configuration](#channel-configuration)). For example, a channel with `name: "ops"`, `channel_type: "slack"`, and `output_name: "my-slack-output"`.
 
 !!! note

--- a/docs/5-integrations/outputs/destinations/slack.md
+++ b/docs/5-integrations/outputs/destinations/slack.md
@@ -2,25 +2,45 @@
 
 Output detections and audit (only) to a Slack community and channel.
 
-* `slack_api_token`: the Slack provided API token used to authenticate.
-* `slack_channel`: the channel to output to within the community.
+* `slack_api_token`: the Bot User OAuth Token from your Slack App.
+* `slack_channel`: the channel to output to within the community (e.g. `#detections`).
+* `slack_webhook_url`: (optional) the Slack Interactivity Request URL. Required when using the output with interactive extensions like [ext-feedback](../../extensions/limacharlie/feedback.md). Set this to the callback endpoint provided by the extension (e.g. `https://feedback-system.limacharlie.io/callback/slack`).
 
 Example:
 
 ```
-slack_api_token: sample_api_token
+slack_api_token: xoxb-your-bot-token
 slack_channel: #detections
+```
+
+When used with [ext-feedback](../../extensions/limacharlie/feedback.md) for interactive messages:
+
+```
+slack_api_token: xoxb-your-bot-token
+slack_channel: #security-ops
+slack_webhook_url: https://feedback-system.limacharlie.io/callback/slack
 ```
 
 ## Provisioning
 
-To use this Output, you need to create a Slack App and Bot. This is very simple:
+To use this Output, you need to create a Slack App and Bot:
 
-1. Head over to https://api.slack.com/apps
-2. Click on "Create App" and select the workspace where it should go
-3. From the sidebar, click on OAuth & Permissions
-4. Go to the section "Bot Token Scope" and click "Add an OAuth Scope"
-5. Select the scope `chat:write`
-6. From the sidebar, click "Install App" and then "Install to Workspace"
-7. Copy token shown, this is the `slack_api_token` you need in LimaCharlie
-8. In your Slack workspace, go to the channel you want to receive messages in, and type the slash command: `/invite @limacharlie` (assuming the app name is `limacharlie`)
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
+2. Click **Create New App**, select **From scratch**, and choose the workspace
+3. From the sidebar, click **OAuth & Permissions**
+4. Under **Bot Token Scopes**, click **Add an OAuth Scope** and add `chat:write`
+5. From the sidebar, click **Install App**, then **Install to Workspace**
+6. Copy the **Bot User OAuth Token** — this is the `slack_api_token` you need in LimaCharlie
+7. In your Slack workspace, go to the target channel and invite the bot with the slash command: `/invite @your-app-name`
+
+### Interactivity Setup (for ext-feedback)
+
+If using this output with the [Feedback extension](../../extensions/limacharlie/feedback.md) for interactive Slack messages (approval buttons, acknowledgements):
+
+1. In your Slack App settings ([api.slack.com/apps](https://api.slack.com/apps)), click **Interactivity & Shortcuts** in the sidebar
+2. Toggle **Interactivity** to **On**
+3. Set the **Request URL** to `https://feedback-system.limacharlie.io/callback/slack`
+4. Click **Save Changes**
+5. In LimaCharlie, set the `slack_webhook_url` parameter on the output to the same URL: `https://feedback-system.limacharlie.io/callback/slack`
+
+This allows Slack to send button-click interactions back to the feedback extension for processing.


### PR DESCRIPTION
## Summary

- Add `slack_webhook_url` parameter to the Slack output destination docs — needed when using the output with ext-feedback for interactive Slack messages (approval buttons, acknowledgements)
- Expand Slack provisioning steps and add an Interactivity Setup subsection explaining where to configure the Request URL in the Slack App and what to set it to
- Update the ext-feedback Slack Setup to reference the new parameter and link to the Slack output destination page

## Test plan

- [ ] Verify the slack.md renders correctly with the new parameter docs and interactivity section
- [ ] Verify the feedback.md Slack channel table and Slack Setup section are consistent with the new parameter
- [ ] Confirm cross-links between slack.md and feedback.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)