### PR TITLE
docs: remove non-existent slack_webhook_url parameter

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -24,7 +24,7 @@ A **channel** defines how feedback requests are delivered to respondents. Each c
 | Channel Type | Description | In-Chat Buttons | Requirements |
 |-------------|-------------|:---------------:|--------------|
 | `web` | Built-in web UI. Returns a shareable URL that displays the question with response buttons or text input. | N/A | None |
-| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A [Slack Tailored Output](../../outputs/destinations/slack.md) with `slack_api_token`, `slack_channel`, and `slack_webhook_url`. See [Slack Setup](#slack-setup). |
+| `slack` | Sends an interactive Block Kit message to a Slack channel with action buttons. | Yes | A [Slack Tailored Output](../../outputs/destinations/slack.md) with `slack_api_token` and `slack_channel`. See [Slack Setup](#slack-setup). |
 | `telegram` | Sends a message with inline keyboard buttons to a Telegram chat via Bot API. | Yes | A [Telegram Tailored Output](../../outputs/destinations/telegram.md) with `bot_token` and `chat_id`. See [Telegram Setup](#telegram-setup). |
 | `ms_teams` | Sends an Adaptive Card to a Microsoft Teams channel via webhook. A button links to the web UI for response. | No (link to web UI) | A [Microsoft Teams Tailored Output](../../outputs/destinations/ms-teams.md) with `webhook_url`. See [Microsoft Teams Setup](#microsoft-teams-setup). |
 | `email` | Sends an HTML email with the question and a link to the web approval page. | No (link to web UI) | An [SMTP Tailored Output](../../outputs/destinations/smtp.md) with `dest_host`, `dest_email`, `from_email`, and SMTP credentials. See [Email Setup](#email-setup). |
@@ -238,7 +238,6 @@ To use Slack channels:
 4. In LimaCharlie, create a [Slack Tailored Output](../../outputs/destinations/slack.md) with:
     - `slack_api_token`: the Bot User OAuth Token
     - `slack_channel`: the target channel (e.g. `#security-ops`)
-    - `slack_webhook_url`: `https://feedback-system.limacharlie.io/callback/slack`
 5. Add a Slack channel to your extension config referencing the output name (see [Channel Configuration](#channel-configuration)). For example, a channel with `name: "ops"`, `channel_type: "slack"`, and `output_name: "my-slack-output"`.
 
 !!! note

--- a/docs/5-integrations/outputs/destinations/slack.md
+++ b/docs/5-integrations/outputs/destinations/slack.md
@@ -4,21 +4,12 @@ Output detections and audit (only) to a Slack community and channel.
 
 * `slack_api_token`: the Bot User OAuth Token from your Slack App.
 * `slack_channel`: the channel to output to within the community (e.g. `#detections`).
-* `slack_webhook_url`: (optional) the Slack Interactivity Request URL. Required when using the output with interactive extensions like [ext-feedback](../../extensions/limacharlie/feedback.md). Set this to the callback endpoint provided by the extension (e.g. `https://feedback-system.limacharlie.io/callback/slack`).
 
 Example:
 
 ```
 slack_api_token: xoxb-your-bot-token
 slack_channel: #detections
-```
-
-When used with [ext-feedback](../../extensions/limacharlie/feedback.md) for interactive messages:
-
-```
-slack_api_token: xoxb-your-bot-token
-slack_channel: #security-ops
-slack_webhook_url: https://feedback-system.limacharlie.io/callback/slack
 ```
 
 ## Provisioning
@@ -41,6 +32,5 @@ If using this output with the [Feedback extension](../../extensions/limacharlie/
 2. Toggle **Interactivity** to **On**
 3. Set the **Request URL** to `https://feedback-system.limacharlie.io/callback/slack`
 4. Click **Save Changes**
-5. In LimaCharlie, set the `slack_webhook_url` parameter on the output to the same URL: `https://feedback-system.limacharlie.io/callback/slack`
 
-This allows Slack to send button-click interactions back to the feedback extension for processing.
+This allows Slack to send button-click interactions back to the feedback extension for processing. No additional LimaCharlie output parameters are needed — the extension registers the callback automatically.


### PR DESCRIPTION
## Summary

- Remove `slack_webhook_url` from the Slack output destination docs — this parameter does not exist in the output definition. The ext-feedback extension registers the interactivity callback automatically since the URL is static.
- Remove `slack_webhook_url` from the ext-feedback channel requirements table and Slack Setup steps
- Keep the Interactivity Setup section in slack.md (steps 1-4 for configuring the Slack App) since users still need to enable interactivity on the Slack side
- Clarify that no additional LimaCharlie output parameters are needed beyond `slack_api_token` and `slack_channel`

Fixes the incorrect `slack_webhook_url` parameter added in #180.

## Test plan

- [ ] Verify slack.md no longer references `slack_webhook_url`
- [ ] Verify feedback.md Slack channel table and setup section only list `slack_api_token` and `slack_channel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)