### PR TITLE
Fix timeout_seconds in D&R examples to use raw integers

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/feedback.md
+++ b/docs/5-integrations/extensions/limacharlie/feedback.md
@@ -276,7 +276,7 @@ value: /usr/bin/suspicious-tool
     denied_content:
       action: '{{ "monitor" }}'
       sid: routing.sid
-    timeout_seconds: '{{ 300 }}'
+    timeout_seconds: 300
     timeout_choice: '{{ "denied" }}'
 ```
 

--- a/docs/5-integrations/tutorials/human-in-the-loop-response.md
+++ b/docs/5-integrations/tutorials/human-in-the-loop-response.md
@@ -137,7 +137,7 @@ The response has two actions: report the detection, and request approval via ext
       hostname: routing.hostname
       file_path: event.FILE_PATH
       action: '{{ "monitor" }}'
-    timeout_seconds: '{{ 600 }}'
+    timeout_seconds: 600
     timeout_choice: '{{ "denied" }}'
   suppression:
     max_count: 1


### PR DESCRIPTION
## Summary
- D&R extension request examples used `timeout_seconds: '{{ 300 }}'` which renders as a string, but ext-feedback schema expects an integer
- Platform rejects with `INVALID_PARAMETER - invalid value for timeout_seconds: not an integer, a string`
- Changed to raw integers (`timeout_seconds: 300` / `timeout_seconds: 600`) in two files

## Files
- `docs/5-integrations/extensions/limacharlie/feedback.md`
- `docs/5-integrations/tutorials/human-in-the-loop-response.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)