### PR TITLE
docs: fix incorrect macOS version name in Sequoia install page

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
@@ -1,6 +1,6 @@
 # macOS Agent Installation - Latest Versions (macOS 15 Sequoia and newer)
 
-This document provides details of how to install, verify, and uninstall the LimaCharlie Endpoint Agent on macOS (versions 15 Sonoma). We also offer separate documentation for older versions.
+This document provides details of how to install, verify, and uninstall the LimaCharlie Endpoint Agent on macOS (version 15 Sequoia). We also offer separate documentation for older versions.
 
 ## Installer Options
 


### PR DESCRIPTION
## Summary
- Fix typo on the macOS Sequoia install page: intro said "versions 15 Sonoma" — corrected to "version 15 Sequoia" to match the page title.

## Test plan
- [x] Verified the change in `docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)