### PR TITLE
docs: access design + verification guides for multi-org (MSSP) deployments

### DIFF
--- a/docs/7-administration/access/designing-access.md
+++ b/docs/7-administration/access/designing-access.md
@@ -77,20 +77,20 @@ Many MSSPs also create a dedicated organization used only internally (templates,
 
 ## Granting access to your internal staff
 
-Design the groups around job functions, not around customers. A typical starting set:
+Design the groups around job functions, not around customers. A typical starting set — the right-most column is the permission level you want each group to grant (matching the predefined roles you use for direct users makes the overall model easier to reason about):
 
-| Group | Members | Predefined role on included orgs |
+| Group | Members | Permission level |
 | --- | --- | --- |
-| `engineers` | Detection engineers, platform admins | `Administrator` |
-| `analysts-l2` | Senior analysts, IR leads | `Administrator` |
-| `analysts-l1` | Front-line SOC | `Operator` |
-| `read-only` | Leadership, auditors | `Viewer` |
+| `engineers` | Detection engineers, platform admins | Administrator-equivalent |
+| `analysts-l2` | Senior analysts, IR leads | Administrator-equivalent |
+| `analysts-l1` | Front-line SOC | Operator-equivalent |
+| `read-only` | Leadership, auditors | Viewer-equivalent |
 
 Workflow once the groups exist:
 
-1. **Create each group once.** `limacharlie group create` (or via the **Groups** page).
+1. **Create each group once.** `limacharlie group create --name <name>` (or via the **Groups** page).
 2. **Add every customer org** to each relevant group. `limacharlie group org-add --gid <id> --oid <customer_oid>`.
-3. **Set the group's permissions** via a predefined role — simplest and easiest to audit. Groups use the same permission set as direct users.
+3. **Set the group's permissions.** In the **Groups** page of the web app, select the permissions that match the intended permission level. Via the CLI, pass the explicit permission list: `limacharlie group permissions-set --gid <id> --permissions 'sensor.list,sensor.get,dr.list,...'`. Note that the group CLI takes a raw permission list — unlike `limacharlie user permissions set-role` for direct users, there is no single role-preset flag. Keep the list aligned with the direct-user role of the same name so effective permissions stay easy to reason about.
 4. **Add a user to exactly the group(s) matching their job.** `limacharlie group member-add --gid <id> --email <address>`.
 5. **When you onboard a new customer**, simply add the new org to each staff group (step 2). Every staff member instantly gets the right level of access on the new tenant, with no per-user work.
 
@@ -132,8 +132,8 @@ A few controls sharply reduce the risk of an access-control mistake:
 
 Once you have the architecture above in place, adding a new customer is a short, repeatable list:
 
-1. **Create the customer's organization.** The creator automatically holds `Owner` on it.
-2. **Transfer ownership to a shared internal account or designated engineer,** so access does not depend on the creator's personal account. See [Can I Transfer Ownership of an Organization?](../../8-reference/faq/account-management.md#can-i-transfer-ownership-of-an-organization).
+1. **Create the customer's organization.** The creator automatically holds the `Owner` role on it.
+2. **Grant `Owner` to a shared internal account as well,** so administrative access does not depend on the creator's personal account being available. `limacharlie --oid <customer_oid> user permissions set-role --email <shared-account> --role Owner`. A full billing/legal ownership transfer is a separate support request; see [Can I Transfer Ownership of an Organization?](../../8-reference/faq/account-management.md#can-i-transfer-ownership-of-an-organization).
 3. **Add the new org to each staff Organization Group** that should cover it (e.g. `engineers-prod`, `analysts-l1`, `read-only`). Staff access is now complete — no per-user work.
 4. **Invite the customer's designated contacts directly on the new org,** using a predefined role. Do not add them to any group.
 5. **Configure the rest of the tenant** (installation keys, adapters, D&R rules, outputs) — often from Infrastructure-as-Code templates if you have them; see [Infrastructure Extension](../../5-integrations/extensions/limacharlie/infrastructure.md).

--- a/docs/7-administration/access/designing-access.md
+++ b/docs/7-administration/access/designing-access.md
@@ -44,8 +44,8 @@ flowchart LR
     end
 
     subgraph EndUsers [End-customer users added directly]
-        U1[alice@customerA.com]
-        U2[bob@customerB.com]
+        U1[Alice - Customer A contact]
+        U2[Bob - Customer B contact]
     end
 
     GE --- C1

--- a/docs/7-administration/access/designing-access.md
+++ b/docs/7-administration/access/designing-access.md
@@ -30,39 +30,39 @@ The pattern below scales from two customers to several hundred without restructu
 
 ```mermaid
 flowchart LR
-    subgraph Staff["MSSP Staff Groups (by job function)"]
-        GE["Group: Engineers<br/>role: Administrator"]
-        GA1["Group: L1 Analysts<br/>role: Operator"]
-        GA2["Group: L2 Analysts<br/>role: Administrator"]
-        GRO["Group: Read-only / Execs<br/>role: Viewer"]
+    subgraph Staff [MSSP Staff Groups by job function]
+        GE[Engineers group<br/>Administrator-equivalent]
+        GA2[L2 Analysts group<br/>Administrator-equivalent]
+        GA1[L1 Analysts group<br/>Operator-equivalent]
+        GRO[Read-only group<br/>Viewer-equivalent]
     end
 
-    subgraph Customers["Customer Organizations (one per tenant)"]
-        C1[("Org: Customer A")]
-        C2[("Org: Customer B")]
-        C3[("Org: Customer C")]
+    subgraph Customers [Customer Organizations one per tenant]
+        C1[Customer A org]
+        C2[Customer B org]
+        C3[Customer C org]
     end
 
-    subgraph CustomerUsers["End-customer users<br/>(added DIRECTLY to their own org)"]
-        U1["alice@customerA.com"]
-        U2["bob@customerB.com"]
+    subgraph EndUsers [End-customer users added directly]
+        U1[alice@customerA.com]
+        U2[bob@customerB.com]
     end
 
     GE --- C1
     GE --- C2
     GE --- C3
-    GA1 --- C1
-    GA1 --- C2
-    GA1 --- C3
     GA2 --- C1
     GA2 --- C2
     GA2 --- C3
+    GA1 --- C1
+    GA1 --- C2
+    GA1 --- C3
     GRO --- C1
     GRO --- C2
     GRO --- C3
 
-    U1 -.direct.-> C1
-    U2 -.direct.-> C2
+    U1 -.-> C1
+    U2 -.-> C2
 ```
 
 Three rules keep this architecture coherent:

--- a/docs/7-administration/access/designing-access.md
+++ b/docs/7-administration/access/designing-access.md
@@ -1,0 +1,160 @@
+# Designing Access for Multi-Org Deployments
+
+This guide is written for administrators who operate more than a single organization — typically MSSPs, MDRs, or enterprises with multiple business units — and who need to give access to two distinct populations:
+
+- **Internal staff** (analysts, engineers, managers) who need access across *many* organizations.
+- **End customers** (or business-unit owners) who should only see their *own* organization.
+
+The mechanics of granting and verifying access are documented in [User Access](user-access.md). This page focuses on the architectural decisions that happen *before* you start clicking "Add user" — so that the access model stays safe and manageable as you grow from one customer to fifty.
+
+## Building blocks
+
+Three LimaCharlie primitives combine to form every access model:
+
+| Primitive | Scope | Typical use |
+| --- | --- | --- |
+| **Organization** | Single tenant (isolated data, sensors, billing) | One per customer / business unit |
+| **Direct user** | One user ↔ one organization | A user who should see only that single org (e.g. an end-customer contact) |
+| **Organization Group** | Set of orgs × set of users × set of permissions | A job-function bundle: everyone in the group gets the same permissions on every org in the group |
+
+Supporting primitives that reinforce the model:
+
+- **Predefined roles** (`Owner`, `Administrator`, `Operator`, `Viewer`, `Basic`) — apply a whole permission preset in one step. See [Reference: Permissions](../../8-reference/permissions.md).
+- **Organization API keys** — machine access, scoped to a specific set of permissions on a specific org. See [API Keys](api-keys.md).
+- **SSO / Strict SSO** — force users on your domain to authenticate via your IdP only. See [SSO](sso.md).
+- **Group owners vs. group members** — owners manage a group (add users, add orgs, change permissions) but the group's permissions do **not** apply to them. Members receive the permissions but cannot modify the group.
+
+## Recommended architecture for an MSSP
+
+The pattern below scales from two customers to several hundred without restructuring. Use it as the starting point and adapt as needed.
+
+```mermaid
+flowchart LR
+    subgraph Staff["MSSP Staff Groups (by job function)"]
+        GE["Group: Engineers<br/>role: Administrator"]
+        GA1["Group: L1 Analysts<br/>role: Operator"]
+        GA2["Group: L2 Analysts<br/>role: Administrator"]
+        GRO["Group: Read-only / Execs<br/>role: Viewer"]
+    end
+
+    subgraph Customers["Customer Organizations (one per tenant)"]
+        C1[("Org: Customer A")]
+        C2[("Org: Customer B")]
+        C3[("Org: Customer C")]
+    end
+
+    subgraph CustomerUsers["End-customer users<br/>(added DIRECTLY to their own org)"]
+        U1["alice@customerA.com"]
+        U2["bob@customerB.com"]
+    end
+
+    GE --- C1
+    GE --- C2
+    GE --- C3
+    GA1 --- C1
+    GA1 --- C2
+    GA1 --- C3
+    GA2 --- C1
+    GA2 --- C2
+    GA2 --- C3
+    GRO --- C1
+    GRO --- C2
+    GRO --- C3
+
+    U1 -.direct.-> C1
+    U2 -.direct.-> C2
+```
+
+Three rules keep this architecture coherent:
+
+1. **One organization per customer tenant.** Data, sensors, billing and configuration are self-contained in an organization. A customer *is* an organization. Do not mix customers inside a single org.
+2. **Your staff get access through Organization Groups, by job function.** Never add internal staff directly to a customer org — that does not scale and silently drifts over time.
+3. **Your customers get access directly on their own organization.** Never add an end-customer user to a group that spans multiple customer orgs — groups are additive, and a group that touches other customers would leak access to data the user must not see.
+
+### Optional: an internal "management" organization
+
+Many MSSPs also create a dedicated organization used only internally (templates, IaC source of truth, demo / training work). It is not a customer tenant. You can include it in a staff group, but do **not** enrol customer users in it.
+
+## Granting access to your internal staff
+
+Design the groups around job functions, not around customers. A typical starting set:
+
+| Group | Members | Predefined role on included orgs |
+| --- | --- | --- |
+| `engineers` | Detection engineers, platform admins | `Administrator` |
+| `analysts-l2` | Senior analysts, IR leads | `Administrator` |
+| `analysts-l1` | Front-line SOC | `Operator` |
+| `read-only` | Leadership, auditors | `Viewer` |
+
+Workflow once the groups exist:
+
+1. **Create each group once.** `limacharlie group create` (or via the **Groups** page).
+2. **Add every customer org** to each relevant group. `limacharlie group org-add --gid <id> --oid <customer_oid>`.
+3. **Set the group's permissions** via a predefined role — simplest and easiest to audit. Groups use the same permission set as direct users.
+4. **Add a user to exactly the group(s) matching their job.** `limacharlie group member-add --gid <id> --email <address>`.
+5. **When you onboard a new customer**, simply add the new org to each staff group (step 2). Every staff member instantly gets the right level of access on the new tenant, with no per-user work.
+
+### Separating production from non-production
+
+A very common refinement is to split a sensitive group (e.g. `engineers`) into two:
+
+- `engineers-nonprod` — includes sandbox / demo / pre-prod customer orgs.
+- `engineers-prod` — includes live customer orgs, restricted to senior staff who have signed off on your production change-control process.
+
+Membership in `engineers-prod` becomes the formal gate to production access, and is easy to audit (`limacharlie group get --id <engineers-prod>` lists members, orgs, and permissions in one response).
+
+## Granting access to your end customers
+
+End customers must stay confined to their own organization. The safe pattern is always the same:
+
+1. **Add the customer's email directly to their own org only.** `limacharlie --oid <customer_oid> user invite --email <address>`, or the **Users** page of that org.
+2. **Assign a predefined role** that matches what you agreed to in your service agreement. `limacharlie --oid <customer_oid> user permissions set-role --email <address> --role Viewer` (or `Operator`, `Administrator`, etc.).
+3. **Do not add customer users to any staff Organization Group.** A group that contains other customers' orgs would silently grant the user access to data belonging to those other customers.
+
+!!! warning "Groups are additive only"
+    Permissions granted through a group are **added** to the user's direct permissions on each included organization. A group cannot be used to *reduce* or *restrict* what a user can see. Treat "membership in a group" as "give every permission in that group, on every org in that group."
+
+If you want to give a customer access to *multiple* of their own organizations (for example, a customer with several business units), you have two clean options:
+
+- **Direct users on each org.** Simple, auditable, fine if the customer only has a handful of orgs.
+- **A customer-specific Organization Group** that contains *only* that customer's orgs and *only* that customer's users. Do not mix tenants inside a single group.
+
+## Hardening
+
+A few controls sharply reduce the risk of an access-control mistake:
+
+- **Strict SSO Enforcement on your own domain.** Forces every user authenticating as `@yourcompany.com` to go through your identity provider. Offboarding in your IdP immediately locks the user out of LimaCharlie. See [Strict SSO Enforcement](sso.md#strict-sso-enforcement).
+- **Organization API keys over user API keys.** An Organization API key is scoped to a single organization and to the minimum permissions needed by the integration. User API keys grant the same access as the user themselves across *every* organization they can reach — reserve them for interactive work only, never for production automation. See [User API Keys](api-keys.md#user-api-keys).
+- **Separate group owners from members.** An engineering manager can be an *owner* of a staff group (to add/remove members) without being a member themselves — they gain the ability to manage access without automatically having access to customer data. This is a useful separation-of-duties control.
+- **Review access on a cadence.** The companion section [Verifying and Reviewing Access](user-access.md#verifying-and-reviewing-access) shows how to enumerate every user, group, and effective permission on an organization, plus how to pull the audit trail of access changes.
+
+## New-customer onboarding checklist
+
+Once you have the architecture above in place, adding a new customer is a short, repeatable list:
+
+1. **Create the customer's organization.** The creator automatically holds `Owner` on it.
+2. **Transfer ownership to a shared internal account or designated engineer,** so access does not depend on the creator's personal account. See [Can I Transfer Ownership of an Organization?](../../8-reference/faq/account-management.md#can-i-transfer-ownership-of-an-organization).
+3. **Add the new org to each staff Organization Group** that should cover it (e.g. `engineers-prod`, `analysts-l1`, `read-only`). Staff access is now complete — no per-user work.
+4. **Invite the customer's designated contacts directly on the new org,** using a predefined role. Do not add them to any group.
+5. **Configure the rest of the tenant** (installation keys, adapters, D&R rules, outputs) — often from Infrastructure-as-Code templates if you have them; see [Infrastructure Extension](../../5-integrations/extensions/limacharlie/infrastructure.md).
+6. **Run the [verification checklist](user-access.md#suggested-validation-checklist-for-a-new-production-organization)** before declaring the tenant live.
+
+## Anti-patterns to avoid
+
+| Anti-pattern | Why it breaks | What to do instead |
+| --- | --- | --- |
+| Adding staff directly to each customer org | Does not scale, drifts, permissions diverge across orgs | Staff access only via Organization Groups, by job function |
+| Putting customer users in a multi-tenant group | Groups are additive — the user now sees every other org in the group | Direct users on the customer's own org only |
+| One huge "everyone" staff group with every permission | No separation of duties, no prod gate | Split groups by role (`Viewer`, `Operator`, `Administrator`) and by blast radius (`nonprod` vs `prod`) |
+| Using a user API key for an integration | Scopes to every org the user can reach; breaks when the user leaves | Organization API key scoped to the minimum permissions on that single org |
+| Hand-picking permissions for every user | Hard to audit, easy to drift | Use predefined roles (`set-role`) and refine only when a role genuinely does not fit |
+
+---
+
+## Related
+
+- [User Access](user-access.md) — mechanics of adding users, groups, and verifying access.
+- [Reference: Permissions](../../8-reference/permissions.md) — full permission catalogue and predefined roles.
+- [API Keys](api-keys.md) — machine access, Organization vs. User API keys.
+- [SSO](sso.md) — federated authentication and strict SSO enforcement.
+- [Security Service Providers (MSSP, MSP, MDR)](../../1-getting-started/use-cases/mssp-msp-mdr.md) — broader MSSP platform use cases.

--- a/docs/7-administration/access/user-access.md
+++ b/docs/7-administration/access/user-access.md
@@ -75,7 +75,7 @@ To review activity that has occurred in this group, click on **Activity Logs** (
 
 After creating a new organization — especially a production tenant — you will typically want to confirm, to yourself or to a system administrator, exactly who can reach the org and with which permissions. Access to an organization comes from two sources: users added **directly** to the organization, and users added via an **Organization Group** that includes the organization. A complete review must cover both.
 
-The sections below show how to answer the common questions using the web app, the `limacharlie` CLI, or both. All CLI examples assume you have selected the organization you want to inspect (either via `--oid <uuid>` or through `limacharlie auth use`).
+The sections below show how to answer the common questions using the web app, the `limacharlie` CLI, or both. All CLI examples assume you have selected the organization you want to inspect (either via `--oid <uuid>` or through `limacharlie auth use-org`).
 
 ### 1. Who has direct access to this organization?
 
@@ -126,7 +126,7 @@ For a cleaner starting point on a new production org, assign a [predefined role]
 
 ### 4. What access-related changes have been made, and by whom?
 
-Both the organization and every group maintain a tamper-evident audit trail you can use to verify that the access posture you see today is the result of intended changes.
+Both the organization and every group maintain an audit trail you can use to verify that the access posture you see today is the result of intended changes. For long-term compliance, consider also forwarding the `audit` stream to separate, append-only storage via an [Output](../../5-integrations/outputs/stream-structures.md#3-audit-stream-structure).
 
 **Organization audit log (web app):** open **Audit Logs** in the organization. Filter for user-management events to see when users were invited, removed, or had their permissions changed, and by which account.
 

--- a/docs/7-administration/access/user-access.md
+++ b/docs/7-administration/access/user-access.md
@@ -1,5 +1,8 @@
 # User Access
 
+!!! tip "Running more than one organization?"
+    If you operate multiple organizations — for example as an MSSP, MDR, or an enterprise with several business units — read [Designing Access for Multi-Org Deployments](designing-access.md) first. It explains how to structure organizations, groups, and roles so that the individual steps below compose into a safe, maintainable access model.
+
 To control who has access to an Organization, and what they have access to, go to the "Users" section of the web application.
 
 Adding users is done by email address and requires the user to already have a limacharlie.io account.

--- a/docs/7-administration/access/user-access.md
+++ b/docs/7-administration/access/user-access.md
@@ -68,4 +68,92 @@ To review activity that has occurred in this group, click on **Activity Logs** (
 
 ![](../../assets/images/image(343).png)
 
+## Verifying and Reviewing Access
+
+After creating a new organization — especially a production tenant — you will typically want to confirm, to yourself or to a system administrator, exactly who can reach the org and with which permissions. Access to an organization comes from two sources: users added **directly** to the organization, and users added via an **Organization Group** that includes the organization. A complete review must cover both.
+
+The sections below show how to answer the common questions using the web app, the `limacharlie` CLI, or both. All CLI examples assume you have selected the organization you want to inspect (either via `--oid <uuid>` or through `limacharlie auth use`).
+
+### 1. Who has direct access to this organization?
+
+**Web app:** open the organization and go to the **Users** section. Every account listed there has been added directly to the organization. Click an email to see the exact permissions granted to that user.
+
+**CLI:** list the users directly on the organization, and pull the full per-user permission map:
+
+```bash
+# Users added directly to the org
+limacharlie user list
+
+# Exact permissions for every direct user on this org
+limacharlie user permissions list
+```
+
+Cross-reference the list against the people who are *supposed* to have access. Any user who should not be there can be removed with `limacharlie user remove --email <address>` or from the **Users** section of the web app.
+
+### 2. Which groups grant access to this organization?
+
+Users can also reach the organization through Organization Groups. An org-level user review alone will not show those users — you need to review the groups as well.
+
+**Web app:** open **Groups** from the upper-right menu. Open each group you own or manage and look at the **Organizations** panel: if your new production organization appears there, every user listed in the **Users** panel of that group inherits the group's permissions on it.
+
+**CLI:** list your groups, then inspect each group's organizations, members, owners, and permissions:
+
+```bash
+# List all groups visible to you
+limacharlie group list
+
+# Inspect one group — shows orgs, members, owners, and the permissions granted
+limacharlie group get --id <group_id>
+```
+
+If the production organization appears under `orgs` for a group, every email under `members` has the permissions listed under `perms` on that organization (in addition to any direct permissions they hold).
+
+!!! note
+    The permissions granted by a group are **added** to any permissions the user already has on the organization directly. Groups can only *add* access, never subtract it — so a user who is directly over-privileged cannot be "downgraded" by a group.
+
+### 3. What effective permissions does a given user have?
+
+To confirm the final, effective permission set for a single user on a production org:
+
+1. Start with the user's direct permissions: in the web app, open **Users**, click the user, and note the checked permissions — or use `limacharlie user permissions list` and look up the user's email in the output.
+2. Then walk every group that includes this organization (see step 2 above) and note each group whose **Users** panel contains this user. Add the group's permissions to the user's direct permissions.
+3. The union of those sets is the effective access the user has on the organization.
+
+For a cleaner starting point on a new production org, assign a [predefined role](../../8-reference/permissions.md) with `limacharlie user permissions set-role --email <address> --role <Owner|Administrator|Operator|Viewer|Basic>` — this replaces any prior direct permissions for the user on that org.
+
+### 4. What access-related changes have been made, and by whom?
+
+Both the organization and every group maintain a tamper-evident audit trail you can use to verify that the access posture you see today is the result of intended changes.
+
+**Organization audit log (web app):** open **Audit Logs** in the organization. Filter for user-management events to see when users were invited, removed, or had their permissions changed, and by which account.
+
+**Organization audit log (CLI):** the `limacharlie audit list` command returns administrative events for the organization. Each entry includes `ident` (the account that performed the action), `etype` (event type), `msg`, and `ts`:
+
+```bash
+# Last 24 hours (default window)
+limacharlie audit list
+
+# Custom window — review all changes since the org was created
+limacharlie audit list --start $(date -d '2026-04-01' +%s) --end $(date +%s)
+```
+
+**Group audit log:** each Organization Group has its own activity log, reachable from **Activity Logs** in the group's left panel in the web app, or via:
+
+```bash
+limacharlie group logs --gid <group_id>
+```
+
+Use the group log to verify who added the production org to the group, who added members, and when permissions on the group were last changed.
+
+### Suggested validation checklist for a new production organization
+
+A practical sequence to hand to a system administrator when standing up a production tenant:
+
+1. **Confirm the direct user list.** `limacharlie user list` (or the **Users** page) should match the agreed list of production operators exactly. Remove anyone unexpected.
+2. **Confirm each user's permissions are intentional.** Inspect `limacharlie user permissions list` or the per-user permission modal in the web app. Prefer applying a [predefined role](../../8-reference/permissions.md) over hand-picked permissions unless you have a specific reason.
+3. **Enumerate every group the org belongs to.** Run `limacharlie group list` and `limacharlie group get --id <group_id>` for each group, and record every group whose `orgs` array contains the new org. Confirm each group's `members` and `perms` are expected.
+4. **Compute effective access per user.** For each operator, union direct permissions with permissions from every group containing the org. Confirm the result matches the documented access policy.
+5. **Review the audit trail.** Walk `limacharlie audit list` since the org was created, plus `limacharlie group logs --gid <group_id>` for each group granting access, to confirm that every user addition and permission grant was performed by an authorized administrator.
+6. **Re-run this checklist on a cadence.** Access drifts as people join and leave. The same commands can be scripted into a periodic review for ongoing compliance.
+
 In LimaCharlie, an Organization represents a tenant within the Agentic SecOps Workspace, providing a self-contained environment to manage security data, configurations, and assets independently. Each Organization has its own sensors, detection rules, data sources, and outputs, offering complete control over security operations. This structure enables flexible, multi-tenant setups, ideal for managed security providers or enterprises managing multiple departments or clients.

--- a/docs/7-administration/index.md
+++ b/docs/7-administration/index.md
@@ -12,5 +12,6 @@ Organization configuration and management.
 ## See Also
 
 - [User Access](access/user-access.md)
+- [Designing Access for Multi-Org Deployments](access/designing-access.md)
 - [API Keys](access/api-keys.md)
 - [Billing](billing/options.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -471,6 +471,7 @@ nav:
       - Access:
           - API Keys: 7-administration/access/api-keys.md
           - User Access: 7-administration/access/user-access.md
+          - Designing Access: 7-administration/access/designing-access.md
           - SSO: 7-administration/access/sso.md
       - Billing:
           - Options: 7-administration/billing/options.md


### PR DESCRIPTION
## Summary

Adds two documentation pieces, both aimed at administrators standing up new organizations (especially MSSPs / MDRs with their own end customers):

1. **New page** `7-administration/access/designing-access.md` — *Designing Access for Multi-Org Deployments*. Architectural guidance for structuring orgs, Organization Groups, and predefined roles when you have internal staff that spans many tenants and end customers that must stay confined to their own tenant. Covers the recommended architecture (with a diagram), staff-access pattern, end-customer access pattern, prod/non-prod separation, hardening (strict SSO, org API keys, group owner vs. member), a new-customer onboarding checklist, and common anti-patterns.

2. **New section** inside `7-administration/access/user-access.md` — *Verifying and Reviewing Access*. Mechanics for confirming exactly who can reach an organization and with which permissions — direct users, Organization Groups, effective per-user permissions, and the audit trail — with both web-UI and `limacharlie` CLI steps, plus a validation checklist for a production tenant.

The administration index, mkdocs nav, and the top of `user-access.md` are updated to surface the new design page.

## Context

A customer asked two related questions: how to ensure only selected members have access to a newly-created production org (answered by the *verification* section), and — especially as an MSSP — how to best architect access across their own staff plus their own customers (answered by the new *design* page).

Existing docs explained the mechanics of granting access and touched on MSSP RBAC conceptually, but did not provide either a verification playbook or an architectural design guide. These additions fill both gaps.

## Test plan

- [ ] `mkdocs serve` renders both pages; Mermaid diagram on the new page displays correctly
- [ ] Nav shows *Designing Access* under **Administration → Access**, between *User Access* and *SSO*
- [ ] All internal links resolve (`user-access.md`, `api-keys.md`, `sso.md`, `permissions.md`, `infrastructure.md`, `account-management.md`, `mssp-msp-mdr.md`)
- [ ] CLI commands shown (`limacharlie user …`, `group …`, `audit list`) match current CLI behaviour
- [ ] Admonitions (`!!! tip`, `!!! warning`, `!!! note`) render in the chosen theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)