### PR TITLE
docs(ext-cases): mark Cases extension as Public Beta

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/cases.md
+++ b/docs/5-integrations/extensions/limacharlie/cases.md
@@ -1,7 +1,7 @@
 # Cases
 
-!!! warning "Beta"
-    Cases is currently in Beta. It will change without warnings, and no backward compatibility is promised or provided.
+!!! warning "Public Beta"
+    Cases is currently in Public Beta. It will change without warnings, and no backward compatibility is promised or provided.
 
 The Cases extension is a purpose-built SOC triage system that automatically converts LimaCharlie detections into trackable cases with SLA enforcement, investigation tooling, and performance reporting. It is designed for high-volume environments where every detection needs to be acknowledged, investigated, classified, and resolved within measurable timeframes.
 


### PR DESCRIPTION
## Summary
- Update the Cases extension admonition from "Beta" to "Public Beta" to reflect its current status (no longer private beta).

## Test plan
- [x] Verified no other docs reference ext-cases as "private beta"
- [ ] Mkdocs renders the warning admonition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)