### PR TITLE
docs: add language tags to fenced code blocks (MD040)

### DIFF
--- a/docs/1-getting-started/core-concepts.md
+++ b/docs/1-getting-started/core-concepts.md
@@ -144,7 +144,7 @@ Each output stream type has a different structure. Understanding this helps you:
 
 This is the most common data transformation in LimaCharlie:
 
-```
+```text
 1. Sensor generates Event
    {routing: {...}, event: {FILE_PATH: "evil.exe", ...}}
 

--- a/docs/1-getting-started/use-cases/investigation-guide.md
+++ b/docs/1-getting-started/use-cases/investigation-guide.md
@@ -56,7 +56,7 @@ These tags follow a consistent format pattern. You define the values based on yo
 
 Use `phase:` tags chronologically to visualize attack progression through MITRE ATT&CK tactics:
 
-```
+```text
 [phase:initial-access] → [phase:execution] → [phase:persistence] → [phase:credential-access] → [phase:lateral-movement] → [phase:exfiltration]
 ```
 
@@ -128,19 +128,19 @@ Document how entities were discovered and validated in the `context` field:
 
 **For IPs:**
 
-```
+```text
 Provenance: [discovered in which event type]. Geo: [country/ASN]. TI: [threat intel match]. Historical: [seen before in org?].
 ```
 
 **For Hashes:**
 
-```
+```text
 Provenance: [file name and path]. AV: [detection ratio]. Sandbox: [behavior summary]. First seen: [date].
 ```
 
 **For Domains:**
 
-```
+```text
 Provenance: [DNS query or URL]. Registration: [age, registrar]. TI: [threat intel match]. Resolution: [IP addresses].
 ```
 
@@ -154,7 +154,7 @@ Use structured note types for consistent documentation:
 
 Record raw facts without interpretation:
 
-```
+```text
 [TIMESTAMP] [HOST] [EVENT_TYPE]
 Observed: [description of what was seen]
 Key data: [relevant field values]
@@ -165,7 +165,7 @@ Related atoms: [list of event atoms]
 
 Document working theories:
 
-```
+```text
 HYPOTHESIS: [statement]
 
 Supporting evidence:
@@ -184,7 +184,7 @@ Alternative explanations:
 
 Document confirmed discoveries:
 
-```
+```text
 FINDING: [definitive statement]
 
 Evidence:
@@ -202,7 +202,7 @@ Confidence: [high/medium/low]
 
 Document the full attack narrative:
 
-```
+```text
 ATTACK CHAIN:
 [Phase 1] → [Phase 2] → [Phase 3] → ...
 
@@ -253,14 +253,14 @@ Defense gaps: [what failed]
 
 Write for non-technical stakeholders:
 
-```
+```text
 On [date], [attack type] was detected on [target]. The attacker [brief action summary].
 Impact: [what was affected]. Status: [current state]. Attribution: [if known].
 ```
 
 **Example:**
 
-```
+```text
 On November 15, 2024, a targeted spearphishing attack compromised a Finance department workstation.
 The attacker harvested credentials and moved laterally to 15 servers, exfiltrating approximately 50GB
 of financial data over 72 hours. Containment was achieved by isolating affected systems.
@@ -271,7 +271,7 @@ Attribution: Financially-motivated actor (medium confidence).
 
 Document technical determination:
 
-```
+```text
 CLASSIFICATION: [true positive/false positive] - [incident type]
 ROOT CAUSE: [initial access method]
 ATTRIBUTION: [threat actor/campaign] ([confidence level])

--- a/docs/2-sensors-deployment/adapters/as-a-service.md
+++ b/docs/2-sensors-deployment/adapters/as-a-service.md
@@ -67,7 +67,7 @@ WantedBy=multi-user.target
 
 Your adapter command may differ depending on your use case--this is an example of a [file](types/file.md) adapter to ingest logs from a JSON file.
 
-```
+```bash
 /path/to/adapter-directory/lc-adapter file file_path=/path/to/logs.json client_options.identity.installation_key=<INSTALLATION KEY> client_options.identity.oid=<ORG ID> client_options.platform=json client_options.sensor_seed_key=<SENSOR SEED KEY> client_options.mapping.event_type_path=<EVENT TYPE FIELD> client_options.hostname=<HOSTNAME>
 ```
 

--- a/docs/2-sensors-deployment/adapters/tutorials/google-cloud-logs.md
+++ b/docs/2-sensors-deployment/adapters/tutorials/google-cloud-logs.md
@@ -39,7 +39,7 @@ Click the Preview Logs button in the top right to be taken to the main logging i
 
 For this example, let's use the following log filter:
 
-```
+```text
 logName:cloudaudit.googleapis.com
 protoPayload.serviceName!="k8s.io"
 protoPayload.serviceName!="compute.googleapis.com"

--- a/docs/2-sensors-deployment/adapters/tutorials/otel-webhook.md
+++ b/docs/2-sensors-deployment/adapters/tutorials/otel-webhook.md
@@ -10,7 +10,7 @@ OpenTelemetry SDKs and collectors export telemetry by sending HTTP POST requests
 
 The URL pattern is:
 
-```
+```text
 https://<hook-domain>/<OID>/<HOOKNAME>/<SECRET>/v1/<signal>
 ```
 
@@ -67,7 +67,7 @@ limacharlie org urls
 
 This returns a domain like `9157798c50af372c.hook.limacharlie.io`. Your full OTLP base endpoint is:
 
-```
+```text
 https://9157798c50af372c.hook.limacharlie.io/<OID>/otel-hook/my-otel-secret
 ```
 

--- a/docs/2-sensors-deployment/adapters/types/sentinelone.md
+++ b/docs/2-sensors-deployment/adapters/types/sentinelone.md
@@ -20,7 +20,7 @@ Adapter Type: `sentinel_one`
 - `start_time` - optional start time to fetch past events.
 - `urls` - Advanced, CLI only: a comma-separated list of REST API paths to scrub. If omitted, by default the adapter brings activities, alerts, and threats:
 
-  ```
+  ```text
   /web/api/v2.1/activities,
   /web/api/v2.1/cloud-detection/alerts,
   /web/api/v2.1/threats

--- a/docs/2-sensors-deployment/adapters/types/sophos.md
+++ b/docs/2-sensors-deployment/adapters/types/sophos.md
@@ -30,7 +30,7 @@ Sophos documentation - <https://developer.sophos.com/getting-started-tenant>
 2. Get your client ID and client secret from the credentials you just created
 3. Get your JWT -- be sure to replace the values with the client ID and secret from the last step
 
-   ```
+   ```bash
    curl -XPOST -H "Content-Type:application/x-www-form-urlencoded" -d "grant_type=client_credentials&client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET&scope=token" https://id.sophos.com/api/v2/oauth2/token
    ```
 
@@ -50,7 +50,7 @@ Sophos documentation - <https://developer.sophos.com/getting-started-tenant>
 
 4. Get your tenant ID -- you will need the `access_token` (JWT) from the last step.
 
-   ```
+   ```bash
    curl -XGET -H "Authorization: Bearer YOUR_JWT_HERE" https://api.central.sophos.com/whoami/v1
    ```
 

--- a/docs/2-sensors-deployment/adapters/types/syslog.md
+++ b/docs/2-sensors-deployment/adapters/types/syslog.md
@@ -58,7 +58,7 @@ Here's a breakdown of the above example:
 
 To test it, assuming we're on the same Debian box as the container, pipe the syslog to the container:
 
-```
+```text
 journalctl -f -q | netcat 127.0.0.1 1514
 ```
 
@@ -106,7 +106,7 @@ syslog:
 
 This step will depend on the type of syslog daemon you are using (syslog, rsyslog, syslog-ng, etc.) Within the daemon configuration file, configure the desired facility(-ies) to direct to the local listener. In the following example, we configured `auth` and `authpriv` events to write to both `/var/log/audit.log` and `127.0.0.1:1514`.
 
-```
+```text
 auth,authpriv.*   /var/log/auth.log
 auth,authpriv.*   @@127.0.0.1:1514
 ```
@@ -117,7 +117,7 @@ After applying the appropriate configuration, restart the syslog daemon.
 
 Utilizing a tool like `netcat`, you can listen on the appropriate port to confirm that messages are being sent. The following command will spawn a `netcat` listener on port 1514:
 
-```
+```text
 nc -l -p 1514
 ```
 
@@ -125,7 +125,7 @@ nc -l -p 1514
 
 Execute the binary Adapter with the syslog configuration file in order to start the LimaCharlie listener. If started correctly, you should see the following messages in `stdout`:
 
-```
+```text
 DBG <date>: usp-client connecting
 DBG <date>: usp-client connected
 DBG <date>: listening for connections on :1514

--- a/docs/2-sensors-deployment/adapters/types/windows-event-log.md
+++ b/docs/2-sensors-deployment/adapters/types/windows-event-log.md
@@ -40,25 +40,25 @@ wel:
 
 Security Events (High Priority):
 
-```
+```text
   Security:'*[System[(Level=1 or Level=2 or Level=3)]]'
 ```
 
 Logon Events Only:
 
-```
+```text
   Security:'*[System[(EventID=4624 or EventID=4625 or EventID=4634)]]'
 ```
 
 System Errors:
 
-```
+```text
   System:'*[System[(Level=1 or Level=2)]]'
 ```
 
 Specific Provider:
 
-```
+```text
   Application:'*[System[Provider[@Name="Microsoft-Windows-ApplicationError"]]]'
 ```
 

--- a/docs/2-sensors-deployment/adapters/usage.md
+++ b/docs/2-sensors-deployment/adapters/usage.md
@@ -369,7 +369,7 @@ index_type: user
 
 Put together in a client option, you could have:
 
-```json
+```text
 {
   "client_options": {
     ...,

--- a/docs/2-sensors-deployment/adapters/usage.md
+++ b/docs/2-sensors-deployment/adapters/usage.md
@@ -15,7 +15,7 @@ Configurations can be provided to the adapter in one of three ways:
 
 Here's an example config as a config file for an adapter using the `file` method of collection:
 
-```
+```yaml
 file: // The root of the config is the adapter collection method.
   client_options:
     identity:
@@ -188,7 +188,7 @@ LimaCharlie includes standard Grok patterns for common data types:
 
 **Example Firewall Log Record:**
 
-```
+```text
 2024-01-01 12:00:00 ACCEPT TCP 192.168.1.100:54321 10.0.0.5:443 packets=1 bytes=78
 ```
 
@@ -249,19 +249,19 @@ The timezone must be a valid [IANA timezone name](https://en.wikipedia.org/wiki/
 
 **With this log line as an example:**
 
-```
+```text
 Nov 09 10:57:09 penguin PackageKit[21212]: daemon quit
 ```
 
 **you could apply the following regular expression as** `parsing_re`**:**
 
-```
+```text
 (?P<date>... \d\d \d\d:\d\d:\d\d) (?P<host>.+) (?P<exe>.+?)\[(?P<pid>\d+)\]: (?P<msg>.*)
 ```
 
 which would result in the following event in LimaCharlie:
 
-```
+```json
 {
   "date": "Nov 09 10:57:09",
   "host": "penguin",
@@ -275,19 +275,19 @@ which would result in the following event in LimaCharlie:
 
 Alternatively you can specify a regular expression that does NOT contain Named Groups, like this:
 
-```
+```text
 (?:<\d+>\s*)?(\w+)=(".*?"|\S+)
 ```
 
 When in this mode, LimaCharlie assumes the regular expression will generate a list of matches where each match has 2 submatches, and submatch index 1 is the Key name, and submatch index 2 is the value. This is compatible with logs like CEF for example where the log could look like:
 
-```
+```text
 <20>hostname=my-host log_name=http_logs timestamp=....
 ```
 
 which would end up generating:
 
-```
+```json
 {
   "hostname" : "my-host",
   "log_name": "http_logs",
@@ -311,7 +311,7 @@ This process is done by specifying the "path" to the relevant field in the JSON 
 
 For example, using this event:
 
-```
+```json
 {
   "a": "x",
   "b": "y",
@@ -360,7 +360,7 @@ An index descriptor can have the following fields:
 
 Here is an example of a simple index descriptor:
 
-```
+```yaml
 events_included:
   - PutObject
 path: userAgent
@@ -369,7 +369,7 @@ index_type: user
 
 Put together in a client option, you could have:
 
-```
+```json
 {
   "client_options": {
     ...,
@@ -455,7 +455,7 @@ Exit codes:
 
 Example successful output:
 
-```
+```text
 starting
 loading config from file: config.yaml
 found 1 configs to run
@@ -478,7 +478,7 @@ Event 1:
 
 Example error output when no events are parsed (e.g., regex doesn't match):
 
-```
+```text
 starting
 loading config from file: config.yaml
 found 1 configs to run

--- a/docs/2-sensors-deployment/endpoint-agent/docker/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/docker/installation.md
@@ -102,7 +102,7 @@ services:
 
 To start the container, run:
 
-```
+```bash
 docker-compose up -d
 ```
 

--- a/docs/2-sensors-deployment/endpoint-agent/hostname-resolution.md
+++ b/docs/2-sensors-deployment/endpoint-agent/hostname-resolution.md
@@ -15,7 +15,7 @@ This method allows the endpoint agent to better resolve its hostname in large en
 
 In some environments the reverse DNS lookup is undesirable (for example, when it is slow, unreliable, or returns a hostname that is not meaningful for the deployment). The reverse DNS step can be disabled by setting the following environment variable on the host before the Endpoint Agent starts:
 
-```
+```text
 LC_DISABLE_REVERSE_DNS_HOSTNAME=1
 ```
 

--- a/docs/2-sensors-deployment/endpoint-agent/macos/installation-older.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/installation-older.md
@@ -6,7 +6,7 @@ This document provides details of how to install, verify, and uninstall the Lima
 
 When running the installer from the command line, you can pass the following arguments:
 
-```
+```text
 -v: display build version.
 -q: quiet; do not display banner.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.

--- a/docs/2-sensors-deployment/endpoint-agent/macos/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/installation.md
@@ -6,7 +6,7 @@ This document provides details of how to install, verify, and uninstall the Lima
 
 When running the installer from the command line, you can pass the following arguments:
 
-```
+```text
 -v: display build version.
 -q: quiet; do not display banner.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.

--- a/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
@@ -6,7 +6,7 @@ This document provides details of how to install, verify, and uninstall the Lima
 
 When running the installer from the command line, you can pass the following arguments:
 
-```
+```text
 -v: display build version.
 -q: quiet; do not display banner.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.

--- a/docs/2-sensors-deployment/endpoint-agent/vdi/templates.md
+++ b/docs/2-sensors-deployment/endpoint-agent/vdi/templates.md
@@ -23,7 +23,7 @@ A shortcut for creating this file is to invoke the LimaCharlie EDR binary (like 
 
 Example `hcp_vdi.dat` file content:
 
-```
+```text
 1696882542
 ```
 

--- a/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
@@ -264,7 +264,7 @@ Get-Service rphcpsvc | Select-Object Name, Status, StartType
 
 Expected output:
 
-```
+```text
 Name     Status StartType
 ----     ------ ---------
 rphcpsvc Running Automatic
@@ -274,7 +274,7 @@ rphcpsvc Running Automatic
 
 Run this command:
 
-```
+```text
 sc query rphcpsvc
 ```
 
@@ -364,7 +364,7 @@ Run the installer with the clean uninstall flag:
 
 rphcp.exe -c
 
-```
+```text
 
 This removes the service and deletes all identity files.
 
@@ -374,7 +374,7 @@ To uninstall but keep identity files (for potential reinstallation):
 
 rphcp.exe -r
 
-```
+```text
 
 ### Using the MSI
 
@@ -388,7 +388,7 @@ Or via command line:
 
 msiexec /x "path\to\installer.msi" /qn
 
-```
+```text
 
 ### Using LimaCharlie Console
 

--- a/docs/4-data-queries/template-strings.md
+++ b/docs/4-data-queries/template-strings.md
@@ -69,7 +69,7 @@ For example, if we had the following data:
 
 And we wanted to rename the `d` value to `c` on ingestion, remove the d value, and add a field called `hostname`, we could use the following configuration:
 
-```
+```text
 ...
    client_options:
      mapping:

--- a/docs/4-data-queries/template-transforms.md
+++ b/docs/4-data-queries/template-transforms.md
@@ -69,7 +69,7 @@ For example, if we had the following data:
 
 And we wanted to rename the `d` value to `c` on ingestion, remove the d value, and add a field called `hostname`, we could use the following configuration:
 
-```
+```text
 ...
    client_options:
      mapping:

--- a/docs/4-data-queries/tutorials/bigquery-looker-studio.md
+++ b/docs/4-data-queries/tutorials/bigquery-looker-studio.md
@@ -10,7 +10,7 @@ Within your project of choice, begin by creating a new dataset. For the purposes
 
 Let's examine this hierarchy for a moment:
 
-```
+```text
 ├── limacharlie-bq-testing    # project
 │   ├── windows_process_details    # dataset
 │   │   ├── network_connections    # table

--- a/docs/5-integrations/api-integrations/pangea.md
+++ b/docs/5-integrations/api-integrations/pangea.md
@@ -25,13 +25,13 @@ The Pangea API key (known as a token within the Pangea platform) is added via th
 
 The API key follows this format:
 
-```
+```text
 domain/token
 ```
 
 Example:
 
-```
+```text
 aws.us.pangea.cloud/pts_7kb33fyz313372vuu5zgnotarealtoken
 ```
 

--- a/docs/5-integrations/extensions/cloud-cli/1password.md
+++ b/docs/5-integrations/extensions/cloud-cli/1password.md
@@ -28,6 +28,6 @@ To utilize 1Password's automated CLI capabilities, you will need to create and u
 
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 serviceAccountToken
 ```

--- a/docs/5-integrations/extensions/cloud-cli/aws.md
+++ b/docs/5-integrations/extensions/cloud-cli/aws.md
@@ -31,7 +31,7 @@ To utilize AWS CLI capabilities, you will need:
 - You will need an AWS access key ID and AWS secret access key
 - Create a secret in the secrets manager in the following format:
 
-  ```
+  ```text
   accessKeyID/secretAccessKey
   ```
 

--- a/docs/5-integrations/extensions/cloud-cli/azure.md
+++ b/docs/5-integrations/extensions/cloud-cli/azure.md
@@ -25,6 +25,6 @@ To utilize the Azure CLI, you will need:
 - An application and a [service principal](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal) with the appropriate permissions and a [client secret](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#option-3-create-a-new-client-secret)
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 appID/clientSecret/tenantID
 ```

--- a/docs/5-integrations/extensions/cloud-cli/digitalocean.md
+++ b/docs/5-integrations/extensions/cloud-cli/digitalocean.md
@@ -25,6 +25,6 @@ To utilize `doctl` capabilities, you will need:
 - A personal access token. More information on this can be found [here](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
 - Create a secret in the secrets manager in the following format:
 
-  ```
+  ```text
   personalAccessToken
   ```

--- a/docs/5-integrations/extensions/cloud-cli/github.md
+++ b/docs/5-integrations/extensions/cloud-cli/github.md
@@ -25,6 +25,6 @@ To utilize the GitHub CLI, you will need:
 - A [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 access_token
 ```

--- a/docs/5-integrations/extensions/cloud-cli/microsoft365.md
+++ b/docs/5-integrations/extensions/cloud-cli/microsoft365.md
@@ -31,6 +31,6 @@ The following example disables the user account with the provided user ID.
 - Upon invocation, LimaCharlie will first run the `m365 login` command with the credentials provided.
 - Create a secret in the secrets manager in the following format:
 
-  ```
+  ```text
   appID/clientSecret/tenantID
   ```

--- a/docs/5-integrations/extensions/cloud-cli/okta.md
+++ b/docs/5-integrations/extensions/cloud-cli/okta.md
@@ -25,7 +25,7 @@ To make use of the Okta CLI, you will need:
 - An API key. More information about provisioning an API key can be found [here](https://developer.okta.com/docs/guides/create-an-api-token/main/).
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 okta_domain/api_key
 ```
 
@@ -39,13 +39,13 @@ Fetches a user from your Okta organization.
 
 #### Command
 
-```
+```bash
 user get USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user get 00untroxqpl08VcNC5d7
 ```
 
@@ -108,13 +108,13 @@ Lists users that do not have a status of "DEPROVISIONED" (by default), up to the
 
 #### Command
 
-```
+```bash
 user list OPTIONAL_FILTER
 ```
 
 #### Example Input
 
-```
+```bash
 user list
 ```
 
@@ -165,19 +165,19 @@ Deactivates a user.
 
 #### Command
 
-```
+```bash
 user deactivate USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user deactivate 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```
 
@@ -189,19 +189,19 @@ Activates a user.
 
 #### Command
 
-```
+```bash
 user activate USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user activate 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```
 
@@ -211,19 +211,19 @@ This operation transitions the user to the status of "PASSWORD\_EXPIRED" so that
 
 #### Command
 
-```
+```bash
 user expire-password USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user expire-password 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```
 
@@ -235,19 +235,19 @@ Suspends a user. The user will have a status of "SUSPENDED" when the process is 
 
 #### Command
 
-```
+```bash
 user suspend USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user suspend 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```
 
@@ -259,19 +259,19 @@ Unsuspends a user and returns them to the "ACTIVE" state. This operation can onl
 
 #### Command
 
-```
+```bash
 user unsuspend USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user unsuspend 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```
 
@@ -281,18 +281,18 @@ Unlocks a user with a "LOCKED\_OUT" status and returns them to "ACTIVE" status. 
 
 #### Command
 
-```
+```bash
 user unlock USERID
 ```
 
 #### Example Input
 
-```
+```bash
 user unlock 00up0nl0lftw7331WSz
 ```
 
 #### Example Output
 
-```
+```text
 None
 ```

--- a/docs/5-integrations/extensions/cloud-cli/sdm.md
+++ b/docs/5-integrations/extensions/cloud-cli/sdm.md
@@ -25,6 +25,6 @@ To utilize StrongDM's CLI capabilities, you will need:
 - An admin or service account token. More information on provisioning this token can be found [here](https://www.strongdm.com/docs/admin/tokens-and-keys/).
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 token
 ```

--- a/docs/5-integrations/extensions/cloud-cli/sublime.md
+++ b/docs/5-integrations/extensions/cloud-cli/sublime.md
@@ -25,6 +25,6 @@ To utilize Sublime's CLI capabilities, you will need:
 - You will need an API key. More information about provisioning an API key can be found [here](https://docs.sublimesecurity.com/reference/authentication).
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 api_key
 ```

--- a/docs/5-integrations/extensions/cloud-cli/tailscale.md
+++ b/docs/5-integrations/extensions/cloud-cli/tailscale.md
@@ -25,7 +25,7 @@ To utilize Tailscale's CLI capabilities, you will need:
 - An [auth key](https://tailscale.com/kb/1085/auth-keys)
 - Create a secret in the secrets manager in the following format:
 
-```
+```text
 authKey
 ```
 

--- a/docs/5-integrations/extensions/cloud-cli/vultr.md
+++ b/docs/5-integrations/extensions/cloud-cli/vultr.md
@@ -27,6 +27,6 @@ To utilize `vultr-cli` capabilities, you will need:
   <!-- Screenshot of Vultr access control settings was unavailable during migration from document360 -->
 - Create a secret in the secrets manager in the following format:
 
-  ```
+  ```text
   personalAccessToken
   ```

--- a/docs/5-integrations/extensions/labs/playbook.md
+++ b/docs/5-integrations/extensions/labs/playbook.md
@@ -218,7 +218,7 @@ Custom packages and execution environment tweaks are not available in self-serve
 
 Example:
 
-```
+```yaml
 hives:
     playbook:
         my-playbook:

--- a/docs/5-integrations/extensions/limacharlie/epp.md
+++ b/docs/5-integrations/extensions/limacharlie/epp.md
@@ -72,7 +72,7 @@ Select a Windows Sensor. Open the Sensor Console As you type "epp" you'll see th
 >
 > The EPP solution relies on some new events. They are now defaults, and the extension adds them to existing orgs. In rare case you may need to add them manually to Sensor / Event Collection / Event Collection or your Infra As Code. Here is the list:
 >
-> ```
+> ```text
 > EPP_STATUS_REP,EPP_LIST_EXCLUSIONS_REP,EPP_ADD_EXCLUSION_REP,EPP_REM_EXCLUSION_REP,
 > EPP_LIST_QUARANTINE_REP,EPP_SCAN_REP
 > ```

--- a/docs/5-integrations/extensions/limacharlie/exfil.md
+++ b/docs/5-integrations/extensions/limacharlie/exfil.md
@@ -33,7 +33,7 @@ There are three rule options within the Exfil extension:
 
 A sample **Watch Rule** might be
 
-```
+```text
 Event: MODULE_LOAD
 Path: FILE_PATH
 Operator: ends with

--- a/docs/5-integrations/extensions/limacharlie/git-sync.md
+++ b/docs/5-integrations/extensions/limacharlie/git-sync.md
@@ -33,7 +33,7 @@ Assuming you have an empty git repository, you can configure the extension to ex
 
 For applying org configs from a git repository, the repo must adhere to the following structure. The root of the repository must contain an `orgs` directory with `[org-id]` child directories, each containing an `index.yaml` .
 
-```
+```text
 .
 └── orgs [required]
     └── a326700d-3cd7-49d1-ad08-20b396d8549d [required]
@@ -44,7 +44,7 @@ The `index.yaml` determines which other files in the repo are included in the co
 
 For instance, assume all of the configurations for this org were unique to this org and could be nested inside of the org's directory.
 
-```
+```text
 .
 └── orgs
     └── a326700d-3cd7-49d1-ad08-20b396d8549d
@@ -93,7 +93,7 @@ include:
 
 Now, assume you have a global rule set you want to apply across many orgs. You could structure the repo similar to the example below.
 
-```
+```text
 .
 ├── hives
 │   ├── dr-general.yaml
@@ -120,7 +120,7 @@ include:
 
 Configuration exports will be placed in a separate `exports` subdirectory to avoid overwriting configurations that are pushed across multiple organizations.
 
-```
+```text
 .
 └── exports
     └── orgs

--- a/docs/5-integrations/extensions/third-party/plaso.md
+++ b/docs/5-integrations/extensions/third-party/plaso.md
@@ -139,7 +139,7 @@ Running the extension generates the following useful outputs:
   - Pay close attention to fields such as `warnings_by_parser` or `warnings_by_path_spec` which may reveal parser errors that were encountered.
   - Sample output of `pinfo` showing counts of parsed artifacts nested under `storage_counters` -- this provides insight as to which, and how many events will be present in your CSV timeline.
 
-```
+```text
 "amcache": 986,
 "appcompatcache": 4096,
 "bagmru": 29,

--- a/docs/5-integrations/extensions/third-party/renigma.md
+++ b/docs/5-integrations/extensions/third-party/renigma.md
@@ -28,7 +28,7 @@ You can submit a file or URL to the REnigma extension for processing in one of 2
 
    1. Detect:
 
-      ```
+      ```yaml
       event: ingest
       op: exists
       path: /

--- a/docs/5-integrations/extensions/third-party/velociraptor.md
+++ b/docs/5-integrations/extensions/third-party/velociraptor.md
@@ -41,7 +41,7 @@ These are optional arguments (or parameters) passed directly to the Velociraptor
 
 For example, to run a [Linux.Triage.UAC](https://triage.velocidex.com/docs/linux.triage.uac/) collection targeting all categories, specify:
 
-```
+```text
 "Targets=[\"_All\"]"
 ```
 

--- a/docs/5-integrations/extensions/third-party/zeek.md
+++ b/docs/5-integrations/extensions/third-party/zeek.md
@@ -39,7 +39,7 @@ target: artifact_event
 
 ## Results
 
-```
+```text
 /opt/zeek/bin/zeek -C LogAscii::use_json=T --no-checksums --readfile /path/to/your.pcap
 ```
 
@@ -67,7 +67,7 @@ All PCAPs uploaded will trigger the [D&R rule below](#dr-rule).
 
 If you have already generated a PCAP on a system or systems, you can manually ingest those as artifacts by running the following in your sensor console:
 
-```
+```text
 artifact_get --file /path/to/your.pcap --type pcap
 ```
 

--- a/docs/5-integrations/outputs/destinations/amazon-s3.md
+++ b/docs/5-integrations/outputs/destinations/amazon-s3.md
@@ -17,7 +17,7 @@ If you have your own visualization stack, or you just need the data archived, yo
 
 Example:
 
-```
+```text
 bucket: my-bucket-name
 key_id: AKIAABCDEHPUXHHHHSSQ
 secret_key: fonsjifnidn8anf4fh74y3yr34gf3hrhgh8er

--- a/docs/5-integrations/outputs/destinations/apache-kafka.md
+++ b/docs/5-integrations/outputs/destinations/apache-kafka.md
@@ -14,7 +14,7 @@ Output events and detections to a Kafka target.
 
 Example:
 
-```
+```text
 dest_host: kafka.corp.com
 is_tls: "true"
 is_strict_tls: "true"

--- a/docs/5-integrations/outputs/destinations/azure-event-hub.md
+++ b/docs/5-integrations/outputs/destinations/azure-event-hub.md
@@ -8,7 +8,7 @@ Note that the connection string should end with `;EntityPath=your-hub-name` whic
 
 Example:
 
-```
+```text
 connection_string: Endpoint=sb://lc-test.servicebus.windows.net/;SharedAccessKeyName=lc;SharedAccessKey=jidnfisnjfnsdnfdnfjd=;EntityPath=test-hub
 ```
 

--- a/docs/5-integrations/outputs/destinations/azure-storage-blob.md
+++ b/docs/5-integrations/outputs/destinations/azure-storage-blob.md
@@ -8,7 +8,7 @@ Output events and detections to a Blob Container in Azure Storage Blobs.
 
 Example:
 
-```
+```text
 blob_container: testlcdatabucket
 account_name: lctestdata
 secret_key: dkndsgnlngfdlgfd

--- a/docs/5-integrations/outputs/destinations/bigquery.md
+++ b/docs/5-integrations/outputs/destinations/bigquery.md
@@ -14,7 +14,7 @@ For a practical use case of this output, see this [tutorial on pushing Velocirap
 
 Example:
 
-```
+```text
 schema: event_type:STRING, oid:STRING, sid:STRING
 table: alerts
 dataset: limacharlie_data

--- a/docs/5-integrations/outputs/destinations/elastic.md
+++ b/docs/5-integrations/outputs/destinations/elastic.md
@@ -11,7 +11,7 @@ Output events and detections to [Elastic](https://www.elastic.co/).
 
 Example:
 
-```
+```text
 addresses: 11.10.10.11,11.10.11.11
 username: some
 password: pass1234

--- a/docs/5-integrations/outputs/destinations/google-cloud-storage.md
+++ b/docs/5-integrations/outputs/destinations/google-cloud-storage.md
@@ -15,7 +15,7 @@ If you already use Google Chronicle, we make it easy to send telemetry you've co
 
 Example:
 
-```
+```text
 bucket: my-bucket-name
 secret_key: {
   "type": "service_account",

--- a/docs/5-integrations/outputs/destinations/google-pubsub.md
+++ b/docs/5-integrations/outputs/destinations/google-pubsub.md
@@ -8,7 +8,7 @@ Output events and detections to a Pubsub topic.
 
 Example:
 
-```
+```text
 project: my-project
 topic: telemetry
 secret_key: {

--- a/docs/5-integrations/outputs/destinations/humio.md
+++ b/docs/5-integrations/outputs/destinations/humio.md
@@ -8,14 +8,14 @@ Output events and detections to the [Humio.com](https://humio.com) service.
 
 Example:
 
-```
+```text
 humio_repo: sandbox
 humio_api_token: fdkoefj0erigjre8iANUDBFyfjfoerjfi9erge
 ```
 
 Note: You may need to [create a new parser in Humio](https://docs.humio.com/docs/parsers/creating-a-parser/) to correctly [parse timestamps](https://docs.humio.com/reference/query-functions/functions/parsetimestamp/).  You can use the following JSON parser:
 
-```
+```text
 parseJson() | parseTimestamp(field=@timestamp,format="unixTimeMillis",timezone="Etc/UTC")
 ```
 

--- a/docs/5-integrations/outputs/destinations/ms-teams.md
+++ b/docs/5-integrations/outputs/destinations/ms-teams.md
@@ -9,7 +9,7 @@ Messages are delivered as [Adaptive Cards](https://learn.microsoft.com/en-us/ada
 
 Example:
 
-```
+```text
 webhook_url: https://<environment-id>.<region>.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/...
 ```
 

--- a/docs/5-integrations/outputs/destinations/opensearch.md
+++ b/docs/5-integrations/outputs/destinations/opensearch.md
@@ -9,7 +9,7 @@ Output events and detections to [OpenSearch](https://opensearch.org/).
 
 Example:
 
-```
+```text
 addresses: https://1.2.3.4:9200, https://elastic.mydomain.com:9200
 username: some
 password: pass1234

--- a/docs/5-integrations/outputs/destinations/scp.md
+++ b/docs/5-integrations/outputs/destinations/scp.md
@@ -10,7 +10,7 @@ Output events and detections over SCP (SSH file transfer).
 
 Example:
 
-```
+```text
 dest_host: storage.corp.com
 dir: /uploads/
 username: storage_user

--- a/docs/5-integrations/outputs/destinations/sftp.md
+++ b/docs/5-integrations/outputs/destinations/sftp.md
@@ -10,7 +10,7 @@ Output events and detections over SFTP.
 
 Example:
 
-```
+```text
 dest_host: storage.corp.com
 dir: /uploads/
 username: storage_user

--- a/docs/5-integrations/outputs/destinations/slack.md
+++ b/docs/5-integrations/outputs/destinations/slack.md
@@ -7,7 +7,7 @@ Output detections and audit (only) to a Slack community and channel.
 
 Example:
 
-```
+```text
 slack_api_token: xoxb-your-bot-token
 slack_channel: #detections
 ```

--- a/docs/5-integrations/outputs/destinations/smtp.md
+++ b/docs/5-integrations/outputs/destinations/smtp.md
@@ -27,7 +27,7 @@ Output individually each event, detection, audit, deployment or log through an e
 
 Example:
 
-```
+```text
 dest_host: smtp.gmail.com
 dest_email: soc@corp.com
 from_email: lc@corp.com

--- a/docs/5-integrations/outputs/destinations/syslog.md
+++ b/docs/5-integrations/outputs/destinations/syslog.md
@@ -12,7 +12,7 @@ Output events and detections to a syslog target.
 
 Example:
 
-```
+```text
 dest_host: storage.corp.com
 is_tls: "true"
 is_strict_tls: "true"

--- a/docs/5-integrations/outputs/destinations/telegram.md
+++ b/docs/5-integrations/outputs/destinations/telegram.md
@@ -9,7 +9,7 @@ Output detections and audit (only) to a Telegram chat, group, or channel.
 
 Example:
 
-```
+```text
 bot_token: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 chat_id: -1001234567890
 parse_mode: Markdown

--- a/docs/5-integrations/outputs/destinations/tines.md
+++ b/docs/5-integrations/outputs/destinations/tines.md
@@ -6,7 +6,7 @@ Output events and detections to [Tines](https://tines.io/).
 
 Example:
 
-```
+```text
 dest_host: https://something.tines.com/webhook/de2314c5f6246d17e82bf7b5742c9eaf/2d2dbcd2ab3845e9592d33c0526bc123
 ```
 

--- a/docs/5-integrations/outputs/destinations/webhook-bulk.md
+++ b/docs/5-integrations/outputs/destinations/webhook-bulk.md
@@ -10,7 +10,7 @@ Output batches of events, detections, audits, deployments or artifacts through a
 
 Example:
 
-```
+```text
 dest_host: https://webhooks.corp.com/new_detection
 secret_key: this-is-my-secret-shared-key
 auth_header_name: x-my-special-auth

--- a/docs/5-integrations/outputs/destinations/webhook.md
+++ b/docs/5-integrations/outputs/destinations/webhook.md
@@ -8,7 +8,7 @@ Output individually each event, detection, audit, deployment or artifact through
 
 Example:
 
-```
+```text
 dest_host: https://webhooks.corp.com/new_detection
 secret_key: this-is-my-secret-shared-key
 auth_header_name: x-my-special-auth
@@ -17,7 +17,7 @@ auth_header_value: 4756345846583498
 
 Example [hook to Google Chat](https://developers.google.com/chat/how-tos/webhooks):
 
-```
+```text
 dest_host: https://chat.googleapis.com/v1/spaces/AAAA4-AAAB/messages?key=afsdfgfdgfE6vySjMm-dfdssss&token=pBh2oZWr7NTSj9jisenfijsnvfisnvijnfsdivndfgyOYQ%3D
 secret_key: gchat-hook-sig42
 custom_transform: |

--- a/docs/5-integrations/services/replay.md
+++ b/docs/5-integrations/services/replay.md
@@ -51,13 +51,13 @@ The [Python CLI](https://github.com/refractionPOINT/python-limacharlie) gives yo
 
 Sample command line to query one sensor:
 
-```
+```bash
 limacharlie replay run --detect-file ./test_detect.yaml --respond-file ./test_respond.yaml --start 1556568500 --end 1556568600
 ```
 
 Sample command line to query an entire organization:
 
-```
+```bash
 limacharlie replay run --name my-rule-name --start 1555359000 --end 1556568600
 ```
 

--- a/docs/5-integrations/tutorials/human-in-the-loop-response.md
+++ b/docs/5-integrations/tutorials/human-in-the-loop-response.md
@@ -4,7 +4,7 @@ This tutorial walks through building an end-to-end workflow that detects a crede
 
 ## What You Will Build
 
-```
+```text
 NEW_PROCESS event (mimikatz.exe)
         |
         v

--- a/docs/5-integrations/tutorials/velociraptor-bigquery.md
+++ b/docs/5-integrations/tutorials/velociraptor-bigquery.md
@@ -59,7 +59,7 @@ BigQuery dataset containing Velociraptor hunt results:
 
       1. Detection
 
-         ```
+         ```yaml
          event: velociraptor_collection
          op: exists
          path: event/collection
@@ -86,7 +86,7 @@ Once the data arrives in BigQuery, it will be in three simple columns: `sid`, `j
 
 Let's say we wanted to split out all results of a `Windows.System.Pslist` hunt so that each process, from each system, is returned in it's own row. Here is an example notebook to accomplish this:
 
-```
+```sql
 SELECT
   sid,
   json_extract_scalar(obj, '$.Name') as Name,
@@ -110,7 +110,7 @@ This results in the following view of our data
 
 Suppose we wanted to perform some stacking analysis to identify the rarest combinations of `Exe` and `CommandLine`; the following query could help:
 
-```
+```sql
 SELECT
   json_extract_scalar(obj, '$.Exe') as Exe,
   json_extract_scalar(obj, '$.CommandLine') as CommandLine,
@@ -130,7 +130,7 @@ This results in the following view of our data
 
 Now let's say you wanted to look for only processes that are `Authenticode` = `untrusted`, you would use a query such as this:
 
-```
+```sql
 SELECT
   sid,
   json_extract_scalar(obj, '$.Name') as Name,
@@ -157,7 +157,7 @@ Here are some brief examples of `WHERE` statements to perform specific filtering
 
 This example checks for the presence of a string `mimikatz` appearing anywhere within `CommandLine`
 
-```
+```text
 WHERE
   STRPOS(json_extract_scalar(obj, '$.CommandLine'), 'mimikatz') > 0 AND
 ```
@@ -166,7 +166,7 @@ WHERE
 
 This example checks for the presence of an integer `0` in a numeric field `GroupID`
 
-```
+```text
 WHERE
   CAST(json_extract_scalar(obj, '$.GroupID') AS INT64) = 0
 ```
@@ -175,7 +175,7 @@ WHERE
 
 In the `Windows.System.Pslist` examples above, there are a few columns which contain nested JSON such as `Authenticode` and `Hash`. To expand these objects in their entirety in the corresponding column/row, we'd write a query like this:
 
-```
+```sql
 SELECT
   json_extract(obj, '$.Authenticode') as Authenticode, # json_extract to unpack nested json
   json_extract_scalar(obj, '$.Authenticode.Trusted') as Trusted,

--- a/docs/6-developer-guide/extensions/building-extensions.md
+++ b/docs/6-developer-guide/extensions/building-extensions.md
@@ -104,7 +104,7 @@ Here's an example high-level structure of a schema.
 
 While hidden in the example above, each `field` key-value pair shares the same structure and has a minimal implementation as such:
 
-```yaml
+```text
 field_name: {
   data_type: "string",
   description: "",

--- a/docs/6-developer-guide/extensions/building-extensions.md
+++ b/docs/6-developer-guide/extensions/building-extensions.md
@@ -97,14 +97,14 @@ Here's an example high-level structure of a schema.
 **The Field Configuration**
  Notice that for both the `config_schema` and the `request_schema` there is a recurring object structure that looks like the following:
 
-```
+```text
 "fields": { .. }, // key-value pair
 "requirements": [[]],
 ```
 
 While hidden in the example above, each `field` key-value pair shares the same structure and has a minimal implementation as such:
 
-```
+```yaml
 field_name: {
   data_type: "string",
   description: "",

--- a/docs/6-developer-guide/mcp-server.md
+++ b/docs/6-developer-guide/mcp-server.md
@@ -67,7 +67,7 @@ Or ask Claude: *"List my LimaCharlie organizations"*
 
 If your MCP client supports OAuth authentication, configure it to use the LimaCharlie MCP endpoint:
 
-```
+```text
 https://mcp.limacharlie.io/mcp
 ```
 

--- a/docs/6-developer-guide/sdks/python-sdk.md
+++ b/docs/6-developer-guide/sdks/python-sdk.md
@@ -157,7 +157,7 @@ client = Client(
 
 ### Architecture
 
-```
+```text
 limacharlie
 ├── client.Client              # HTTP client with JWT and retry logic
 ├── sdk/

--- a/docs/7-administration/config-hive/secrets.md
+++ b/docs/7-administration/config-hive/secrets.md
@@ -363,13 +363,13 @@ Using a secret in combination with an output has very few steps:
 
 Let's create a simple secret using the LimaCharlie CLI in a terminal. First, create a small file with the secret record in it:
 
-```
+```text
 echo "my-secret-value" > my-secret
 ```
 
 Next, set this secret in Hive via the LimaCharlie CLI:
 
-```
+```bash
 limacharlie hive set secret --key my-secret --data my-secret --data-key secret
 ```
 

--- a/docs/7-administration/config-hive/yara.md
+++ b/docs/7-administration/config-hive/yara.md
@@ -271,7 +271,7 @@ Assuming you have a Yara rule in the `rule.yara` file.
 
 Load the rule in the LimaCharlie Hive via the CLI:
 
-```
+```bash
 limacharlie hive set yara --key my-rule --data rule.yara --data-key rule
 ```
 
@@ -290,6 +290,6 @@ You should get a confirmation that the rule was created, including metadata of t
 
 Next, assuming you want to issue a scan command directly to a Sensor (via the Console or a rule):
 
-```
+```text
 yara_scan hive://yara/my-rule
 ```

--- a/docs/8-reference/authentication-resource-locator.md
+++ b/docs/8-reference/authentication-resource-locator.md
@@ -10,13 +10,13 @@ Authenticated Resource Locators (ARLs) describe a way to specify access to a rem
 
 ### With authentication
 
-```
+```text
 [methodName,methodDest,authType,authData]
 ```
 
 ### Without authentication
 
-```
+```text
 [methodName,methodDest]
 ```
 

--- a/docs/8-reference/edr-events.md
+++ b/docs/8-reference/edr-events.md
@@ -363,7 +363,7 @@ Generated when a file is deleted.
 > - Consider using File Integrity Monitoring (FIM)
 > - Look for this on an ad-hoc basis from the Sensor Console. ex.
 >
->   ```
+>   ```text
 >   history_dump -e FILE_DELETE
 >   ```
 
@@ -450,7 +450,7 @@ Generated when a file is modified.
 > - Consider using File Integrity Monitoring (FIM)
 > - Look for this on an ad-hoc basis from the Sensor Console. ex.
 >
->   ```
+>   ```text
 >   history_dump -e FILE_MODIFIED
 >   ```
 
@@ -511,7 +511,7 @@ Response event for the `fim_add` sensor command. An `ERROR: 0` implies the path 
 
 **Output:**
 
-```
+```text
 "event": {
   "ERROR":0
 }
@@ -527,7 +527,7 @@ An `ERROR: 3` response implies the provided path was not found in the list of FI
 
 **Output:**
 
-```
+```text
 "event": {
   "ERROR":0
 }
@@ -1207,7 +1207,7 @@ List of packages installed on the system. This is currently Windows only but wil
 
 **Sample Event:**
 
-```
+```text
 "PACKAGES": [
   {
     "PACKAGE_NAME": "Microsoft Windows Driver Development Kit Uninstall"

--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -143,7 +143,7 @@ Search for files matching a specific hash across a directory tree.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> dir_findhash --dir_path "/var" --hash <HASH_VALUE>
 ```
 
@@ -163,7 +163,7 @@ Perform DNS resolution on the endpoint to determine what DNS server responds.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> dns_resolve --hostname "example.com"
 ```
 
@@ -183,7 +183,7 @@ Retrieve a previously cached document from the sensor's local cache.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> doc_cache_get --hash <DOC_HASH>
 ```
 
@@ -207,7 +207,7 @@ Add an exfiltration detection watch for specific event types and patterns.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> exfil_add --event "DNS_REQUEST" --operator "contains" --path "event/DOMAIN_NAME" --value "malware" --expire 3600
 ```
 
@@ -227,7 +227,7 @@ Remove an exfiltration detection watch by its ID.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> exfil_del --id <WATCH_ID>
 ```
 
@@ -245,7 +245,7 @@ List all active exfiltration detection watches on the sensor.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> exfil_get
 ```
 
@@ -265,7 +265,7 @@ Delete a file from the endpoint filesystem.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> file_del --file_path "/tmp/suspicious_file"
 ```
 
@@ -285,7 +285,7 @@ Retrieve a file from the endpoint and upload it to LimaCharlie cloud storage.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> file_get --file_path "C:\\Windows\\System32\\calc.exe"
 ```
 
@@ -305,7 +305,7 @@ Calculate cryptographic hashes (MD5, SHA1, SHA256) for a file.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> file_hash --file_path "/etc/passwd"
 ```
 
@@ -339,7 +339,7 @@ Get detailed metadata about a file without retrieving its contents.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> file_info --file_path "C:\\Program Files\\app.exe"
 ```
 
@@ -374,7 +374,7 @@ Move or rename a file on the endpoint filesystem.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> file_mov --src_path "/tmp/file.txt" --dst_path "/tmp/renamed.txt"
 ```
 
@@ -394,7 +394,7 @@ Add a File Integrity Monitoring (FIM) watch for a specific path or pattern.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> fim_add --file_path "C:\\Windows\\System32\\*.dll"
 ```
 
@@ -414,7 +414,7 @@ Remove a File Integrity Monitoring watch.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> fim_del --file_path "C:\\Windows\\System32\\*.dll"
 ```
 
@@ -432,7 +432,7 @@ List all active File Integrity Monitoring watches on the sensor.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> fim_get
 ```
 
@@ -450,7 +450,7 @@ Retrieve internal sensor debug data for troubleshooting.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> get_debug_data
 ```
 
@@ -470,7 +470,7 @@ Scan for hidden or stealthy modules loaded in process memory that may not appear
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> hidden_module_scan --pid 1234
 ```
 
@@ -488,7 +488,7 @@ Export a dump of recent events from the sensor's local event cache.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> history_dump
 ```
 
@@ -509,7 +509,7 @@ Retrieve Windows Event Logs or macOS Unified Logs from the endpoint.
 
 **Usage Example:**
 
-```
+```bash
 # Windows
 limacharlie sensor task <SID> log_get --source "Security"
 
@@ -534,7 +534,7 @@ Search process memory for specific string patterns.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> mem_find_string --pid 1234 --strings "password"
 ```
 
@@ -555,7 +555,7 @@ Find handles (file, registry, process) held by a process on Windows.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> mem_find_handle --pid 1234 --needle "malware.exe"
 ```
 
@@ -575,7 +575,7 @@ Get memory map of a process showing loaded modules and memory regions.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> mem_map --pid 1234
 ```
 
@@ -597,7 +597,7 @@ Read raw memory from a process at a specific address.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> mem_read --pid 1234 --base_address 0x00400000 --size 1024
 ```
 
@@ -617,7 +617,7 @@ Extract all readable strings from a process's memory.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> mem_strings --pid 1234
 ```
 
@@ -635,7 +635,7 @@ Get current network connections on the endpoint (similar to netstat command).
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> netstat
 ```
 
@@ -673,7 +673,7 @@ Get aggregated network statistics and active connections summary.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> network_summary
 ```
 
@@ -693,7 +693,7 @@ Terminate a running process.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_kill_process --pid 1234
 ```
 
@@ -709,7 +709,7 @@ List installed software packages on the endpoint.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_packages
 ```
 
@@ -743,7 +743,7 @@ Get a list of all running processes with detailed information.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_processes
 ```
 
@@ -777,7 +777,7 @@ Resume a suspended process.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_resume --pid 1234
 ```
 
@@ -795,7 +795,7 @@ List all services/daemons running on the endpoint.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_services
 ```
 
@@ -815,7 +815,7 @@ Suspend (pause) a running process.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_suspend --pid 1234
 ```
 
@@ -833,7 +833,7 @@ List programs configured to run automatically at system startup.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_autoruns
 ```
 
@@ -851,7 +851,7 @@ List all loaded kernel drivers/modules.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_drivers
 ```
 
@@ -869,7 +869,7 @@ Get detailed operating system version information.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> os_version
 ```
 
@@ -899,7 +899,7 @@ Re-enable network connectivity for a sensor that was previously isolated.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> rejoin_network
 ```
 
@@ -919,7 +919,7 @@ Execute a command or script on the endpoint (out-of-band execution).
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> run --command "ps aux | grep chrome"
 ```
 
@@ -937,7 +937,7 @@ Isolate a sensor from the network (except LimaCharlie cloud connectivity).
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> segregate_network
 ```
 
@@ -960,7 +960,7 @@ Scan files or process memory with YARA rules.
 
 **Usage Example:**
 
-```
+```bash
 # Scan a file
 limacharlie sensor task <SID> yara_scan --file_path "C:\\suspicious.exe" --rule "rule test { strings: $a = \"malware\" condition: $a }"
 
@@ -982,7 +982,7 @@ List available network interfaces for packet capture.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> pcap_ifaces
 ```
 
@@ -1003,7 +1003,7 @@ Start capturing network packets on a specified interface.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> pcap_start --iface eth0 --max_size 100
 ```
 
@@ -1023,7 +1023,7 @@ Stop an active packet capture and upload the PCAP file.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> pcap_stop
 ```
 
@@ -1043,7 +1043,7 @@ List Windows registry keys and values.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> reg_list --reg_path "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
 ```
 
@@ -1063,7 +1063,7 @@ Trigger an Endpoint Protection (EPP) scan on a file or directory.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> epp_scan --file_path "C:\\Users\\Public"
 ```
 
@@ -1081,7 +1081,7 @@ List EPP scan exclusions currently configured on the sensor.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> epp_list_exclusions
 ```
 
@@ -1102,7 +1102,7 @@ Add a path or process to EPP scan exclusions.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> epp_add_exclusion --file_path "C:\\safe_app"
 ```
 
@@ -1123,7 +1123,7 @@ Remove a path or process from EPP scan exclusions.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> epp_rem_exclusion --file_path "C:\\safe_app"
 ```
 
@@ -1141,7 +1141,7 @@ List files currently in EPP quarantine.
 
 **Usage Example:**
 
-```
+```bash
 limacharlie sensor task <SID> epp_list_quarantine
 ```
 

--- a/docs/8-reference/faq/sensor-removal.md
+++ b/docs/8-reference/faq/sensor-removal.md
@@ -56,7 +56,7 @@ Open the Terminal and run the following commands
 
 ❌ The following result would indicate that the uninstall was not successful:
 
-```
+```text
 * * N7N82884NH com.refractionpoint.rphcp.extension (1.0.241204/1.0.241204) RPHCP [activated enabled]
 ```
 

--- a/docs/8-reference/faq/troubleshooting.md
+++ b/docs/8-reference/faq/troubleshooting.md
@@ -39,7 +39,7 @@ Sensors since version 4.21.2 also generate a local log file able to be used to h
 
 This log provides a simple line for each basic step of connectivity to the cloud. It only logs the first connection attempted to the cloud and rolls over every time the sensor starts. A successful connection should look like:
 
-```
+```text
 hcp launched
 configs applied
 conn started

--- a/docs/8-reference/response-actions.md
+++ b/docs/8-reference/response-actions.md
@@ -190,7 +190,7 @@ You can also specify a `based on report: true` parameter. When true (defaults to
 
 Isolates the sensor from the network in a persistent fashion (if the sensor/host reboots, it will remain isolated). Only works on platforms supporting the `segregate_network` [sensor command](endpoint-commands.md#segregatenetwork).
 
-```
+```text
 - action: isolate network
 ```
 
@@ -202,7 +202,7 @@ When the network isolation feature is used, LimaCharlie will block connections t
 
 Seals the sensor in a persistent fashion (if the sensor/host reboots, it will remain sealed). Only works on platforms supporting the `seal` [sensor command](endpoint-commands.md#seal).
 
-```
+```text
 - action: seal
 ```
 
@@ -214,7 +214,7 @@ Sealing a sensor enables tamper resistance, preventing direct modifications to t
 
 Removes the seal status of a sensor that had it set using `seal`.
 
-```
+```text
 - action: unseal
 ```
 
@@ -237,7 +237,7 @@ Example:
 
 Removes the isolation status of a sensor that had it set using `isolate network`.
 
-```
+```text
 - action: rejoin network
 ```
 

--- a/docs/9-ai-sessions/api-reference.md
+++ b/docs/9-ai-sessions/api-reference.md
@@ -13,13 +13,13 @@ This document provides a complete reference for the AI Sessions REST API and Web
 
 All API requests require a valid LimaCharlie JWT token in the Authorization header:
 
-```
+```text
 Authorization: Bearer <LC-JWT>
 ```
 
 For WebSocket connections, you can also pass the token as a query parameter:
 
-```
+```text
 wss://ai-sessions.limacharlie.io/v1/sessions/{sessionId}/ws?token=<LC-JWT>
 ```
 
@@ -39,7 +39,7 @@ wss://ai-sessions.limacharlie.io/v1/sessions/{sessionId}/ws?token=<LC-JWT>
 
 #### Register User
 
-```
+```text
 POST /v1/register
 ```
 
@@ -62,7 +62,7 @@ Register the authenticated user for the AI Sessions platform.
 
 #### Deregister User
 
-```
+```text
 DELETE /v1/register
 ```
 
@@ -82,7 +82,7 @@ Deregister the user and delete all associated data. This terminates all active s
 
 #### List Sessions
 
-```
+```text
 GET /v1/sessions
 ```
 
@@ -116,7 +116,7 @@ GET /v1/sessions
 
 #### Create Session
 
-```
+```text
 POST /v1/sessions
 ```
 
@@ -154,7 +154,7 @@ POST /v1/sessions
 
 #### Get Session
 
-```
+```text
 GET /v1/sessions/{sessionId}
 ```
 
@@ -180,7 +180,7 @@ GET /v1/sessions/{sessionId}
 
 #### Terminate Session
 
-```
+```text
 DELETE /v1/sessions/{sessionId}
 ```
 
@@ -194,7 +194,7 @@ DELETE /v1/sessions/{sessionId}
 
 #### Delete Session Record
 
-```
+```text
 DELETE /v1/sessions/{sessionId}/record
 ```
 
@@ -214,7 +214,7 @@ Delete a terminated session from history. Only sessions in the `ended` state can
 
 #### List Profiles
 
-```
+```text
 GET /v1/profiles
 ```
 
@@ -243,7 +243,7 @@ GET /v1/profiles
 
 #### Create Profile
 
-```
+```text
 POST /v1/profiles
 ```
 
@@ -291,19 +291,19 @@ POST /v1/profiles
 
 #### Get Profile
 
-```
+```text
 GET /v1/profiles/{profileId}
 ```
 
 #### Update Profile
 
-```
+```text
 PUT /v1/profiles/{profileId}
 ```
 
 #### Delete Profile
 
-```
+```text
 DELETE /v1/profiles/{profileId}
 ```
 
@@ -311,13 +311,13 @@ DELETE /v1/profiles/{profileId}
 
 #### Set Default Profile
 
-```
+```text
 POST /v1/profiles/{profileId}/default
 ```
 
 #### Capture Session as Profile
 
-```
+```text
 POST /v1/sessions/{sessionId}/capture-profile
 ```
 
@@ -336,7 +336,7 @@ POST /v1/sessions/{sessionId}/capture-profile
 
 #### Start OAuth Flow
 
-```
+```text
 POST /v1/auth/claude/start
 ```
 
@@ -352,7 +352,7 @@ POST /v1/auth/claude/start
 
 #### Get OAuth URL
 
-```
+```text
 GET /v1/auth/claude/url?session_id={oauth_session_id}
 ```
 
@@ -377,7 +377,7 @@ GET /v1/auth/claude/url?session_id={oauth_session_id}
 
 #### Submit OAuth Code
 
-```
+```text
 POST /v1/auth/claude/code
 ```
 
@@ -402,7 +402,7 @@ POST /v1/auth/claude/code
 
 #### Store API Key
 
-```
+```text
 POST /v1/auth/claude/apikey
 ```
 
@@ -425,7 +425,7 @@ POST /v1/auth/claude/apikey
 
 #### Get Credential Status
 
-```
+```text
 GET /v1/auth/claude/status
 ```
 
@@ -441,7 +441,7 @@ GET /v1/auth/claude/status
 
 #### Delete Credentials
 
-```
+```text
 DELETE /v1/auth/claude
 ```
 
@@ -451,7 +451,7 @@ DELETE /v1/auth/claude
 
 #### Request Upload URL
 
-```
+```text
 POST /v1/io/sessions/{sessionId}/upload
 ```
 
@@ -482,7 +482,7 @@ POST /v1/io/sessions/{sessionId}/upload
 
 #### Notify Upload Complete
 
-```
+```text
 POST /v1/io/sessions/{sessionId}/upload/complete
 ```
 
@@ -505,7 +505,7 @@ POST /v1/io/sessions/{sessionId}/upload/complete
 
 #### Request Download URL
 
-```
+```text
 POST /v1/io/sessions/{sessionId}/download
 ```
 
@@ -534,7 +534,7 @@ POST /v1/io/sessions/{sessionId}/download
 
 **Endpoint:**
 
-```
+```text
 wss://ai-sessions.limacharlie.io/v1/sessions/{sessionId}/ws
 ```
 

--- a/docs/9-ai-sessions/tool-permissions.md
+++ b/docs/9-ai-sessions/tool-permissions.md
@@ -50,7 +50,7 @@ A bare identifier matches the entire Claude Code tool of that name. Common built
 
 The `Bash` tool accepts a scoping specifier that restricts which commands are covered. Only the `prefix:*` form is recognised, mirroring the official Claude Code CLI syntax:
 
-```
+```text
 Bash(git:*)            # any command starting with "git "
 Bash(npm install:*)    # any command starting with "npm install "
 Bash(kubectl get:*)    # read-only kubectl verbs
@@ -126,7 +126,7 @@ The first time a user registers for AI Sessions, two profiles are provisioned au
 
 - **Default** — a read-only safe baseline. `permission_mode: acceptEdits`, no `denied_tools`, and `allowed_tools` limited to:
 
-    ```
+    ```text
     Read
     Bash(cat:*) Bash(head:*) Bash(tail:*) Bash(less:*)
     Bash(grep:*) Bash(sed:*) Bash(awk:*) Bash(jq:*)

--- a/docs/9-ai-sessions/user-sessions.md
+++ b/docs/9-ai-sessions/user-sessions.md
@@ -274,7 +274,7 @@ curl -o output.txt "{download_url}"
 
 Use Claude to investigate a security incident step by step:
 
-```
+```text
 You: I need to investigate suspicious activity on sensor abc123.
      The user reported strange popup windows.
 
@@ -295,7 +295,7 @@ Claude: I'll investigate this sensor. Let me start by gathering some
 
 Perform quick analysis tasks:
 
-```
+```text
 You: Analyze this list of IP addresses and tell me which ones
      appear in threat intelligence feeds.
 
@@ -314,7 +314,7 @@ Claude: I'll analyze each IP address against available threat
 
 Explore your LimaCharlie environment:
 
-```
+```text
 You: Show me how to create a D&R rule that detects PowerShell
      downloading files from the internet.
 


### PR DESCRIPTION
## Summary

Clears the entire `MD040` (fenced-code-language) backlog from the
markdownlint cleanup tracked in `markdown-lint.md`. Adds explicit
language tags to all 232 untagged fenced code blocks across 77 files.

This is the second PR in the lint backlog cleanup — follow-up to #198
(mechanical `--fix` pass).

## Approach

A heuristic classifier processed each fence's content to suggest a
language. Manual overrides corrected the misclassifications that surfaced
during review:

- Embedded YAML hive configs that pattern-matched as bash
- Dialogue transcripts (`You: ... | Claude: ...`) that pattern-matched
  as YAML because of the colon-prefixed lines
- Log output and pseudocode templates that pattern-matched as YAML
- CLI command syntax docs in `okta.md` that defaulted to `text`,
  promoted to `bash` since they're meant to be invoked at a shell prompt

For HTTP-flavored content in `9-ai-sessions/api-reference.md` (method+path
lines, lone `Authorization:` headers, WebSocket URLs), `text` is used
rather than `http`. Pygments' `http` lexer expects a full HTTP request
(method + path + version + headers + body) and wraps partial-syntax
content like `POST /v1/foo` in `<span class="err">`, producing a visual
regression. `text` keeps the existing rendering.

## Tag distribution

- `bash` — CLI commands, `limacharlie`/`lc-adapter` invocations, `curl`,
  `docker-compose`, `sc query`, etc.
- `yaml` — D&R rules, hive configs, adapter configs
- `json` — event payloads, JSON example structures
- `python` — Python code snippets
- `sql` — BigQuery / SQL examples
- `text` — log output, ASCII trees, console output, pseudocode templates,
  HTTP signatures, conversation transcripts, regex patterns, URLs

## Verification

- **MD040 count**: 232 → 0
- **Total lint backlog**: 972 → 740 (-232)
- **`mkdocs build --strict`**: 218 INFO/WARNING messages, identical to
  master — no new build regressions
- **Rendered HTML**: 16 pages now show syntax highlighting where they
  previously rendered as `language-text` (visual improvement). The 2
  pre-existing `class="err"` markers in master (both from `...`
  placeholders inside `\`\`\`json` blocks I didn't touch) are unchanged.
- Pre-existing rendered output for previously-untagged blocks was
  `language-text` in master — these were already visually unstyled, so
  the only real-world effect of this PR is improved highlighting on
  blocks tagged with a non-`text` language.

## Out of scope (next PRs)

Per the workflow in `markdown-lint.md`, follow-ups should each clear one
substantive rule:

- `MD046` — code-block-style consistency (~183 cases)
- `MD045` — image alt text (~152)
- `MD051` — broken anchor links (~150 — these are also the `INFO`
  lines in `mkdocs build --strict`)
- `MD036` — bold paragraphs as headings (~72)
- `MD024` — duplicate headings (~59)
- `MD029` — ordered list prefix (~77)
- `MD001` — heading-increment (~33)

Once cleared, drop `continue-on-error: true` from the `check-markdown` CI
job (or pin enforced rules in a checked-in `.markdownlint.json`).

## Test plan

- [ ] CI `check-markdown` reports a smaller violation count (no MD040)
- [ ] CI `Link Checker` (lychee) passes
- [ ] Visual spot-check of `5-integrations/extensions/cloud-cli/okta.md`
      and `8-reference/endpoint-commands.md` to confirm bash highlighting
      reads correctly
- [ ] Visual spot-check of `9-ai-sessions/api-reference.md` to confirm
      `text` blocks for HTTP signatures don't show error underlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)