### PR TITLE
ci(markdownlint): disable MD046 — conflicts with pymdownx.tabbed

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -152,6 +152,7 @@ jobs:
               "default": true,
               "MD013": false,
               "MD033": false,
-              "MD041": false
+              "MD041": false,
+              "MD046": false
             }
         continue-on-error: true

--- a/markdown-lint.md
+++ b/markdown-lint.md
@@ -29,7 +29,7 @@ uses inline:
 
 ```bash
 npx --yes markdownlint-cli2 \
-  --config <(echo '{"default": true, "MD013": false, "MD033": false, "MD041": false}') \
+  --config <(echo '{"default": true, "MD013": false, "MD033": false, "MD041": false, "MD046": false}') \
   "docs/**/*.md"
 ```
 
@@ -75,9 +75,18 @@ changes. Examples:
 
 - `MD004` (bullet style consistency)
 - `MD031` / `MD032` (blank lines around fences/lists)
-- `MD046` (code block style)
 - `MD060` (table column alignment)
 - `MD029` (ordered list prefix)
+
+**Disabled** — these rules are turned off in our config because they
+conflict with mkdocs-material extensions we use repo-wide:
+
+- `MD046` (code block style) — disabled. Our docs use the
+  `pymdownx.tabbed` extension (`=== "Tab"` blocks) which requires
+  4-space indentation for tab content. Markdownlint reads CommonMark,
+  doesn't recognize the extension, and reports the indented fences
+  inside tabs as inconsistent code-block style. Disabling avoids the
+  false positives.
 
 **Substantive (manual)** — these need editorial judgment and meaningfully
 improve doc quality and AI / LLM readability. Prioritize these:
@@ -133,7 +142,7 @@ Run the linter today to see where we stand:
 
 ```bash
 npx --yes markdownlint-cli2 \
-  --config <(echo '{"default": true, "MD013": false, "MD033": false, "MD041": false}') \
+  --config <(echo '{"default": true, "MD013": false, "MD033": false, "MD041": false, "MD046": false}') \
   "docs/**/*.md" 2> mdlint.out || true
 grep -oE 'MD[0-9]+/[a-z-]+' mdlint.out | sort | uniq -c | sort -rn
 ```


### PR DESCRIPTION
## Summary

Disables `MD046` (code-block-style) in the markdownlint config used by
the `check-markdown` CI job. Updates `markdown-lint.md` to document
the rationale.

This is the third PR in the lint backlog cleanup. Unlike #198 and #199,
this is a **CI config change, not a content change** — no files under
`docs/` are modified.

## Why

All 183 MD046 violations in the current backlog are false positives
caused by an upstream tooling incompatibility:

- The repo uses the [`pymdownx.tabbed`](https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/)
  mkdocs-material extension (`=== "Tab"` syntax), which requires tab
  content to be indented by 4 spaces.
- Tab content frequently includes fenced code blocks, so those fences
  sit at 4-space indentation in the source.
- Markdownlint reads CommonMark only — it has no awareness of the
  extension. Per CommonMark, a fence opener at 4-space indentation is
  not a fence opener; the whole block is interpreted as an indented
  code block.
- Markdownlint then sees those apparent "indented blocks" alongside
  truly-fenced blocks elsewhere in the same file and flags them as
  inconsistent.

Audited every MD046 violation: **183/183 are inside `pymdownx.tabbed`
blocks**. There are zero genuine indented-code-block violations in the
repo. Disabling the rule loses no real coverage.

## Distribution of false positives (sanity check)

```
56 docs/5-integrations/extensions/limacharlie/cases.md
24 docs/2-sensors-deployment/sensor-tags.md
20 docs/7-administration/config-hive/secrets.md
20 docs/7-administration/config-hive/lookups.md
20 docs/7-administration/config-hive/dr-rules.md
20 docs/3-detection-response/false-positives.md
16 docs/7-administration/config-hive/yara.md
 7 docs/5-integrations/extensions/limacharlie/feedback.md
```

All 8 files use `=== "REST API" / "Python" / "Go" / "CLI"` tabs to show
the same operation in multiple SDKs.

## Verification

- Total lint backlog: **740 → 557** (-183, exactly the MD046 count)
- `MD046` count after: **0**
- `mkdocs build --strict`: 218 INFO/WARNING messages, identical to
  master — no build regressions

## Out of scope (next PRs)

Per the workflow in `markdown-lint.md`:

- `MD045` — image alt text (~152 cases)
- `MD051` — broken anchor links (~150 — also the `INFO` lines in
  `mkdocs build --strict`)
- `MD036` — bold paragraphs as headings (~72)
- `MD024` — duplicate headings (~59)
- `MD029` — ordered list prefix (~77)
- `MD001` — heading-increment (~33)

## Test plan

- [ ] CI `check-markdown` reports a smaller violation count and no MD046
- [ ] CI `Link Checker` (lychee) and `docs.yml` (mkdocs build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)