### PR TITLE
docs: fix broken intra-page anchor links (MD051)

### DIFF
--- a/docs/6-developer-guide/sdks/go-sdk.md
+++ b/docs/6-developer-guide/sdks/go-sdk.md
@@ -24,10 +24,7 @@ The LimaCharlie Go SDK provides a comprehensive client library for interacting w
   - [Hive Configuration Management](#hive-configuration-management)
 - [Data Structures](#data-structures)
 - [Error Handling](#error-handling)
-- [Advanced Features](#advanced-features)
-- [Examples](#examples)
 - [Best Practices](#best-practices)
-- [Troubleshooting](#troubleshooting)
 - [Firehose CLI Tool](#firehose-cli-tool)
 
 ## Installation

--- a/docs/8-reference/edr-events.md
+++ b/docs/8-reference/edr-events.md
@@ -12,101 +12,101 @@ These are the events emitted by the endpoint agent for each supported operating 
 
 | EDR Event Type | macOS | Windows | Linux | Chrome | Edge |
 | --- | --- | --- | --- | --- | --- |
-| [AUTORUN\_CHANGE](#autorunchange) |  | ☑️ |  |  |  |
-| [CLOUD\_NOTIFICATION](#cloudnotification) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [CODE\_IDENTITY](#codeidentity) | ☑️ | ☑️ | ☑️ |  |  |
+| [AUTORUN\_CHANGE](#autorun_change) |  | ☑️ |  |  |  |
+| [CLOUD\_NOTIFICATION](#cloud_notification) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [CODE\_IDENTITY](#code_identity) | ☑️ | ☑️ | ☑️ |  |  |
 | [CONNECTED](#connected) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [DATA\_DROPPED](#datadropped) | ☑️ | ☑️ | ☑️ |  |  |
-| [DEBUG\_DATA\_REP](#getdebugdata) |  | ☑️ |  |  |  |
-| [DELETED\_SENSOR](#deletedsensor) | ☑️ | ☑️ | ☑️ |  |  |
-| [DIR\_FINDHASH\_REP](#dirfindhash) | ☑️ | ☑️ | ☑️ |  |  |
-| [DIR\_LIST\_REP](#dirlist) | ☑️ | ☑️ | ☑️ |  |  |
-| [DNS\_REQUEST](#dnsrequest) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [DRIVER\_CHANGE](#driverchange) |  | ☑️ |  |  |  |
-| [EXEC\_OOB](#execoob) | ☑️ |  | ☑️ |  |  |
-| [EXISTING\_PROCESS](#existingprocess) | ☑️ | ☑️ | ☑️ |  |  |
-| [EXPORT\_COMPLETE](#exportcomplete) | ☑️ | ☑️ | ☑️ |  |  |
-| [FIM\_ADD](#fimadd) | ☑️ | ☑️ | ☑️ |  |  |
-| [FIM\_REMOVE](#fimremove) | ☑️ | ☑️ | ☑️ |  |  |
-| [FIM\_HIT](#fimhit) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_CREATE](#filecreate) | ☑️ | ☑️ |  |  |  |
-| [FILE\_DEL\_REP](#filedel) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_DELETE](#filedelete) | ☑️ | ☑️ |  |  |  |
-| [FILE\_GET\_REP](#fileget) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_HASH\_REP](#filehash) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_INFO\_REP](#fileinfo) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_MODIFIED](#filemodified) | ☑️ | ☑️ |  |  |  |
-| [FILE\_MOV\_REP](#filemov) | ☑️ | ☑️ | ☑️ |  |  |
-| [FILE\_TYPE\_ACCESSED](#filetypeaccessed) | ☑️ | ☑️ |  |  |  |
-| [GET\_DOCUMENT\_REP](#doccacheget) | ☑️ | ☑️ |  |  |  |
-| [GET\_EXFIL\_EVENT\_REP](#exfilget) | ☑️ | ☑️ | ☑️ |  |  |
-| [HIDDEN\_MODULE\_DETECTED](#hiddenmoduledetected) |  | ☑️ |  |  |  |
-| [HISTORY\_DUMP\_REP](#historydump) | ☑️ | ☑️ | ☑️ |  |  |
-| [HTTP\_REQUEST](#httprequest) |  |  |  | ☑️ | ☑️ |
-| [HTTP\_REQUEST\_HEADERS](#httprequestheaders) |  |  |  | ☑️ |  |
-| [HTTP\_RESPONSE\_HEADERS](#httpresponseheaders) |  |  |  | ☑️ |  |
-| [INGEST](#ingest) | ☑️ | ☑️ | ☑️ |  |  |
-| [LOG\_GET\_REP](#logget) |  |  |  |  |  |
-| [LOG\_LIST\_REP](#loglist) |  |  |  |  |  |
-| [MEM\_FIND\_HANDLES\_REP](#memfindhandle) |  | ☑️ |  |  |  |
-| [MEM\_FIND\_STRING\_REP](#memfindstring) | ☑️ | ☑️ | ☑️ |  |  |
-| [MEM\_HANDLES\_REP](#memhandles) |  | ☑️ |  |  |  |
-| [MEM\_MAP\_REP](#memmap) | ☑️ | ☑️ | ☑️ |  |  |
-| [MEM\_READ\_REP](#memread) | ☑️ | ☑️ | ☑️ |  |  |
-| [MEM\_STRINGS\_REP](#memstrings) | ☑️ | ☑️ | ☑️ |  |  |
-| [MODULE\_LOAD](#moduleload) |  | ☑️ | ☑️ |  |  |
-| [MODULE\_MEM\_DISK\_MISMATCH](#modulememdiskmismatch) | ☑️ | ☑️ | ☑️ |  |  |
-| [NETSTAT\_REP](#netstat) | ☑️ | ☑️ | ☑️ |  |  |
-| [NETWORK\_CONNECTIONS](#networkconnections) | ☑️ | ☑️ | ☑️ |  |  |
-| [NETWORK\_SUMMARY](#networksummary) | ☑️ | ☑️ | ☑️ |  |  |
-| [NEW\_DOCUMENT](#newdocument) | ☑️ | ☑️ |  |  |  |
-| [NEW\_NAMED\_PIPE](#newnamedpipe) |  | ☑️ |  |  |  |
-| [NEW\_PROCESS](#newprocess) | ☑️ | ☑️ | ☑️ |  |  |
-| [NEW\_REMOTE\_THREAD](#newremotethread) |  | ☑️ |  |  |  |
-| [NEW\_TCP4\_CONNECTION](#newtcp4connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [NEW\_TCP6\_CONNECTION](#newtcp6connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [NEW\_UDP4\_CONNECTION](#newudp4connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [NEW\_UDP6\_CONNECTION](#newudp6connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [OPEN\_NAMED\_PIPE](#opennamedpipe) |  | ☑️ |  |  |  |
-| [OS\_AUTORUNS\_REP](#osautoruns) | ☑️ | ☑️ |  |  |  |
-| [OS\_DRIVERS\_REP](#osdrivers) |  | ☑️ |  |  |  |
-| [OS\_KILL\_PROCESS\_REP](#oskillprocess) | ☑️ | ☑️ | ☑️ |  |  |
-| [OS\_PACKAGES\_REP](#ospackages) |  | ☑️ |  |  |  |
-| [OS\_PROCESSES\_REP](#osprocesses) | ☑️ | ☑️ | ☑️ |  |  |
-| [OS\_RESUME\_REP](#osresume) | ☑️ | ☑️ | ☑️ |  |  |
-| [OS\_SERVICES\_REP](#osservices) | ☑️ | ☑️ | ☑️ |  |  |
-| [OS\_SUSPEND\_REP](#ossuspend) | ☑️ | ☑️ | ☑️ |  |  |
-| [OS\_USERS\_REP](#osusers) |  | ☑️ |  |  |  |
-| [OS\_VERSION\_REP](#osversion) | ☑️ | ☑️ | ☑️ |  |  |
-| [PCAP\_LIST\_INTERFACES\_REP](#pcapifaces) |  |  | ☑️ |  |  |
-| [PROCESS\_ENVIRONMENT](#processenvironment) |  | ☑️ | ☑️ |  |  |
+| DATA\_DROPPED | ☑️ | ☑️ | ☑️ |  |  |
+| [DEBUG\_DATA\_REP](#debug_data_rep) |  | ☑️ |  |  |  |
+| DELETED\_SENSOR | ☑️ | ☑️ | ☑️ |  |  |
+| [DIR\_FINDHASH\_REP](#dir_findhash_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [DIR\_LIST\_REP](#dir_list_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [DNS\_REQUEST](#dns_request) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [DRIVER\_CHANGE](#driver_change) |  | ☑️ |  |  |  |
+| EXEC\_OOB | ☑️ |  | ☑️ |  |  |
+| [EXISTING\_PROCESS](#existing_process) | ☑️ | ☑️ | ☑️ |  |  |
+| EXPORT\_COMPLETE | ☑️ | ☑️ | ☑️ |  |  |
+| [FIM\_ADD](#fim_add) | ☑️ | ☑️ | ☑️ |  |  |
+| [FIM\_REMOVE](#fim_remove) | ☑️ | ☑️ | ☑️ |  |  |
+| [FIM\_HIT](#fim_hit) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_CREATE](#file_create) | ☑️ | ☑️ |  |  |  |
+| [FILE\_DEL\_REP](#file_del_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_DELETE](#file_delete) | ☑️ | ☑️ |  |  |  |
+| [FILE\_GET\_REP](#file_get_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_HASH\_REP](#file_hash_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_INFO\_REP](#file_info_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_MODIFIED](#file_modified) | ☑️ | ☑️ |  |  |  |
+| [FILE\_MOV\_REP](#file_mov_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_TYPE\_ACCESSED](#file_type_accessed) | ☑️ | ☑️ |  |  |  |
+| [GET\_DOCUMENT\_REP](#get_document_rep) | ☑️ | ☑️ |  |  |  |
+| [GET\_EXFIL\_EVENT\_REP](#get_exfil_event_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [HIDDEN\_MODULE\_DETECTED](#hidden_module_detected) |  | ☑️ |  |  |  |
+| [HISTORY\_DUMP\_REP](#history_dump_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [HTTP\_REQUEST](#http_request) |  |  |  | ☑️ | ☑️ |
+| [HTTP\_REQUEST\_HEADERS](#http_request_headers) |  |  |  | ☑️ |  |
+| [HTTP\_RESPONSE\_HEADERS](#http_response_headers) |  |  |  | ☑️ |  |
+| INGEST | ☑️ | ☑️ | ☑️ |  |  |
+| [LOG\_GET\_REP](#log_get_rep) |  |  |  |  |  |
+| [LOG\_LIST\_REP](#log_list_rep) |  |  |  |  |  |
+| [MEM\_FIND\_HANDLES\_REP](#mem_find_handles_rep) |  | ☑️ |  |  |  |
+| [MEM\_FIND\_STRING\_REP](#mem_find_string_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [MEM\_HANDLES\_REP](#mem_handles_rep) |  | ☑️ |  |  |  |
+| [MEM\_MAP\_REP](#mem_map_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [MEM\_READ\_REP](#mem_read_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [MEM\_STRINGS\_REP](#mem_strings_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [MODULE\_LOAD](#module_load) |  | ☑️ | ☑️ |  |  |
+| MODULE\_MEM\_DISK\_MISMATCH | ☑️ | ☑️ | ☑️ |  |  |
+| [NETSTAT\_REP](#netstat_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [NETWORK\_CONNECTIONS](#network_connections) | ☑️ | ☑️ | ☑️ |  |  |
+| NETWORK\_SUMMARY | ☑️ | ☑️ | ☑️ |  |  |
+| [NEW\_DOCUMENT](#new_document) | ☑️ | ☑️ |  |  |  |
+| [NEW\_NAMED\_PIPE](#new_named_pipe) |  | ☑️ |  |  |  |
+| [NEW\_PROCESS](#new_process) | ☑️ | ☑️ | ☑️ |  |  |
+| [NEW\_REMOTE\_THREAD](#new_remote_thread) |  | ☑️ |  |  |  |
+| [NEW\_TCP4\_CONNECTION](#new_tcp4_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [NEW\_TCP6\_CONNECTION](#new_tcp6_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [NEW\_UDP4\_CONNECTION](#new_udp4_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [NEW\_UDP6\_CONNECTION](#new_udp6_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [OPEN\_NAMED\_PIPE](#open_named_pipe) |  | ☑️ |  |  |  |
+| [OS\_AUTORUNS\_REP](#os_autoruns_rep) | ☑️ | ☑️ |  |  |  |
+| [OS\_DRIVERS\_REP](#os_drivers_rep) |  | ☑️ |  |  |  |
+| [OS\_KILL\_PROCESS\_REP](#os_kill_process_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [OS\_PACKAGES\_REP](#os_packages_rep) |  | ☑️ |  |  |  |
+| [OS\_PROCESSES\_REP](#os_processes_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [OS\_RESUME\_REP](#os_resume_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [OS\_SERVICES\_REP](#os_services_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [OS\_SUSPEND\_REP](#os_suspend_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [OS\_USERS\_REP](#os_users_rep) |  | ☑️ |  |  |  |
+| [OS\_VERSION\_REP](#os_version_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [PCAP\_LIST\_INTERFACES\_REP](#pcap_list_interfaces_rep) |  |  | ☑️ |  |  |
+| [PROCESS\_ENVIRONMENT](#process_environment) |  | ☑️ | ☑️ |  |  |
 | [RECEIPT](#receipt) | ☑️ | ☑️ | ☑️ | ☑️ |  |
-| [REGISTRY\_CREATE](#registrycreate) |  | ☑️ |  |  |  |
-| [REGISTRY\_DELETE](#registrydelete) |  | ☑️ |  |  |  |
-| [REGISTRY\_LIST\_REP](#reglist) |  | ☑️ |  |  |  |
-| [REGISTRY\_WRITE](#registrywrite) |  | ☑️ |  |  |  |
-| [REJOIN\_NETWORK](#rejoinnetwork) | ☑️ | ☑️ | ☑️ | ☑️ |  |
-| [REMOTE\_PROCESS\_HANDLE](#remoteprocesshandle) |  | ☑️ |  |  |  |
-| [SEGREGATE\_NETWORK](#segregatenetwork) | ☑️ | ☑️ | ☑️ | ☑️ |  |
-| [SENSITIVE\_PROCESS\_ACCESS](#sensitiveprocessaccess) |  | ☑️ |  |  |  |
-| [SERVICE\_CHANGE](#servicechange) | ☑️ | ☑️ | ☑️ |  |  |
-| [SHUTTING\_DOWN](#shuttingdown) | ☑️ | ☑️ | ☑️ |  |  |
-| [SSH\_LOGIN](#sshlogin) | ☑️ |  |  |  |  |
-| [SSH\_LOGOUT](#sshlogout) | ☑️ |  |  |  |  |
-| [STARTING\_UP](#startingup) | ☑️ | ☑️ | ☑️ |  |  |
-| [TERMINATE\_PROCESS](#terminateprocess) | ☑️ | ☑️ | ☑️ |  |  |
-| [TERMINATE\_TCP4\_CONNECTION](#terminatetcp4connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [TERMINATE\_TCP6\_CONNECTION](#terminatetcp6connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [TERMINATE\_UDP4\_CONNECTION](#terminateudp4connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [TERMINATE\_UDP6\_CONNECTION](#terminateudp6connection) | ☑️ | ☑️ | ☑️ |  |  |
-| [THREAD\_INJECTION](#threadinjection) |  | ☑️ |  |  |  |
-| [USER\_LOGIN](#userlogin) | ☑️ |  |  |  |  |
-| [USER\_LOGOUT](#userlogout) | ☑️ |  |  |  |  |
-| [USER\_OBSERVED](#userobserved) | ☑️ | ☑️ | ☑️ |  |  |
-| [VOLUME\_MOUNT](#volumemount) | ☑️ | ☑️ |  |  |  |
-| [VOLUME\_UNMOUNT](#volumeunmount) | ☑️ | ☑️ |  |  |  |
-| [WEL](#wel) |  | ☑️ |  |  |  |
-| [YARA\_DETECTION](#yaradetection) | ☑️ | ☑️ | ☑️ |  |  |
+| [REGISTRY\_CREATE](#registry_create) |  | ☑️ |  |  |  |
+| [REGISTRY\_DELETE](#registry_delete) |  | ☑️ |  |  |  |
+| [REGISTRY\_LIST\_REP](#registry_list_rep) |  | ☑️ |  |  |  |
+| [REGISTRY\_WRITE](#registry_write) |  | ☑️ |  |  |  |
+| [REJOIN\_NETWORK](#rejoin_network) | ☑️ | ☑️ | ☑️ | ☑️ |  |
+| [REMOTE\_PROCESS\_HANDLE](#remote_process_handle) |  | ☑️ |  |  |  |
+| [SEGREGATE\_NETWORK](#segregate_network) | ☑️ | ☑️ | ☑️ | ☑️ |  |
+| [SENSITIVE\_PROCESS\_ACCESS](#sensitive_process_access) |  | ☑️ |  |  |  |
+| [SERVICE\_CHANGE](#service_change) | ☑️ | ☑️ | ☑️ |  |  |
+| [SHUTTING\_DOWN](#shutting_down) | ☑️ | ☑️ | ☑️ |  |  |
+| [SSH\_LOGIN](#ssh_login) | ☑️ |  |  |  |  |
+| [SSH\_LOGOUT](#ssh_logout) | ☑️ |  |  |  |  |
+| [STARTING\_UP](#starting_up) | ☑️ | ☑️ | ☑️ |  |  |
+| [TERMINATE\_PROCESS](#terminate_process) | ☑️ | ☑️ | ☑️ |  |  |
+| [TERMINATE\_TCP4\_CONNECTION](#terminate_tcp4_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [TERMINATE\_TCP6\_CONNECTION](#terminate_tcp6_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [TERMINATE\_UDP4\_CONNECTION](#terminate_udp4_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [TERMINATE\_UDP6\_CONNECTION](#terminate_udp6_connection) | ☑️ | ☑️ | ☑️ |  |  |
+| [THREAD\_INJECTION](#thread_injection) |  | ☑️ |  |  |  |
+| [USER\_LOGIN](#user_login) | ☑️ |  |  |  |  |
+| [USER\_LOGOUT](#user_logout) | ☑️ |  |  |  |  |
+| [USER\_OBSERVED](#user_observed) | ☑️ | ☑️ | ☑️ |  |  |
+| [VOLUME\_MOUNT](#volume_mount) | ☑️ | ☑️ |  |  |  |
+| [VOLUME\_UNMOUNT](#volume_unmount) | ☑️ | ☑️ |  |  |  |
+| WEL |  | ☑️ |  |  |  |
+| [YARA\_DETECTION](#yara_detection) | ☑️ | ☑️ | ☑️ |  |  |
 
 ## Event Descriptions
 

--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -6,62 +6,62 @@ For commands which emit a report/reply event type from the agent, the correspond
 
 | Command | Report/Reply Event | macOS | Windows | Linux | Chrome | Edge |
 | --- | --- | --- | --- | --- | --- | --- |
-| [artifact\_get](#artifactget) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [deny\_tree](#denytree) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [dir\_find\_hash](#dirfindhash) | [DIR\_FINDHASH\_REP](edr-events.md#dirfindhashrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [dir\_list](#dirlist) | [DIR\_LIST\_REP](edr-events.md#dirlistrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [dns\_resolve](#dnsresolve) | [DNS\_REQUEST](edr-events.md#dnsrequest) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [doc\_cache\_get](#doccacheget) | [GET\_DOCUMENT\_REP](edr-events.md#getdocumentrep) | ☑️ | ☑️ |  |  |  |
-| [get\_debug\_data](#getdebugdata) | [DEBUG\_DATA\_REP](edr-events.md#debugdatarep) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_add](#exfiladd) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_del](#exfildel) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_get](#exfilget) | [GET\_EXFIL\_EVENT\_REP](edr-events.md#getexfileventrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_del](#filedel) | [FILE\_DEL\_REP](edr-events.md#filedelrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_get](#fileget) | [FILE\_GET\_REP](edr-events.md#filegetrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_hash](#filehash) | [FILE\_HASH\_REP](edr-events.md#filehashrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_info](#fileinfo) | [FILE\_INFO\_REP](edr-events.md#fileinforep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_mov](#filemov) | [FILE\_MOV\_REP](edr-events.md#filemovrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_add](#fimadd) | [FIM\_ADD](edr-events.md#fimadd) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_del](#fimdel) | [FIM\_DEL](edr-events.md#fimdel) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_get](#fimget) | [FIM\_LIST\_REP](edr-events.md#fimlistrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [hidden\_module\_scan](#hiddenmodulescan) | [HIDDEN\_MODULE\_DETECTED](edr-events.md#hiddenmoduledetected) |  | ☑️ | ☑️ |  |  |
-| [history\_dump](#historydump) | [HISTORY\_DUMP\_REP](edr-events.md#historydumprep) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [log\_get](#logget) | N/A |  | ☑️ |  |  |  |
-| [logoff](#logoff) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_find\_handle](#memfindhandle) | [MEM\_FIND\_HANDLES\_REP](edr-events.md#memfindhandlesrep) |  | ☑️ |  |  |  |
-| [mem\_find\_string](#memfindstring) | [MEM\_FIND\_STRING\_REP](edr-events.md#memfindstringrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_handles](#memhandles) | [MEM\_HANDLES\_REP](edr-events.md#memhandlesrep) |  | ☑️ |  |  |  |
-| [mem\_map](#memmap) | [MEM\_MAP\_REP](edr-events.md#memmaprep) | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_read](#memread) | [MEM\_READ\_REP](edr-events.md#memreadrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_strings](#memstrings) | [MEM\_STRINGS\_REP](edr-events.md#memstringsrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [artifact\_get](#artifact_get) | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| deny\_tree | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [dir\_find\_hash](#dir_findhash) | [DIR\_FINDHASH\_REP](edr-events.md#dirfindhashrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [dir\_list](#dir_list) | [DIR\_LIST\_REP](edr-events.md#dirlistrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [dns\_resolve](#dns_resolve) | [DNS\_REQUEST](edr-events.md#dnsrequest) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [doc\_cache\_get](#doc_cache_get) | [GET\_DOCUMENT\_REP](edr-events.md#getdocumentrep) | ☑️ | ☑️ |  |  |  |
+| [get\_debug\_data](#get_debug_data) | [DEBUG\_DATA\_REP](edr-events.md#debugdatarep) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_add](#exfil_add) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_del](#exfil_del) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_get](#exfil_get) | [GET\_EXFIL\_EVENT\_REP](edr-events.md#getexfileventrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_del](#file_del) | [FILE\_DEL\_REP](edr-events.md#filedelrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_get](#file_get) | [FILE\_GET\_REP](edr-events.md#filegetrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_hash](#file_hash) | [FILE\_HASH\_REP](edr-events.md#filehashrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_info](#file_info) | [FILE\_INFO\_REP](edr-events.md#fileinforep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_mov](#file_mov) | [FILE\_MOV\_REP](edr-events.md#filemovrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_add](#fim_add) | [FIM\_ADD](edr-events.md#fimadd) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_del](#fim_del) | [FIM\_DEL](edr-events.md#fimdel) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_get](#fim_get) | [FIM\_LIST\_REP](edr-events.md#fimlistrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [hidden\_module\_scan](#hidden_module_scan) | [HIDDEN\_MODULE\_DETECTED](edr-events.md#hiddenmoduledetected) |  | ☑️ | ☑️ |  |  |
+| [history\_dump](#history_dump) | [HISTORY\_DUMP\_REP](edr-events.md#historydumprep) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [log\_get](#log_get) | N/A |  | ☑️ |  |  |  |
+| logoff | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [mem\_find\_handle](#mem_find_handle) | [MEM\_FIND\_HANDLES\_REP](edr-events.md#memfindhandlesrep) |  | ☑️ |  |  |  |
+| [mem\_find\_string](#mem_find_string) | [MEM\_FIND\_STRING\_REP](edr-events.md#memfindstringrep) | ☑️ | ☑️ | ☑️ |  |  |
+| mem\_handles | [MEM\_HANDLES\_REP](edr-events.md#memhandlesrep) |  | ☑️ |  |  |  |
+| [mem\_map](#mem_map) | [MEM\_MAP\_REP](edr-events.md#memmaprep) | ☑️ | ☑️ | ☑️ |  |  |
+| [mem\_read](#mem_read) | [MEM\_READ\_REP](edr-events.md#memreadrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [mem\_strings](#mem_strings) | [MEM\_STRINGS\_REP](edr-events.md#memstringsrep) | ☑️ | ☑️ | ☑️ |  |  |
 | [netstat](#netstat) | [NETSTAT\_REP](edr-events.md#netstatrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_autoruns](#osautoruns) | [OS\_AUTORUNS\_REP](edr-events.md#osautorunsrep) | ☑️ | ☑️ |  |  |  |
-| [os\_drivers](#osdrivers) | N/A |  | ☑️ |  |  |  |
-| [os\_kill\_process](#oskillprocess) | [OS\_KILL\_PROCESS\_REP](edr-events.md#oskillprocessrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_packages](#ospackages) | [OS\_PACKAGES\_REP](edr-events.md#ospackagesrep) |  | ☑️ | ☑️ | ☑️ | ☑️ |
-| [os\_processes](#osprocesses) | [OS\_PROCESSES\_REP](edr-events.md#osprocessesrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_resume](#osresume) | [OS\_RESUME\_REP](edr-events.md#osresumerep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_services](#osservices) | [OS\_SERVICES\_REP](edr-events.md#osservicesrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_suspend](#ossuspend) | [OS\_SUSPEND\_REP](edr-events.md#ossuspendrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_users](#osusers) | [OS\_USERS\_REP](edr-events.md#osusersrep) |  | ☑️ |  |  |  |
-| [os\_version](#osversion) | [OS\_VERSION\_REP](edr-events.md#osversionrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [put](#put) | [RECEIPT](edr-events.md#receipt) | ☑️ | ☑️ | ☑️ |  |  |
-| [rejoin\_network](#rejoinnetwork) | [REJOIN\_NETWORK](edr-events.md#rejoinnetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [restart](#restart) | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_autoruns](#os_autoruns) | [OS\_AUTORUNS\_REP](edr-events.md#osautorunsrep) | ☑️ | ☑️ |  |  |  |
+| [os\_drivers](#os_drivers) | N/A |  | ☑️ |  |  |  |
+| [os\_kill\_process](#os_kill_process) | [OS\_KILL\_PROCESS\_REP](edr-events.md#oskillprocessrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_packages](#os_packages) | [OS\_PACKAGES\_REP](edr-events.md#ospackagesrep) |  | ☑️ | ☑️ | ☑️ | ☑️ |
+| [os\_processes](#os_processes) | [OS\_PROCESSES\_REP](edr-events.md#osprocessesrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_resume](#os_resume) | [OS\_RESUME\_REP](edr-events.md#osresumerep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_services](#os_services) | [OS\_SERVICES\_REP](edr-events.md#osservicesrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_suspend](#os_suspend) | [OS\_SUSPEND\_REP](edr-events.md#ossuspendrep) | ☑️ | ☑️ | ☑️ |  |  |
+| os\_users | [OS\_USERS\_REP](edr-events.md#osusersrep) |  | ☑️ |  |  |  |
+| [os\_version](#os_version) | [OS\_VERSION\_REP](edr-events.md#osversionrep) | ☑️ | ☑️ | ☑️ |  |  |
+| put | [RECEIPT](edr-events.md#receipt) | ☑️ | ☑️ | ☑️ |  |  |
+| [rejoin\_network](#rejoin_network) | [REJOIN\_NETWORK](edr-events.md#rejoinnetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| restart | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | [run](#run) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [seal](#seal) |  |  | ☑️ |  |  |  |
-| [segregate\_network](#segregatenetwork) | [SEGREGATE\_NETWORK](edr-events.md#segregatenetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [set\_performance\_mode](#setperformancemode) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [shutdown](#shutdown) |  | ☑️ | ☑️ | ☑️ |  |  |
-| [uninstall](#uninstall) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [yara\_scan](#yarascan) | [YARA\_DETECTION](edr-events.md#yaradetection) | ☑️ | ☑️ | ☑️ |  |  |
-| [yara\_update](#yaraupdate) | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [epp\_status](#eppstatus) | [EPP\_STATUS\_REP] | ☑️ |  |  |  |  |
-| [epp\_scan](#eppscan) | [EPP\_SCAN\_REP] | ☑️ |  |  |  |  |
-| [epp\_list\_exclusions](#epplistexclusions) | [EPP\_LIST\_EXCLUSIONS\_REP] | ☑️ |  |  |  |  |
-| [epp\_add\_exclusion](#eppaddexclusion) | [EPP\_ADD\_EXCLUSION\_REP] | ☑️ |  |  |  |  |
-| [epp\_rem\_exclusion](#eppremexclusion) | [EPP\_REM\_EXCLUSION\_REP] | ☑️ |  |  |  |  |
-| [epp\_list\_quarantine](#epplistquarantine) | [EPP\_LIST\_QUARANTINE\_REP] | ☑️ |  |  |  |  |
+| seal |  |  | ☑️ |  |  |  |
+| [segregate\_network](#segregate_network) | [SEGREGATE\_NETWORK](edr-events.md#segregatenetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| set\_performance\_mode | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| shutdown |  | ☑️ | ☑️ | ☑️ |  |  |
+| uninstall | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [yara\_scan](#yara_scan) | [YARA\_DETECTION](edr-events.md#yaradetection) | ☑️ | ☑️ | ☑️ |  |  |
+| yara\_update | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| epp\_status | [EPP\_STATUS\_REP] | ☑️ |  |  |  |  |
+| [epp\_scan](#epp_scan) | [EPP\_SCAN\_REP] | ☑️ |  |  |  |  |
+| [epp\_list\_exclusions](#epp_list_exclusions) | [EPP\_LIST\_EXCLUSIONS\_REP] | ☑️ |  |  |  |  |
+| [epp\_add\_exclusion](#epp_add_exclusion) | [EPP\_ADD\_EXCLUSION\_REP] | ☑️ |  |  |  |  |
+| [epp\_rem\_exclusion](#epp_rem_exclusion) | [EPP\_REM\_EXCLUSION\_REP] | ☑️ |  |  |  |  |
+| [epp\_list\_quarantine](#epp_list_quarantine) | [EPP\_LIST\_QUARANTINE\_REP] | ☑️ |  |  |  |  |
 
 ## Command Descriptions
 


### PR DESCRIPTION
## Summary

Clears all 150 MD051 (link-fragments) violations across 3 files. These
broken-anchor links were also surfacing as `INFO` messages in
`mkdocs build --strict`, so this PR also drops the build's INFO/WARNING
count from **218 to 68**.

Fourth PR in the lint backlog cleanup. Follow-up to #198, #199, #200.

## Three categories of fix

### 1. Slug rewrites — 127 cases

Most violations were links that typed the slug with underscores
stripped. Example:

```markdown
[AUTORUN\_CHANGE](#autorunchange)   <!-- broken: slug stripped -->
[AUTORUN\_CHANGE](#autorun_change)  <!-- fixed: matches the real heading -->
```

The actual heading `### AUTORUN_CHANGE` is slugified by mkdocs / python-markdown
to `autorun_change` (underscore preserved). Whoever authored the links
hand-typed the slug and dropped the underscore. Each fix was generated by
slugifying the link text (which matches the heading text exactly) and
replacing the bad slug.

### 2. Unwrapped table cells — 20 cases

In `docs/8-reference/edr-events.md` and `docs/8-reference/endpoint-commands.md`,
the top-of-file capability tables wrap each event/command name in a link.
20 of those names have no corresponding `### Heading` later in the file —
the table mentions them, but the doc never had a detail section. Examples:

- edr-events.md: `DATA_DROPPED`, `DELETED_SENSOR`, `EXEC_OOB`, `EXPORT_COMPLETE`,
  `INGEST`, `MODULE_MEM_DISK_MISMATCH`, `NETWORK_SUMMARY`, `WEL`
- endpoint-commands.md: `deny_tree`, `logoff`, `mem_handles`, `os_users`,
  `put`, `restart`, `seal`, `set_performance_mode`, `shutdown`, `uninstall`,
  `yara_update`, `epp_status`

For these, removed the link wrapping but kept the cell text. Tables are
visually intact; the dead links are gone. If these commands/events ever
get detail sections written, the table can be re-linked.

### 3. Stale TOC entries — 3 cases

`docs/6-developer-guide/sdks/go-sdk.md` had a Table of Contents listing
"Advanced Features", "Examples", and "Troubleshooting" sections that
don't exist in the document. Removed those bullet points.

## Verification

- **MD051 count**: 150 → 0
- **Total lint backlog**: 557 → 407 (-150)
- **`mkdocs build --strict`**: 218 → 68 INFO/WARNING messages. The 150
  `Doc file ... contains a link 'foo.md#bar', but the doc ... does not
  contain an anchor 'bar'` INFOs that matched MD051 are gone. The
  remaining 68 are mostly pre-existing **cross-page** broken anchors
  not flagged by MD051 (which checks only same-page `#anchor` links).
  Cross-page anchor cleanup is out of scope for this PR.
- **Rendered HTML**: 4 files differ vs master — `edr-events`,
  `endpoint-commands`, `go-sdk`, and `search_index.json`. All in the
  expected ways:
  - Table-cell `<a>` tags now point to existing IDs
  - 20 dead-link cells unwrapped to plain text
  - 3 stale TOC `<li>` entries removed
- **No regressions**: no new build warnings, no new `class="err"`
  markers, no other pages affected.

## Out of scope (next PRs)

- `MD045` — image alt text (~152 cases)
- `MD036` — bold paragraphs as headings (~72)
- `MD024` — duplicate headings (~59)
- `MD029` — ordered list prefix (~77)
- `MD001` — heading-increment (~33)
- Cross-page broken anchor cleanup (the remaining 64 mkdocs build
  INFOs)
- Final step: drop `continue-on-error: true` from the `check-markdown`
  job once the backlog clears

## Test plan

- [ ] CI `check-markdown` reports 0 MD051 violations
- [ ] CI `Link Checker` (lychee) passes (these are intra-page, so
      lychee's internal checks should now resolve the previously-broken
      `#anchor` references)
- [ ] CI `docs.yml` (mkdocs build) succeeds
- [ ] Visual spot-check of `8-reference/edr-events.md` and
      `8-reference/endpoint-commands.md` table at top of page — confirm
      table is intact and remaining links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)