### PR TITLE
docs: fix cross-page broken anchor links (mkdocs build INFOs)

### DIFF
--- a/docs/1-getting-started/core-concepts.md
+++ b/docs/1-getting-started/core-concepts.md
@@ -93,7 +93,7 @@ When a D&R rule matches an event, LimaCharlie creates a Detection. Detections in
 - Extracted data: Structured IOCs pulled from the event
 - Links: References to documentation or playbooks
 
-[See complete Detection Structure Reference](../3-detection-response/tutorials/writing-testing-rules.md#understanding-detection-structure)
+[See complete Detection Structure Reference](../3-detection-response/tutorials/writing-testing-rules.md)
 
 #### 3. Audit (`audit` stream)
 

--- a/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
@@ -16,7 +16,7 @@ All versions of Debian and CentOS starting around Debian 5 should be supported. 
 
 ### Deb Package
 
-If you are deploying on a Debian Linux system, we recommend using the `.deb` package. You can find a link to the Debian package for various architectures at [Downloading the Agent](../../index.md#downloading-the-agents).
+If you are deploying on a Debian Linux system, we recommend using the `.deb` package. You can find a link to the Debian package for various architectures at [Downloading the Agent](../../index.md).
 
 The deb package will install the LimaCharlie sensor using a `systemd` service, or if unavailable a `system V` service.
 

--- a/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
@@ -12,7 +12,7 @@ Details on manual uninstallation is found at the bottom of each respective OS' i
 
 ### Sensor Commands
 
-For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. More information on that can be found [here](../../8-reference/endpoint-commands.md#uninstall).
+For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. More information on that can be found [here](../../8-reference/endpoint-commands.md).
 
 On Windows, the command defaults to uninstalling the sensor as if installed from the direct installer exe. If an MSI was used for installation, you can add a `--msi` flag to the `uninstall` command to trigger an uninstallation that is compatible with MSI.
 

--- a/docs/2-sensors-deployment/endpoint-agent/vdi/templates.md
+++ b/docs/2-sensors-deployment/endpoint-agent/vdi/templates.md
@@ -6,10 +6,10 @@ The methodology is the same as described above, but you need to be careful to st
 
 The most common mistake is to install the Sensor directly in the template, and then instantiate the rest of the infrastructure from this template. This will result in "cloned sensors", sensors running using the same Sensor ID on different hosts/VMs/Containers.
 
-If these occur, a [sensor\_clone](../../../8-reference/platform-events.md#sensorclone) event will be generated as well as an error in your dashboard. If this happens you have two choices:
+If these occur, a [sensor\_clone](../../../8-reference/platform-events.md#sensor_clone) event will be generated as well as an error in your dashboard. If this happens you have two choices:
 
 1. Fix the installation process and re-deploy.
-2. Run a de-duplication process with a Detection & Response rule [like this](../../../3-detection-response/examples.md#deduplicate-cloned-sensors).
+2. Run a de-duplication process with a Detection & Response rule [like this](../../../3-detection-response/examples.md#de-duplicate-cloned-sensors).
 
 Preparing sensors to run properly from templates can be done by creating a special `hcp_vdi` (macOS and Linux) or `hcp_vdi.dat` (Windows) file in the relevant configuration directory:
 

--- a/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
+++ b/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
@@ -6,7 +6,7 @@
 2. [D&R Rule Fundamentals](#dr-rule-fundamentals)
 3. [Target Types](#target-types)
 4. [Detection Operators](#detection-operators)
-5. [Rule Structure & Configuration](#rule-structure--configuration)
+5. [Rule Structure & Configuration](#rule-structure-configuration) <!-- markdownlint-disable-line MD051 -->
 6. [Response Actions](#response-actions)
 7. [Advanced Features](#advanced-features)
 8. [Cybersecurity Examples by Target Type](#cybersecurity-examples-by-target-type)

--- a/docs/3-detection-response/tutorials/writing-testing-rules.md
+++ b/docs/3-detection-response/tutorials/writing-testing-rules.md
@@ -102,7 +102,7 @@ to apply the following constraints:
 LC supports a lot of different event types, this means that the first thing we should strive to
 do to try to make the rule fail as quickly as possible is to filter all events we don't care about.
 
-In this case, we only care about [CODE_IDENTITY](../../8-reference/edr-events.md#codeidentity) events. We also know that
+In this case, we only care about [CODE_IDENTITY](../../8-reference/edr-events.md#code_identity) events. We also know that
 our rule will use more than one criteria, and those criteria will be AND-ed together because we only
 want to match when they all match.
 

--- a/docs/5-integrations/extensions/third-party/otx.md
+++ b/docs/5-integrations/extensions/third-party/otx.md
@@ -19,17 +19,17 @@ Pulses will be synced to rules and lookups automatically every 3 hours.
 After providing a valid API key, the Extension will automatically create [Detection & Response rules](https://doc.limacharlie.io/docs/detection-and-response) for your organization. The OTX rules make use of the following events:
 
 - Process Events
-  - [CODE_IDENTITY](../../../8-reference/edr-events.md#codeidentity)
-  - [EXISTING_PROCESS](../../../8-reference/edr-events.md#existingprocess)
-  - [MEM_HANDLES_REP](../../../8-reference/edr-events.md#memhandlesrep) (response to the [mem_handles](../../../8-reference/endpoint-commands.md#memhandles) Sensor command)
-  - [NEW_PROCESS](../../../8-reference/edr-events.md#newprocess)
+  - [CODE_IDENTITY](../../../8-reference/edr-events.md#code_identity)
+  - [EXISTING_PROCESS](../../../8-reference/edr-events.md#existing_process)
+  - [MEM_HANDLES_REP](../../../8-reference/edr-events.md#mem_handles_rep) (response to the [mem_handles](../../../8-reference/endpoint-commands.md) Sensor command)
+  - [NEW_PROCESS](../../../8-reference/edr-events.md#new_process)
 - Network Events
-  - [DNS_REQUEST](../../../8-reference/edr-events.md#dnsrequest)
-  - [HTTP_REQUEST](../../../8-reference/edr-events.md#httprequest)
-  - [NETWORK_CONNECTIONS](../../../8-reference/edr-events.md#networkconnections)
-  - [NEW_TCP4_CONNECTION](../../../8-reference/edr-events.md#newtcp4connection)
-  - [NEW_TCP6_CONNECTION](../../../8-reference/edr-events.md#newtcp6connection)
-  - [NEW_UDP4_CONNECTION](../../../8-reference/edr-events.md#newudp4connection)
-  - [NEW_UDP6_CONNECTION](../../../8-reference/edr-events.md#newudp6connection)
+  - [DNS_REQUEST](../../../8-reference/edr-events.md#dns_request)
+  - [HTTP_REQUEST](../../../8-reference/edr-events.md#http_request)
+  - [NETWORK_CONNECTIONS](../../../8-reference/edr-events.md#network_connections)
+  - [NEW_TCP4_CONNECTION](../../../8-reference/edr-events.md#new_tcp4_connection)
+  - [NEW_TCP6_CONNECTION](../../../8-reference/edr-events.md#new_tcp6_connection)
+  - [NEW_UDP4_CONNECTION](../../../8-reference/edr-events.md#new_udp4_connection)
+  - [NEW_UDP6_CONNECTION](../../../8-reference/edr-events.md#new_udp6_connection)
 
 Please ensure that the events you are interested in using with OTX lookups are enabled in the **Sensors >** Event Collection menu.

--- a/docs/5-integrations/outputs/destinations/webhook-bulk.md
+++ b/docs/5-integrations/outputs/destinations/webhook-bulk.md
@@ -3,7 +3,7 @@
 Output batches of events, detections, audits, deployments or artifacts through a POST webhook.
 
 - `dest_host`: the IP or DNS, port and page to HTTP(S) POST to, format `https://www.myorg.com:514/whatever`.
-- `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. This is a required field. [See "Webhook Details" section.](webhook.md#webhook-details)
+- `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. This is a required field. [See "Webhook Details" section.](webhook.md)
 - `auth_header_name` and `auth_header_value`: set a specific value to a specific HTTP header name in the outgoing webhooks.
 - `sec_per_file`: the number of seconds after which a file is cut and uploaded.
 - `is_no_sharding`: do not add a shard directory at the root of the files generated.

--- a/docs/5-integrations/outputs/stream-structures.md
+++ b/docs/5-integrations/outputs/stream-structures.md
@@ -510,7 +510,7 @@ Use deployment events to track sensor health and detect:
 ## Related Documentation
 
 - [Event Structure Reference](../../8-reference/event-schemas.md#event-structure-reference)
-- [Detection Structure](../../3-detection-response/tutorials/writing-testing-rules.md#understanding-detection-structure)
+- [Detection Structure](../../3-detection-response/tutorials/writing-testing-rules.md)
 - [LimaCharlie Data Structures](../../1-getting-started/core-concepts.md#limacharlie-data-structures)
 - [Output Destinations](destinations/amazon-s3.md) - Configuration guides for specific destinations
 - [Testing Outputs](testing.md) - How to validate output configurations

--- a/docs/6-developer-guide/sdks/go-sdk.md
+++ b/docs/6-developer-guide/sdks/go-sdk.md
@@ -13,7 +13,7 @@ The LimaCharlie Go SDK provides a comprehensive client library for interacting w
 - [Client Initialization](#client-initialization)
 - [Core Components](#core-components)
   - [Sensor Management](#sensor-management)
-  - [Detection & Response Rules](#detection--response-rules)
+  - [Detection & Response Rules](#detection-response-rules) <!-- markdownlint-disable-line MD051 -->
   - [Artifacts](#artifacts)
   - [Events and Data Streaming](#events-and-data-streaming)
   - [Organization Management](#organization-management)

--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -8,53 +8,53 @@ For commands which emit a report/reply event type from the agent, the correspond
 | --- | --- | --- | --- | --- | --- | --- |
 | [artifact\_get](#artifact_get) | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | deny\_tree | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [dir\_find\_hash](#dir_findhash) | [DIR\_FINDHASH\_REP](edr-events.md#dirfindhashrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [dir\_list](#dir_list) | [DIR\_LIST\_REP](edr-events.md#dirlistrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [dns\_resolve](#dns_resolve) | [DNS\_REQUEST](edr-events.md#dnsrequest) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
-| [doc\_cache\_get](#doc_cache_get) | [GET\_DOCUMENT\_REP](edr-events.md#getdocumentrep) | ☑️ | ☑️ |  |  |  |
-| [get\_debug\_data](#get_debug_data) | [DEBUG\_DATA\_REP](edr-events.md#debugdatarep) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_add](#exfil_add) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_del](#exfil_del) | [CLOUD\_NOTIFICATION](edr-events.md#cloudnotification) | ☑️ | ☑️ | ☑️ |  |  |
-| [exfil\_get](#exfil_get) | [GET\_EXFIL\_EVENT\_REP](edr-events.md#getexfileventrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_del](#file_del) | [FILE\_DEL\_REP](edr-events.md#filedelrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_get](#file_get) | [FILE\_GET\_REP](edr-events.md#filegetrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_hash](#file_hash) | [FILE\_HASH\_REP](edr-events.md#filehashrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_info](#file_info) | [FILE\_INFO\_REP](edr-events.md#fileinforep) | ☑️ | ☑️ | ☑️ |  |  |
-| [file\_mov](#file_mov) | [FILE\_MOV\_REP](edr-events.md#filemovrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_add](#fim_add) | [FIM\_ADD](edr-events.md#fimadd) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_del](#fim_del) | [FIM\_DEL](edr-events.md#fimdel) | ☑️ | ☑️ | ☑️ |  |  |
-| [fim\_get](#fim_get) | [FIM\_LIST\_REP](edr-events.md#fimlistrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [hidden\_module\_scan](#hidden_module_scan) | [HIDDEN\_MODULE\_DETECTED](edr-events.md#hiddenmoduledetected) |  | ☑️ | ☑️ |  |  |
-| [history\_dump](#history_dump) | [HISTORY\_DUMP\_REP](edr-events.md#historydumprep) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [dir\_find\_hash](#dir_findhash) | [DIR\_FINDHASH\_REP](edr-events.md#dir_findhash_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [dir\_list](#dir_list) | [DIR\_LIST\_REP](edr-events.md#dir_list_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [dns\_resolve](#dns_resolve) | [DNS\_REQUEST](edr-events.md#dns_request) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [doc\_cache\_get](#doc_cache_get) | [GET\_DOCUMENT\_REP](edr-events.md#get_document_rep) | ☑️ | ☑️ |  |  |  |
+| [get\_debug\_data](#get_debug_data) | [DEBUG\_DATA\_REP](edr-events.md#debug_data_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_add](#exfil_add) | [CLOUD\_NOTIFICATION](edr-events.md#cloud_notification) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_del](#exfil_del) | [CLOUD\_NOTIFICATION](edr-events.md#cloud_notification) | ☑️ | ☑️ | ☑️ |  |  |
+| [exfil\_get](#exfil_get) | [GET\_EXFIL\_EVENT\_REP](edr-events.md#get_exfil_event_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_del](#file_del) | [FILE\_DEL\_REP](edr-events.md#file_del_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_get](#file_get) | [FILE\_GET\_REP](edr-events.md#file_get_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_hash](#file_hash) | [FILE\_HASH\_REP](edr-events.md#file_hash_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_info](#file_info) | [FILE\_INFO\_REP](edr-events.md#file_info_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_mov](#file_mov) | [FILE\_MOV\_REP](edr-events.md#file_mov_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_add](#fim_add) | [FIM\_ADD](edr-events.md#fim_add) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_del](#fim_del) | [FIM\_REMOVE](edr-events.md#fim_remove) | ☑️ | ☑️ | ☑️ |  |  |
+| [fim\_get](#fim_get) | [FIM\_LIST\_REP](edr-events.md#fim_list_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [hidden\_module\_scan](#hidden_module_scan) | [HIDDEN\_MODULE\_DETECTED](edr-events.md#hidden_module_detected) |  | ☑️ | ☑️ |  |  |
+| [history\_dump](#history_dump) | [HISTORY\_DUMP\_REP](edr-events.md#history_dump_rep) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | [log\_get](#log_get) | N/A |  | ☑️ |  |  |  |
 | logoff | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_find\_handle](#mem_find_handle) | [MEM\_FIND\_HANDLES\_REP](edr-events.md#memfindhandlesrep) |  | ☑️ |  |  |  |
-| [mem\_find\_string](#mem_find_string) | [MEM\_FIND\_STRING\_REP](edr-events.md#memfindstringrep) | ☑️ | ☑️ | ☑️ |  |  |
-| mem\_handles | [MEM\_HANDLES\_REP](edr-events.md#memhandlesrep) |  | ☑️ |  |  |  |
-| [mem\_map](#mem_map) | [MEM\_MAP\_REP](edr-events.md#memmaprep) | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_read](#mem_read) | [MEM\_READ\_REP](edr-events.md#memreadrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [mem\_strings](#mem_strings) | [MEM\_STRINGS\_REP](edr-events.md#memstringsrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [netstat](#netstat) | [NETSTAT\_REP](edr-events.md#netstatrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_autoruns](#os_autoruns) | [OS\_AUTORUNS\_REP](edr-events.md#osautorunsrep) | ☑️ | ☑️ |  |  |  |
+| [mem\_find\_handle](#mem_find_handle) | [MEM\_FIND\_HANDLES\_REP](edr-events.md#mem_find_handles_rep) |  | ☑️ |  |  |  |
+| [mem\_find\_string](#mem_find_string) | [MEM\_FIND\_STRING\_REP](edr-events.md#mem_find_string_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| mem\_handles | [MEM\_HANDLES\_REP](edr-events.md#mem_handles_rep) |  | ☑️ |  |  |  |
+| [mem\_map](#mem_map) | [MEM\_MAP\_REP](edr-events.md#mem_map_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [mem\_read](#mem_read) | [MEM\_READ\_REP](edr-events.md#mem_read_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [mem\_strings](#mem_strings) | [MEM\_STRINGS\_REP](edr-events.md#mem_strings_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [netstat](#netstat) | [NETSTAT\_REP](edr-events.md#netstat_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_autoruns](#os_autoruns) | [OS\_AUTORUNS\_REP](edr-events.md#os_autoruns_rep) | ☑️ | ☑️ |  |  |  |
 | [os\_drivers](#os_drivers) | N/A |  | ☑️ |  |  |  |
-| [os\_kill\_process](#os_kill_process) | [OS\_KILL\_PROCESS\_REP](edr-events.md#oskillprocessrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_packages](#os_packages) | [OS\_PACKAGES\_REP](edr-events.md#ospackagesrep) |  | ☑️ | ☑️ | ☑️ | ☑️ |
-| [os\_processes](#os_processes) | [OS\_PROCESSES\_REP](edr-events.md#osprocessesrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_resume](#os_resume) | [OS\_RESUME\_REP](edr-events.md#osresumerep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_services](#os_services) | [OS\_SERVICES\_REP](edr-events.md#osservicesrep) | ☑️ | ☑️ | ☑️ |  |  |
-| [os\_suspend](#os_suspend) | [OS\_SUSPEND\_REP](edr-events.md#ossuspendrep) | ☑️ | ☑️ | ☑️ |  |  |
-| os\_users | [OS\_USERS\_REP](edr-events.md#osusersrep) |  | ☑️ |  |  |  |
-| [os\_version](#os_version) | [OS\_VERSION\_REP](edr-events.md#osversionrep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_kill\_process](#os_kill_process) | [OS\_KILL\_PROCESS\_REP](edr-events.md#os_kill_process_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_packages](#os_packages) | [OS\_PACKAGES\_REP](edr-events.md#os_packages_rep) |  | ☑️ | ☑️ | ☑️ | ☑️ |
+| [os\_processes](#os_processes) | [OS\_PROCESSES\_REP](edr-events.md#os_processes_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_resume](#os_resume) | [OS\_RESUME\_REP](edr-events.md#os_resume_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_services](#os_services) | [OS\_SERVICES\_REP](edr-events.md#os_services_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [os\_suspend](#os_suspend) | [OS\_SUSPEND\_REP](edr-events.md#os_suspend_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| os\_users | [OS\_USERS\_REP](edr-events.md#os_users_rep) |  | ☑️ |  |  |  |
+| [os\_version](#os_version) | [OS\_VERSION\_REP](edr-events.md#os_version_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | put | [RECEIPT](edr-events.md#receipt) | ☑️ | ☑️ | ☑️ |  |  |
-| [rejoin\_network](#rejoin_network) | [REJOIN\_NETWORK](edr-events.md#rejoinnetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [rejoin\_network](#rejoin_network) | [REJOIN\_NETWORK](edr-events.md#rejoin_network) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | restart | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | [run](#run) | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | seal |  |  | ☑️ |  |  |  |
-| [segregate\_network](#segregate_network) | [SEGREGATE\_NETWORK](edr-events.md#segregatenetwork) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [segregate\_network](#segregate_network) | [SEGREGATE\_NETWORK](edr-events.md#segregate_network) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | set\_performance\_mode | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | shutdown |  | ☑️ | ☑️ | ☑️ |  |  |
 | uninstall | N/A | ☑️ | ☑️ | ☑️ |  |  |
-| [yara\_scan](#yara_scan) | [YARA\_DETECTION](edr-events.md#yaradetection) | ☑️ | ☑️ | ☑️ |  |  |
+| [yara\_scan](#yara_scan) | [YARA\_DETECTION](edr-events.md#yara_detection) | ☑️ | ☑️ | ☑️ |  |  |
 | yara\_update | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | epp\_status | [EPP\_STATUS\_REP] | ☑️ |  |  |  |  |
 | [epp\_scan](#epp_scan) | [EPP\_SCAN\_REP] | ☑️ |  |  |  |  |

--- a/docs/8-reference/response-actions.md
+++ b/docs/8-reference/response-actions.md
@@ -188,7 +188,7 @@ You can also specify a `based on report: true` parameter. When true (defaults to
 
 ### isolate network
 
-Isolates the sensor from the network in a persistent fashion (if the sensor/host reboots, it will remain isolated). Only works on platforms supporting the `segregate_network` [sensor command](endpoint-commands.md#segregatenetwork).
+Isolates the sensor from the network in a persistent fashion (if the sensor/host reboots, it will remain isolated). Only works on platforms supporting the `segregate_network` [sensor command](endpoint-commands.md#segregate_network).
 
 ```text
 - action: isolate network
@@ -200,7 +200,7 @@ When the network isolation feature is used, LimaCharlie will block connections t
 
 ### seal
 
-Seals the sensor in a persistent fashion (if the sensor/host reboots, it will remain sealed). Only works on platforms supporting the `seal` [sensor command](endpoint-commands.md#seal).
+Seals the sensor in a persistent fashion (if the sensor/host reboots, it will remain sealed). Only works on platforms supporting the `seal` [sensor command](endpoint-commands.md).
 
 ```text
 - action: seal

--- a/docs/8-reference/sensor-selector-expressions.md
+++ b/docs/8-reference/sensor-selector-expressions.md
@@ -7,8 +7,8 @@ The following fields are available in this evaluation:
 - `sid`: the Sensor ID
 - `oid`: the Organization ID
 - `iid`: the Installation Key ID
-- `plat`: the Platform name (see [platforms](id-schema.md#platforms))
-- `ext_plat`: the Extended Platform name (see [platforms](id-schema.md#platforms))
+- `plat`: the Platform name (see [platforms](id-schema.md#platform))
+- `ext_plat`: the Extended Platform name (see [platforms](id-schema.md#platform))
 - `arch`: the Architecture name (see [architectures](id-schema.md#architecture))
 - `enroll`: the Enrollment as a second epoch timestamp
 - `hostname`: the hostname

--- a/docs/9-ai-sessions/index.md
+++ b/docs/9-ai-sessions/index.md
@@ -76,7 +76,7 @@ respond:
 
 ### For User Sessions
 
-1. [Register](user-sessions.md#registration) for AI Sessions
+1. [Register](user-sessions.md#step-1-registration) for AI Sessions
 2. Store your Anthropic credentials (API key or OAuth)
 3. Create a session and start interacting
 


### PR DESCRIPTION
## Summary

Follow-up to #201. Fixes the **64 cross-page** broken-anchor links that
remained after #201 cleared the same-page (MD051) ones. These weren't
flagged by markdownlint — `MD051` only checks same-page `#anchor` links —
but `mkdocs build --strict` surfaces them as
`INFO Doc file 'X' contains a link 'Y.md#Z', but the doc 'Y.md' does
not contain an anchor '#Z'`.

This drops the build's INFO/WARNING count from **68 → 6**. The remaining
6 are just startup / completion notices (no broken-anchor INFOs left).

## Categories

### 53 auto-resolved slug rewrites

Same root cause as #201: hand-typed slugs that don't match the actual
heading slugs (mostly the underscore-stripped pattern,
`#dnsrequest` → `#dns_request`). Resolved by slugifying the link text
and matching against existing headings in the target file.

### 11 manual decisions

**6 dropped anchors** (target heading doesn't exist; link retargets to
the page top):

| File | Old link | Notes |
|---|---|---|
| `core-concepts.md` | `writing-testing-rules.md#understanding-detection-structure` | section never existed |
| `stream-structures.md` | same as above | same |
| `uninstallation.md` | `endpoint-commands.md#uninstall` | `uninstall` row unwrapped in #201 |
| `linux/installation.md` | `index.md#downloading-the-agents` | section never existed |
| `otx.md` | `endpoint-commands.md#memhandles` | `mem_handles` unwrapped in #201 |
| `webhook-bulk.md` | `webhook.md#webhook-details` | section never existed |
| `response-actions.md` | `endpoint-commands.md#seal` | `seal` unwrapped in #201 |

**1 stale rename**: `endpoint-commands.md` capability table had
`[FIM_DEL](edr-events.md#fimdel)` but the event was renamed to
`FIM_REMOVE`. Updated both link text and anchor. The agent command is
still called `fim_del`, but the event it produces is `FIM_REMOVE` (per
the description on the event's section in `edr-events.md`).

**2 slug rewrites**:
- `sensor-selector-expressions.md` → `id-schema.md#platforms` is now
  `#platform` (heading is `## Platform`, singular).
- `ai-sessions/index.md` → `user-sessions.md#registration` is now
  `#step-1-registration` (heading is `### Step 1: Registration`).

**2 inline lint disables**: markdownlint and mkdocs disagree on slugs
for headings containing `&`. Markdownlint expects `--` (preserves the
spaces around `&`), mkdocs / python-markdown collapses to `-`. Since
users navigate via mkdocs, the link must be mkdocs-correct; the
markdownlint complaint is false. Added
`<!-- markdownlint-disable-line MD051 -->` to silence the false
positives:
- `dr-rule-building-guidebook.md` `Rule Structure & Configuration`
- `go-sdk.md` `Detection & Response Rules`

## Verification

- **`mkdocs build --strict`**: 68 → 6 INFO/WARNING messages. The 62
  broken-anchor INFOs are gone; remaining 6 are deprecation/build/
  completion notices.
- **Total lint backlog**: 407 → 407. The 2 disable-line comments
  offset the 2 markdownlint slug-disagreement violations my fixes
  introduced.
- **Rendered HTML**: 15 pages differ vs master, all expected — broken
  links now resolve to actual IDs; dead links retarget to page top;
  no new `class="err"` markers anywhere.
- **`llms.txt`**: byte-identical to master (28,075 bytes).

## Out of scope (next PRs)

- `MD045` — image alt text (~152 cases) — next on the substantive backlog
- `MD036` — bold paragraphs as headings (~72)
- `MD024` — duplicate headings (~59)
- `MD029` — ordered list prefix (~77)
- `MD001` — heading-increment (~33)
- Final step: drop `continue-on-error: true` from the `check-markdown`
  CI job once the backlog clears

## Test plan

- [ ] CI `Link Checker` (lychee) passes — internal links should now
      resolve, since these are exactly the cross-page anchors lychee
      checks
- [ ] CI `docs.yml` (mkdocs build) succeeds and emits no broken-anchor
      INFOs
- [ ] Visual spot-check of the FIM_REMOVE row in
      `8-reference/endpoint-commands.md` capability table

🤖 Generated with [Claude Code](https://claude.com/claude-code)