### PR TITLE
ci(markdownlint): enforce check-markdown — drop continue-on-error

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -156,4 +156,3 @@ jobs:
               "MD046": false,
               "MD024": { "siblings_only": true }
             }
-        continue-on-error: true

--- a/markdown-lint.md
+++ b/markdown-lint.md
@@ -2,11 +2,11 @@
 
 This repo's CI runs [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2)
 against every file under `docs/` (see `.github/workflows/link-checker.yml`,
-job `check-markdown`). The job is currently `continue-on-error: true`, so
-violations are reported but do not block merges.
+job `check-markdown`). The job is **enforced** — violations fail CI and
+block merges.
 
 This doc explains how to run the linter locally, interpret the output, and
-make progress on the backlog so the check can eventually be enforced.
+fix violations before pushing.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Closes the markdownlint backlog initiative started by Bill in #197.

With #204 merged, the lint backlog reached **0**. The
`check-markdown` CI job no longer needs to be advisory, so this drops
`continue-on-error: true` — future violations will fail CI and block
merges.

Also updates `markdown-lint.md` to reflect the new state.

## Backlog history

| PR | Rule(s) cleared | Backlog after |
|---|---|---|
| #198 | mechanical `--fix` pass + structural fence fix | 972 |
| #199 | MD040 (language tags) | 740 |
| #200 | MD046 disabled (extension conflict) | 557 |
| #201 | MD051 same-page anchors | 407 |
| #202 | cross-page anchors (mkdocs INFOs) | 407 |
| #203 | MD045 alt text | 255 |
| #204 | MD036 / MD024 / MD029 / MD001 + residuals | 0 |
| #205 | enforce | 0 |

## Final CI config

```json
{
  "default": true,
  "MD013": false,
  "MD033": false,
  "MD041": false,
  "MD046": false,
  "MD024": { "siblings_only": true }
}
```

## Verification

- `markdownlint-cli2` returns 0 violations across `docs/**/*.md`
- Workflow YAML parses cleanly

## Test plan

- [ ] CI `check-markdown` runs and passes (without
      `continue-on-error`)
- [ ] Future PR introducing a violation should fail CI as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)