### PR TITLE
docs: rewrite generic '[here]' / '[link]' link text (MD059)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,12 +6,11 @@
     "MD041": false,
     "MD046": false,
     "MD024": { "siblings_only": true },
-    // New in markdownlint v0.40.0 — not yet triaged. ~1,400 + ~100 violations
-    // exist across the docs (table column alignment and "click here" style
-    // link text). Each is a candidate for a dedicated cleanup PR; until then,
-    // keep them off so CI stays green on the stable backlog.
-    "MD060": false,
-    "MD059": false
+    // New in markdownlint v0.40.0. MD060 (table-column-style) still has
+    // ~1,400 violations across the docs and is deferred for a dedicated
+    // cleanup PR. MD059 (descriptive-link-text) was cleared in PR #207
+    // and is now enforced.
+    "MD060": false
   },
   "globs": ["docs/**/*.md"]
 }

--- a/docs/2-sensors-deployment/adapters/tutorials/google-cloud-logs.md
+++ b/docs/2-sensors-deployment/adapters/tutorials/google-cloud-logs.md
@@ -161,4 +161,4 @@ That's it, you're good to go!
 
 The next step towards production would be to run the Adapter as a service, or within tmux/screen on the Linux host. Alternatively you could also replicate the above setup using the [Docker container](https://hub.docker.com/r/refractionpoint/lc-adapter) and a serverless platform like Cloud Run.
 
-For more documentation on configuring Adapters, see [here](../usage.md).
+For more documentation, see [Configuring Adapters](../usage.md).

--- a/docs/2-sensors-deployment/adapters/types/1password.md
+++ b/docs/2-sensors-deployment/adapters/types/1password.md
@@ -2,7 +2,7 @@
 
 [1Password](https://1password.com/) provides an events API to fetch audit logs. Events can be ingested directly via a cloud-to-cloud or CLI Adapter.
 
-See 1Password's official API documentation [here](https://developer.1password.com/docs/events-api/reference/).
+See [1Password's official Events API documentation](https://developer.1password.com/docs/events-api/reference/).
 
 1Password telemetry can be addressed via the `1password` platform.
 

--- a/docs/2-sensors-deployment/adapters/types/atlassian.md
+++ b/docs/2-sensors-deployment/adapters/types/atlassian.md
@@ -22,7 +22,7 @@ Jira events are ingested via a cloud-to-cloud webhook Adapter, configured to rec
 
 ### 1. Creating the LimaCharlie Webhook Adapter
 
-The following steps are modified from the generic webhook adapter creation documentation, found [here](../tutorials/webhook-adapter.md).
+These steps are adapted from the [generic webhook adapter creation guide](../tutorials/webhook-adapter.md).
 
 Creating a Webhook Adapter requires a set of parameters, including organization ID, Installation Key, platform, and mapping details. The following configuration has been provided to configure a webhook Adapter for ingesting Jira events:
 

--- a/docs/2-sensors-deployment/adapters/types/azure-event-hub.md
+++ b/docs/2-sensors-deployment/adapters/types/azure-event-hub.md
@@ -10,7 +10,7 @@ This Adapter allows you to connect to an Azure Event Hub to fetch structured dat
 - Entra ID [formerly Azure AD] (Platform: `azure_ad`)
 - Microsoft Defender (Platform: `msdefender`)
 
-Documentation for creating an event hub can be found here [here](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
+Microsoft has [documentation for creating an Event Hub](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
 
 ## Configuring Data Streams
 

--- a/docs/2-sensors-deployment/adapters/types/azure/kubernetes-service.md
+++ b/docs/2-sensors-deployment/adapters/types/azure/kubernetes-service.md
@@ -2,7 +2,7 @@
 
 [Azure Kubernetes Service](https://azure.microsoft.com/en-us/products/kubernetes-service) (AKS) is a quick way to start developing and deploying cloud-native apps in Azure. LimaCharlie can ingest Azure Kubernetes Service logs.
 
-More information about Azure Kubernetes logs and metrics can be found [here](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-livedata-overview).
+Microsoft has [more information about Azure Kubernetes logs and metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-livedata-overview).
 
 ## Log Ingestion
 

--- a/docs/2-sensors-deployment/adapters/types/azure/monitor.md
+++ b/docs/2-sensors-deployment/adapters/types/azure/monitor.md
@@ -1,6 +1,6 @@
 # Azure Monitor
 
-Azure Monitor Logs are a feature of Azure Monitor that collect and organize log and performance data from monitored resources. More information on Azure Monitor Logs can be found [here](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs).
+Azure Monitor Logs are a feature of Azure Monitor that collect and organize log and performance data from monitored resources. See Microsoft's [Azure Monitor Logs reference](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs) for more detail.
 
 LimaCharlie can ingest and natively parse Azure Monitor Logs.
 

--- a/docs/2-sensors-deployment/adapters/types/azure/network-security-group.md
+++ b/docs/2-sensors-deployment/adapters/types/azure/network-security-group.md
@@ -1,6 +1,6 @@
 # Azure Network Security Group
 
-Azure Network security groups help filter network traffic between Azure resources in an Azure virtual network. More information on Azure network security groups can be found [here](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview).
+Azure Network security groups help filter network traffic between Azure resources in an Azure virtual network. See Microsoft's [Network security groups overview](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview) for more detail.
 
 LimaCharlie can ingest and natively parse Azure Network Security Group logs.
 

--- a/docs/2-sensors-deployment/adapters/types/azure/sql-audit-logs.md
+++ b/docs/2-sensors-deployment/adapters/types/azure/sql-audit-logs.md
@@ -1,6 +1,6 @@
 # Azure SQL Audit Logs
 
-Microsoft Azure SQL is a scalable, cloud-hosted database that integrates with the Azure ecosystem. More information on Azure SQL can be found [here](https://azure.microsoft.com/en-us/products/azure-sql/database).
+Microsoft Azure SQL is a scalable, cloud-hosted database that integrates with the Azure ecosystem. See Microsoft's [Azure SQL Database product page](https://azure.microsoft.com/en-us/products/azure-sql/database) for more detail.
 
 LimaCharlie can ingest and natively parse Azure SQL Server audit logs.
 

--- a/docs/2-sensors-deployment/adapters/types/canarytokens.md
+++ b/docs/2-sensors-deployment/adapters/types/canarytokens.md
@@ -6,7 +6,7 @@ Canarytokens can be ingested in LimaCharlie via a Webhook Adapter, and are recog
 
 ## A Little More
 
-LimaCharlie published a blog post in April 2023 to discuss the Canarytoken integration. You can read more about that [here](https://limacharlie.io/blog/early-warnings-with-limacharlie-and-canarytokens).
+LimaCharlie published a [blog post about the Canarytoken integration](https://limacharlie.io/blog/early-warnings-with-limacharlie-and-canarytokens) in April 2023.
 
 ## Adapter Deployment
 
@@ -27,7 +27,7 @@ Click **Complete Cloud Installation** to create the cloud-to-cloud Adapter. Proc
 
 ### 1b. Initial deployment via the LimaCharlie CLI
 
-A Canarytokens Adapter can be deployed via the LimaCharlie CLI. The following step is modified from the generic Webhook Adapter created documentation, found [here](../tutorials/webhook-adapter.md).
+A Canarytokens Adapter can be deployed via the LimaCharlie CLI. The step is adapted from the [generic Webhook Adapter creation guide](../tutorials/webhook-adapter.md).
 
 The following configuration can be modified to easily configure a Webhook Adapter for receiving Canarytokens events.
 

--- a/docs/2-sensors-deployment/adapters/types/cato.md
+++ b/docs/2-sensors-deployment/adapters/types/cato.md
@@ -22,7 +22,7 @@ Adapter Type: `cato`
 
 ### Manual Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/crowdstrike.md
+++ b/docs/2-sensors-deployment/adapters/types/crowdstrike.md
@@ -22,7 +22,7 @@ Adapter Type: `falconcloud`
 
 ### Manual Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/duo.md
+++ b/docs/2-sensors-deployment/adapters/types/duo.md
@@ -8,7 +8,7 @@ This Adapter allows you to connect to the Duo Admin API and fetch logs from it.
 
 Adapter Type: `duo`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `integration_key`: an integration key created from within Duo that associated with your "app".
 - `secret_key`: the secret key for your "app".
 - `api_hostname`: the DNS for your "app", a value given to you by Duo.

--- a/docs/2-sensors-deployment/adapters/types/evtx.md
+++ b/docs/2-sensors-deployment/adapters/types/evtx.md
@@ -10,7 +10,7 @@ For real-time collection of Windows Event Logs, see the [Windows Event Logs](../
 
 Adapter Type: `evtx`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `file_path`: path to the `.evtx` file to ingest.
 - `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
@@ -30,7 +30,7 @@ evtx:
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 /path/to/lc_adapter evtx \

--- a/docs/2-sensors-deployment/adapters/types/file.md
+++ b/docs/2-sensors-deployment/adapters/types/file.md
@@ -60,7 +60,7 @@ file:
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/google-cloud-pubsub.md
+++ b/docs/2-sensors-deployment/adapters/types/google-cloud-pubsub.md
@@ -8,7 +8,7 @@ This Adapter allows you to ingest events from a Google Cloud Pubsub subscription
 
 Adapter Type: `pubsub`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `sub_name`: the name of the subscription to subscribe to.
 - `service_account_creds`: the string version of the JSON credentials for a (Google) Service Account to use accessing the subscription.
 - `project_name`: project name where the `sub_name` exists.

--- a/docs/2-sensors-deployment/adapters/types/google-cloud-storage.md
+++ b/docs/2-sensors-deployment/adapters/types/google-cloud-storage.md
@@ -10,7 +10,7 @@ Note that this adapter operates as a sink by default, meaning it will "consume" 
 
 Adapter Type: `gcs`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `bucket_name`: the name of the bucket to ingest from.
 - `service_account_creds`: the string version of the JSON credentials for a (Google) Service Account to use accessing the bucket.
 - `prefix`: only ingest files with a given path prefix.

--- a/docs/2-sensors-deployment/adapters/types/hubspot.md
+++ b/docs/2-sensors-deployment/adapters/types/hubspot.md
@@ -21,7 +21,7 @@ Adapter Type: `hubspot`
 
 ### Manual Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/imap.md
+++ b/docs/2-sensors-deployment/adapters/types/imap.md
@@ -8,7 +8,7 @@ This Adapter allows you to ingest emails as events from an IMAP server.
 
 Adapter Type: `imap`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `server`: the domain and port of the IMAP server, like `imap.gmail.com:993`.
 - `username`: the user name to log in to IMAP as.
 - `password`: the password for the above user name.

--- a/docs/2-sensors-deployment/adapters/types/json.md
+++ b/docs/2-sensors-deployment/adapters/types/json.md
@@ -54,7 +54,7 @@ file:
 
 ## CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/kubernetes-pods.md
+++ b/docs/2-sensors-deployment/adapters/types/kubernetes-pods.md
@@ -6,7 +6,7 @@ This Adapter allows you to ingest the logs from the pods running in a Kubernetes
 
 The adapter relies on local filesystem access to the standard Kubernetes pod logging structure. This means the adapter is best run as a Daemon Set in Kubernetes with the pod logs location mounted (usually `/var/log/pods`).
 
-A public Docker container is available [here](https://hub.docker.com/r/refractionpoint/lc-adapter-k8s-pods) as `refractionpoint/lc-adapter-k8s-pods`.
+A [public Docker container](https://hub.docker.com/r/refractionpoint/lc-adapter-k8s-pods) is available as `refractionpoint/lc-adapter-k8s-pods`.
 
 ## Configurations
 
@@ -14,7 +14,7 @@ Adapter Type: `k8s_pods`
 
 The following fields are required for configuration:
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `root`: The root of the Kubernetes directory storing logs, usually `/var/log/pods`.
 
 ### Infrastructure as Code Deployment

--- a/docs/2-sensors-deployment/adapters/types/mac-unified-logging.md
+++ b/docs/2-sensors-deployment/adapters/types/mac-unified-logging.md
@@ -20,7 +20,7 @@ All adapters support the same `client_options`, which you should always specify 
 
 ## CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/microsoft-365.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-365.md
@@ -82,7 +82,7 @@ office365:
 
 To establish an Office 365 adapter, we will need to complete a few steps within the Azure portal. Ensure that you have the correct permissions to set up a new App registration.
 
-- Within the Microsoft Azure portal, create a new App registration. You can follow Microsoft's Quickstart guide [here](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
+- Within the Microsoft Azure portal, create a new App registration. See Microsoft's [App registration Quickstart](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
 - The LimaCharlie connector requires a secret for Office 365 data. You can create one under `Certificates & secrets`. Be sure to copy this value and save it somewhere - you can only view it once.
 
 ![image.png](../../../assets/images/image(73).png)
@@ -148,4 +148,4 @@ value: anon
   name: OneDrive File Accessed by Anonymous User
 ```
 
-Note that in the detection above, we pivot on the `FileAccessed` event, which is associated with SharePoint activity. Available event types will depend on source activity and events ingested. More information on audit log activities can be found [here](https://learn.microsoft.com/en-us/purview/audit-log-activities).
+Note that in the detection above, we pivot on the `FileAccessed` event, which is associated with SharePoint activity. Available event types will depend on source activity and events ingested. See Microsoft's [audit log activities reference](https://learn.microsoft.com/en-us/purview/audit-log-activities).

--- a/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
@@ -4,7 +4,7 @@
 
 LimaCharlie can ingest [Microsoft 365 Defender logs](https://learn.microsoft.com/en-us/microsoft-365/security/defender/microsoft-365-defender?view=o365-worldwide) via three methods [Azure Event Hub](azure-event-hub.md) Adapter, the [Microsoft Defender API](https://learn.microsoft.com/en-us/defender-endpoint/api/exposed-apis-create-app-nativeapp), or a Custom Webhook
 
-Documentation for creating an event hub can be found here [here](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
+Microsoft has [documentation for creating an Event Hub](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
 
 Telemetry Platform: `msdefender`
 

--- a/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
@@ -58,9 +58,9 @@ If utilizing the helper, only two fields are required:
 - Name for the adapter
 - Connection string to the Azure Event Hub
 
-You can find more information about Azure Event Hub Adapters [here](azure-event-hub.md).
+See the [Azure Event Hub Adapter documentation](azure-event-hub.md) for more information.
 
-Documentation for creating an event hub can be found here [here](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
+Microsoft has [documentation for creating an Event Hub](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create).
 
 ### Entra ID API
 

--- a/docs/2-sensors-deployment/adapters/types/mimecast.md
+++ b/docs/2-sensors-deployment/adapters/types/mimecast.md
@@ -22,7 +22,7 @@ Adapter Type: `mimecast`
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/okta.md
+++ b/docs/2-sensors-deployment/adapters/types/okta.md
@@ -22,7 +22,7 @@ Adapter Type: `okta`
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/pandadoc.md
+++ b/docs/2-sensors-deployment/adapters/types/pandadoc.md
@@ -21,7 +21,7 @@ Adapter Type: `pandadoc`
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/adapters/types/s3.md
+++ b/docs/2-sensors-deployment/adapters/types/s3.md
@@ -34,7 +34,7 @@ Required IAM Permissions:
 
 Adapter Type: `s3`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `bucket_name`: the name of the bucket to ingest from.
 - `access_key`: an Access Key from S3 used to access the bucket.
 - `secret_key`: the secret key associated with the `access_key` used to access the bucket.

--- a/docs/2-sensors-deployment/adapters/types/sophos.md
+++ b/docs/2-sensors-deployment/adapters/types/sophos.md
@@ -26,7 +26,7 @@ Adapter Type: `sophos`
 
 Sophos documentation - <https://developer.sophos.com/getting-started-tenant>
 
-1. Add a new credential [here](https://cloud.sophos.com/manage/config/settings/credentials)
+1. Add a new credential in [Sophos Central Settings → Credentials](https://cloud.sophos.com/manage/config/settings/credentials)
 2. Get your client ID and client secret from the credentials you just created
 3. Get your JWT -- be sure to replace the values with the client ID and secret from the last step
 

--- a/docs/2-sensors-deployment/adapters/types/sqs.md
+++ b/docs/2-sensors-deployment/adapters/types/sqs.md
@@ -8,7 +8,7 @@ This Adapter allows you to ingest events received from an AWS SQS instance.
 
 Adapter Type: `sqs`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `access_key`: an Access Key from AWS used to access the queue.
 - `secret_key`: the secret key associated with the `access_key` used to access the queue.
 - `queue_url`: the queue URL for the SQS instance.

--- a/docs/2-sensors-deployment/adapters/types/stdin.md
+++ b/docs/2-sensors-deployment/adapters/types/stdin.md
@@ -8,7 +8,7 @@ This Adapter allows you to ingest data piped into the adapter's standard input. 
 
 Adapter Type: `stdin`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 
 ### Configuration File Example
@@ -30,7 +30,7 @@ stdin:
 
 ## CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 # Pipe journalctl output into the adapter

--- a/docs/2-sensors-deployment/adapters/types/sublime-security.md
+++ b/docs/2-sensors-deployment/adapters/types/sublime-security.md
@@ -14,7 +14,7 @@ Adapter Type: `sublime`
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md).
+[Adapter downloads](../deployment.md) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter
@@ -69,7 +69,7 @@ Sublime Security logs are ingested via a cloud-to-cloud webhook Adapter configur
 
 #### 1. Creating the LimaCharlie Webhook Adapter
 
-The following steps are modified from the generic Webhook Adapter creation documentation, found [here](../tutorials/webhook-adapter.md).
+These steps are adapted from the [generic Webhook Adapter creation guide](../tutorials/webhook-adapter.md).
 
 Creating a Webhook Adapter requires a set of parameters, including organization ID, Installation Key, platform, and mapping details, among other parameters. The following configuration can be modified to easily configure a Webhook Adapter for ingesting Sublime Security events:
 

--- a/docs/2-sensors-deployment/adapters/types/syslog.md
+++ b/docs/2-sensors-deployment/adapters/types/syslog.md
@@ -14,7 +14,7 @@ Given its ubiquity, Syslog can be ingested via a myriad of methods in both text/
 
 ### Syslog-specific Configurations
 
-All Adapters have the same common client configuration options, found [here](../usage.md). A syslog Adapter has a few unique configuration options not found with other Adapter types. These include:
+All Adapters share the [common client configuration options](../usage.md). A syslog Adapter has a few unique configuration options not found with other Adapter types. These include:
 
 - `port`: port to listen for syslog from.
 - `iface`: the interface name to listen for new connections/packets from, defaults to all.

--- a/docs/2-sensors-deployment/adapters/types/tailscale.md
+++ b/docs/2-sensors-deployment/adapters/types/tailscale.md
@@ -14,7 +14,7 @@ Tailscale events are ingested via a cloud-to-cloud webhook Adapter configured to
 
 ### 1. Creating the LimaCharlie Webhook Adapter
 
-The following steps are modified from the generic Webhook Adapter creation doc, found [here](../tutorials/webhook-adapter.md).
+These steps are adapted from the [generic Webhook Adapter creation guide](../tutorials/webhook-adapter.md).
 
 Creating a Webhook Adapter requires a set of parameters, including organization ID, Installation Key, platform, and mapping details. The following configuration has been provided to configure a Webhook Adapter for ingesting Tailscale events:
 

--- a/docs/2-sensors-deployment/adapters/types/windows-event-log.md
+++ b/docs/2-sensors-deployment/adapters/types/windows-event-log.md
@@ -8,7 +8,7 @@ This Adapter allows you to connect to the local Windows Event Logs API on Window
 
 Adapter Type: `wel`
 
-- `client_options`: common configuration for adapter as defined [here](../usage.md).
+- `client_options`: see [common adapter configuration](../usage.md).
 - `evt_sources`: a comma separated list of elements in the format `SOURCE:FILTER`, where `SOURCE` is an Event Source name like `Application`, `System` or `Security` and `FILTER` is an `XPath` filter value as described in the documentation linked below.
 - `write_timeout_sec`: number of seconds before a write to LimaCharlie times out (default: 600).
 

--- a/docs/2-sensors-deployment/adapters/types/zendesk.md
+++ b/docs/2-sensors-deployment/adapters/types/zendesk.md
@@ -23,7 +23,7 @@ Adapter Type: `zendesk`
 
 ### CLI Deployment
 
-Adapter downloads can be found [here](../deployment.md#adapter-binaries).
+[Adapter binaries](../deployment.md#adapter-binaries) are available on the deployment page.
 
 ```bash
 chmod +x /path/to/lc_adapter

--- a/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
@@ -12,7 +12,7 @@ Details on manual uninstallation is found at the bottom of each respective OS' i
 
 ### Sensor Commands
 
-For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. More information on that can be found [here](../../8-reference/endpoint-commands.md).
+For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. See the [endpoint commands reference](../../8-reference/endpoint-commands.md) for more detail.
 
 On Windows, the command defaults to uninstalling the sensor as if installed from the direct installer exe. If an MSI was used for installation, you can add a `--msi` flag to the `uninstall` command to trigger an uninstallation that is compatible with MSI.
 

--- a/docs/2-sensors-deployment/enterprise-deployment/intune.md
+++ b/docs/2-sensors-deployment/enterprise-deployment/intune.md
@@ -10,7 +10,7 @@ InTune supports Windows and macOS package deployment.
 
 ## Windows Deployment via Intune
 
-Deploying Windows applications via Intune requires creating an Intune application package (`.intunewin` file extension). To do this, please utilize Microsoft's IntuneWinAppUtil.exe file. Usage and documentation on creating an `.intunewin` file can be found [here](https://learn.microsoft.com/en-us/mem/intune/apps/apps-win32-prepare).
+Deploying Windows applications via Intune requires creating an Intune application package (`.intunewin` file extension). To do this, please utilize Microsoft's IntuneWinAppUtil.exe file. See Microsoft's [`.intunewin` packaging documentation](https://learn.microsoft.com/en-us/mem/intune/apps/apps-win32-prepare).
 
 ### Intune Package Contents
 

--- a/docs/2-sensors-deployment/installation-keys.md
+++ b/docs/2-sensors-deployment/installation-keys.md
@@ -21,7 +21,7 @@ Typically, Sensors require access over port 443 and use pinned SSL certificates.
 
 If you need to install sensors without pinned certificates, an installation key must be created with a specific flag. This must be done via the REST API, by setting the `use_public_root_ca` flag to `true`.
 
-More details can be found [here](https://github.com/refractionPOINT/python-limacharlie/blob/master/limacharlie/Manager.py#L1386).
+See the [Python SDK Manager.replicantRequest source](https://github.com/refractionPOINT/python-limacharlie/blob/master/limacharlie/Manager.py#L1386) for more detail.
 
 ## Use of Tags
 

--- a/docs/2-sensors-deployment/tutorials/defender-logs.md
+++ b/docs/2-sensors-deployment/tutorials/defender-logs.md
@@ -4,7 +4,7 @@ The Windows Sensor can listen, alert, and automate based on various Defender eve
 
 This is done by ingesting [artifacts from the Defender Event Log Source](../../5-integrations/extensions/limacharlie/artifact.md) and using [Detection & Response rules](../../3-detection-response/index.md) to take the appropriate action.
 
-A config template to alert on the common Defender events of interest is available [here](https://github.com/refractionPOINT/templates/blob/master/anti-virus/windows-defender.yaml). The template can be used in conjunction with [Infrastructure Extension](../../5-integrations/extensions/limacharlie/infrastructure.md) or its user interface in the [web app](https://app.limacharlie.io).
+A [config template alerting on common Defender events of interest](https://github.com/refractionPOINT/templates/blob/master/anti-virus/windows-defender.yaml) is available. The template can be used in conjunction with [Infrastructure Extension](../../5-integrations/extensions/limacharlie/infrastructure.md) or its user interface in the [web app](https://app.limacharlie.io).
 
 Specifically, the template alerts on the following Defender events:
 

--- a/docs/2-sensors-deployment/tutorials/linux-audit-logs.md
+++ b/docs/2-sensors-deployment/tutorials/linux-audit-logs.md
@@ -1,6 +1,6 @@
 # Ingesting Linux Audit Logs
 
-One data source of common interest on Linux systems is the `audit.log` file. By default, this file stores entries from the Audit system, which contains information about logins, privilege escalations, and other account-related events. You can find more information about Audit Log files [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sec-understanding_audit_log_files).
+One data source of common interest on Linux systems is the `audit.log` file. By default, this file stores entries from the Audit system, which contains information about logins, privilege escalations, and other account-related events. See [Audit Log file documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sec-understanding_audit_log_files).
 
 There are a few techniques to ingest Linux Audit logs into LimaCharlie:
 
@@ -60,7 +60,7 @@ file:
   no_follow: false
 ```
 
-More details on configuration files and adapter usage can be found [here](../adapters/usage.md).
+See [adapter configuration and usage](../adapters/usage.md) for more detail.
 
 **Step 3:** Run the adapter, providing the `file` option and the appropriate config file.
 

--- a/docs/3-detection-response/managed-rulesets/soc-prime.md
+++ b/docs/3-detection-response/managed-rulesets/soc-prime.md
@@ -1,6 +1,6 @@
 # SOC Prime Rules
 
-To use SOC Prime rules in LimaCharlie, start by configuring lists in [SOC Prime](https://socprime.com/). You can learn how to do it [here](https://socprime.com/blog/enable-continuous-content-management-with-the-soc-prime-platform/).
+To use SOC Prime rules in LimaCharlie, start by configuring lists in [SOC Prime](https://socprime.com/). See [SOC Prime's continuous content management guide](https://socprime.com/blog/enable-continuous-content-management-with-the-soc-prime-platform/) for instructions.
 
 After the lists have been configured, you can finish the configuration in LimaCharlie. Note that currently the SOC Prime API is not available for free users. It is available only for paid users or if they requested a trial.
 

--- a/docs/4-data-queries/events/sysmon-comparison.md
+++ b/docs/4-data-queries/events/sysmon-comparison.md
@@ -1,6 +1,6 @@
 # Sysmon Comparison
 
-System Monitor, or "Sysmon", is a Windows server and device driver that monitors and logs operating system activity. It is part of the Sysinternals toolkit. More information on Sysmon can be found [here](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon).
+System Monitor, or "Sysmon", is a Windows server and device driver that monitors and logs operating system activity. It is part of the Sysinternals toolkit. See Microsoft's [Sysmon download and reference page](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon).
 
 Many organizations deploy Sysmon and structure their detection events around Sysmon-specific event logs, which can offer granular insight into operating system changes. LimaCharlie's EDR telemetry can offer similar events, allowing you to write detections against these events directly.
 
@@ -28,4 +28,4 @@ Note, LC's Endpoint Agent is easily able to [consume Sysmon events](../../2-sens
 
 ## Executable Tracking
 
-Recent updates to Sysmon also include the ability to capture and store information about binaries identified on a system. You can replicate this functionality with LimaCharlie with BinLib. More information on that can be found [here](../../5-integrations/extensions/limacharlie/binlib.md).
+Recent updates to Sysmon also include the ability to capture and store information about binaries identified on a system. You can replicate this functionality in LimaCharlie with the [BinLib extension](../../5-integrations/extensions/limacharlie/binlib.md).

--- a/docs/4-data-queries/template-strings.md
+++ b/docs/4-data-queries/template-strings.md
@@ -8,7 +8,7 @@ A transform allows you to change the shape of JSON data in flight to suit better
 
 ## Template Strings
 
-Template strings in LimaCharlie use the format defined by "text templates" found [here](https://pkg.go.dev/text/template). A useful guide provided by Hashicorp is also available [here](https://learn.hashicorp.com/tutorials/nomad/go-template-syntax).
+Template strings in LimaCharlie use the [Go `text/template` format](https://pkg.go.dev/text/template). [Hashicorp's Go template syntax tutorial](https://learn.hashicorp.com/tutorials/nomad/go-template-syntax) is also a useful reference.
 
 The most basic example for a D&R rule customizing the detection name looks like this:
 
@@ -102,7 +102,7 @@ This object is in the shape of the final JSON you would like to transform to.
 Key names are the literal key names in the output. Values support one of 3 types:
 
 1. Template Strings, as described above. In this case, the template string will be generated and placed at the same place as the key in the transform object.
-2. A `gjson` selector. The selector syntaxt is defined [here](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). It makes it possible to select subsets of input object and map it within the resulting object as defined by the transform.
+2. A `gjson` selector. See the [gjson syntax reference](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for the selector syntax. It makes it possible to select subsets of input object and map it within the resulting object as defined by the transform.
 3. Other JSON objects which will be present in the output.
 
 Let's look at an example, let's say this is the Input to our transform:
@@ -344,7 +344,7 @@ Beyond the built-in modifiers for `gjson` (as seen in their [playground](https:/
 
 - `parsejson`: this modifier takes no arguments, it takes in as input a string that represents a JSON object and outputs the decoded JSON object.
 - `extract`: this modifier takes a single argument, `re` which is a regular expression that uses "named capture groups" (as defined in the [re2 documentation](https://github.com/google/re2/wiki/Syntax)). The group names become the keys of the output JSON object with the matching values.
-- `parsetime`: this modifier takes two arguments, `from` and `to`. It will convert an input string from a given time format (as defined in the Go `time` library format [here](https://pkg.go.dev/time#pkg-constants)) and outputs the resulting time in the `to` format. Beyond the time constants from the previous link, LimaCharlie also supports a `from` format of:
+- `parsetime`: this modifier takes two arguments, `from` and `to`. It converts an input string from a given time format (using the [Go `time` library format constants](https://pkg.go.dev/time#pkg-constants)) and outputs the resulting time in the `to` format. Beyond those time constants, LimaCharlie also supports a `from` format of:
   - `epoch_s`: a second based epoch timestamp
   - `epoch_ms`: a millisecond based epoch timestamp
 

--- a/docs/4-data-queries/template-transforms.md
+++ b/docs/4-data-queries/template-transforms.md
@@ -8,7 +8,7 @@ A transform allows you to change the shape of JSON data in flight to suit better
 
 ## Template Strings
 
-Template strings in LimaCharlie use the format defined by "text templates" found [here](https://pkg.go.dev/text/template). A useful guide provided by Hashicorp is also available [here](https://learn.hashicorp.com/tutorials/nomad/go-template-syntax).
+Template strings in LimaCharlie use the [Go `text/template` format](https://pkg.go.dev/text/template). [Hashicorp's Go template syntax tutorial](https://learn.hashicorp.com/tutorials/nomad/go-template-syntax) is also a useful reference.
 
 The most basic example for a D&R rule customizing the detection name looks like this:
 
@@ -102,7 +102,7 @@ This object is in the shape of the final JSON you would like to transform to.
 Key names are the literal key names in the output. Values support one of 3 types:
 
 1. Template Strings, as described above. In this case, the template string will be generated and placed at the same place as the key in the transform object.
-2. A `gjson` selector. The selector syntaxt is defined [here](https://github.com/tidwall/gjson/blob/master/SYNTAX.md). It makes it possible to select subsets of input object and map it within the resulting object as defined by the transform.
+2. A `gjson` selector. See the [gjson syntax reference](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for the selector syntax. It makes it possible to select subsets of input object and map it within the resulting object as defined by the transform.
 3. Other JSON objects which will be present in the output.
 
 Let's look at an example, let's say this is the Input to our transform:
@@ -344,7 +344,7 @@ Beyond the built-in modifiers for `gjson` (as seen in their [playground](https:/
 
 - `parsejson`: this modifier takes no arguments, it takes in as input a string that represents a JSON object and outputs the decoded JSON object.
 - `extract`: this modifier takes a single argument, `re` which is a regular expression that uses "named capture groups" (as defined in the [re2 documentation](https://github.com/google/re2/wiki/Syntax)). The group names become the keys of the output JSON object with the matching values.
-- `parsetime`: this modifier takes two arguments, `from` and `to`. It will convert an input string from a given time format (as defined in the Go `time` library format [here](https://pkg.go.dev/time#pkg-constants)) and outputs the resulting time in the `to` format. Beyond the time constants from the previous link, LimaCharlie also supports a `from` format of:
+- `parsetime`: this modifier takes two arguments, `from` and `to`. It converts an input string from a given time format (using the [Go `time` library format constants](https://pkg.go.dev/time#pkg-constants)) and outputs the resulting time in the `to` format. Beyond those time constants, LimaCharlie also supports a `from` format of:
   - `epoch_s`: a second based epoch timestamp
   - `epoch_ms`: a millisecond based epoch timestamp
 

--- a/docs/4-data-queries/tutorials/bigquery-looker-studio.md
+++ b/docs/4-data-queries/tutorials/bigquery-looker-studio.md
@@ -20,7 +20,7 @@ The nice part about this type of hierarchy is that I can build out multiple tabl
 
 ![image.png](../../assets/images/image(97).png)
 
-Within the Google Cloud Console, we also want to create a Service Account and gather an API key. More details on that can be found [here](https://cloud.google.com/iam/docs/service-accounts-create).
+Within the Google Cloud Console, we also want to create a Service Account and gather an API key. See Google Cloud's [service account creation guide](https://cloud.google.com/iam/docs/service-accounts-create) for more detail.
 
 Copy the API key and keep it somewhere safe, we'll need to configure it in the output.
 

--- a/docs/5-integrations/api-integrations/ip-geolocation.md
+++ b/docs/5-integrations/api-integrations/ip-geolocation.md
@@ -22,7 +22,7 @@ Step-by-step, this rule will do the following:
 - Upon seeing a `CONNECTED` event, retrieve the `routing/ext_ip` value and send it to MaxMind via the `api/ip-geo` resource
 - Upon receiving a response from `api/ip-geo`, evaluate it using `metadata_rules` to see if the country associated with the IP is located in the EU
 
-The format of the metadata returned is documented [here](https://github.com/maxmind/MaxMind-DB-Reader-python) and looks like this:
+The format of the metadata returned is documented in the [MaxMind DB Reader (Python) repository](https://github.com/maxmind/MaxMind-DB-Reader-python) and looks like this:
 
 ```json
 {

--- a/docs/5-integrations/extensions/cloud-cli/1password.md
+++ b/docs/5-integrations/extensions/cloud-cli/1password.md
@@ -2,7 +2,7 @@
 
 The 1Password CLI brings 1Password to the terminal, allowing you to interact with a 1Password instance from LimaCharlie.
 
-This Extension makes use of 1Password's native CLI, which can be found [here](https://developer.1password.com/docs/cli).
+This extension uses [1Password's native CLI](https://developer.1password.com/docs/cli).
 
 ## 1Password Account Types
 
@@ -24,7 +24,7 @@ Returns a list of all items the account has read access to by default.
 
 ## Credentials
 
-To utilize 1Password's automated CLI capabilities, you will need to create and utilize a Service Account. More information can be found [here](https://developer.1password.com/docs/service-accounts/get-started/).
+To utilize 1Password's automated CLI capabilities, you will need to create and utilize a Service Account. See 1Password's [Service Accounts getting-started guide](https://developer.1password.com/docs/service-accounts/get-started/) for more detail.
 
 - Create a secret in the secrets manager in the following format:
 

--- a/docs/5-integrations/extensions/cloud-cli/aws.md
+++ b/docs/5-integrations/extensions/cloud-cli/aws.md
@@ -2,7 +2,7 @@
 
 AWS CLI is a unified tool that provides a consistent interface for interacting with AWS from the command line. With this component of the Cloud CLI Extension, you can interact with AWS directly from LimaCharlie.
 
-This extension makes use of AWS's native CLI tool, which can be found [here](https://awscli.amazonaws.com/v2/documentation/api/latest/index.html).
+This extension uses [AWS's native CLI tool](https://awscli.amazonaws.com/v2/documentation/api/latest/index.html).
 
 ## Example
 
@@ -35,4 +35,4 @@ To utilize AWS CLI capabilities, you will need:
   accessKeyID/secretAccessKey
   ```
 
-Documentation on creating and managing AWS access keys and other IAM components can be found [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
+AWS provides [documentation on creating and managing access keys and other IAM components](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).

--- a/docs/5-integrations/extensions/cloud-cli/azure.md
+++ b/docs/5-integrations/extensions/cloud-cli/azure.md
@@ -2,7 +2,7 @@
 
 The Azure CLI is a set of commands used to create and manage Azure resources. With this component of the Cloud CLI Extension, you can interact with Azure directly from LimaCharlie.
 
-This extension makes use of the Azure CLI, which can be found [here](https://learn.microsoft.com/en-us/cli/azure/get-started-with-azure-cli).
+This extension uses [the Azure CLI](https://learn.microsoft.com/en-us/cli/azure/get-started-with-azure-cli).
 
 ## Example
 

--- a/docs/5-integrations/extensions/cloud-cli/digitalocean.md
+++ b/docs/5-integrations/extensions/cloud-cli/digitalocean.md
@@ -2,7 +2,7 @@
 
 The DigitalOcean CLI, or `doctl`, is the official CLI for the DigitalOcean API. With this component of the Cloud CLI Extension, you can interact with DigitalOcean directly from LimaCharlie.
 
-This extension makes use of DigitalOcean's official CLI tool, which can be found [here](https://github.com/digitalocean/doctl). Reference documentation can be found [here](https://docs.digitalocean.com/reference/doctl/reference/).
+This extension uses [DigitalOcean's official `doctl` CLI tool](https://github.com/digitalocean/doctl). [Reference documentation](https://docs.digitalocean.com/reference/doctl/reference/) is also available.
 
 ## Example
 
@@ -22,7 +22,7 @@ The following example of a response action will enumerate a list of compute drop
 
 To utilize `doctl` capabilities, you will need:
 
-- A personal access token. More information on this can be found [here](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
+- A personal access token. See DigitalOcean's [create-personal-access-token reference](https://docs.digitalocean.com/reference/api/create-personal-access-token/).
 - Create a secret in the secrets manager in the following format:
 
   ```text

--- a/docs/5-integrations/extensions/cloud-cli/github.md
+++ b/docs/5-integrations/extensions/cloud-cli/github.md
@@ -2,7 +2,7 @@
 
 The GitHub CLI is a tool that brings GitHub to the terminal, allowing you to interact with and control Git accounts, repositories, organizations, and users from the CLI. With this component of the Cloud CLI Extension, you can interact with GitHub directly from LimaCharlie.
 
-This extension makes use of the GitHub CLI, which can be found [here](https://cli.github.com/manual/).
+This extension uses [the GitHub CLI](https://cli.github.com/manual/).
 
 ## Example
 

--- a/docs/5-integrations/extensions/cloud-cli/google-cloud.md
+++ b/docs/5-integrations/extensions/cloud-cli/google-cloud.md
@@ -2,7 +2,7 @@
 
 The Google Cloud command line interface, or gcloud CLI, allows you to create and manage Google Cloud resources and services directly on the command line. With this component of the Cloud CLI Extension, you can interact with Google Cloud directly from LimaCharlie.
 
-This extension makes use of Google Cloud's native CLI tool, which can be found [here](https://cloud.google.com/cli).
+This extension uses [Google Cloud's native CLI tool](https://cloud.google.com/cli).
 
 ## Example
 
@@ -26,7 +26,7 @@ The following example stops the specified GCP compute instance.
 
 To utilize Google Cloud CLI capabilities, you will need:
 
-- A GCP service account JSON key. More information on service account keys can be found [here](https://cloud.google.com/iam/docs/keys-create-delete).
+- A GCP service account JSON key. See Google Cloud's [service account keys guide](https://cloud.google.com/iam/docs/keys-create-delete).
 - Create a secret in the secrets manager in the following format:
 
   ```json

--- a/docs/5-integrations/extensions/cloud-cli/microsoft365.md
+++ b/docs/5-integrations/extensions/cloud-cli/microsoft365.md
@@ -2,7 +2,7 @@
 
 The CLI **for Microsoft 365** is a tool created to help manage Microsoft 365 tenant(s) and SharePoint framework projects. With this component of the Cloud CLI Extension, you can interact with a Microsoft 365 tenant(s) directly from LimaCharlie.
 
-This extension makes use of the PnP Microsoft 365 CLI, which can be found [here](https://github.com/pnp/cli-microsoft365).
+This extension uses [the PnP Microsoft 365 CLI](https://github.com/pnp/cli-microsoft365).
 
 ## Example
 
@@ -27,7 +27,7 @@ The following example disables the user account with the provided user ID.
 
 ## Credentials
 
-- Per the Microsoft 365 CLI documentation, there are multiple login or authentication mechanisms available. The current LimaCharlie implementation utilizes a client secret for authentication. More information on provisioning client secrets can be found [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+- Per the Microsoft 365 CLI documentation, multiple authentication mechanisms are available. The current LimaCharlie implementation uses a client secret. See Microsoft's [Register an app quickstart](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) for provisioning details.
 - Upon invocation, LimaCharlie will first run the `m365 login` command with the credentials provided.
 - Create a secret in the secrets manager in the following format:
 

--- a/docs/5-integrations/extensions/cloud-cli/okta.md
+++ b/docs/5-integrations/extensions/cloud-cli/okta.md
@@ -2,7 +2,7 @@
 
 The Okta CLI allows you to interact with your Okta instance(s) via the command line. With this component of the Cloud CLI Extension, you can interact with Okta directly from LimaCharlie.
 
-This extension makes use of the Okta CLI, which can be found [here](https://cli.okta.com/manual/).
+This extension uses [the Okta CLI](https://cli.okta.com/manual/).
 
 ## Example
 
@@ -22,7 +22,7 @@ The following example returns a list of registered Okta applications.
 
 To make use of the Okta CLI, you will need:
 
-- An API key. More information about provisioning an API key can be found [here](https://developer.okta.com/docs/guides/create-an-api-token/main/).
+- An API key. See Okta's [Create an API token guide](https://developer.okta.com/docs/guides/create-an-api-token/main/).
 - Create a secret in the secrets manager in the following format:
 
 ```text

--- a/docs/5-integrations/extensions/cloud-cli/sdm.md
+++ b/docs/5-integrations/extensions/cloud-cli/sdm.md
@@ -2,7 +2,7 @@
 
 The StrongDM CLI allows you to manage your StrongDM platform(s) via the command-line. With this component of the Cloud CLI Extension, you can interact with StrongDM's directly from LimaCharlie.
 
-More information about the StrongDM CLI can be found [here](https://www.strongdm.com/docs/cli/).
+See the [StrongDM CLI documentation](https://www.strongdm.com/docs/cli/) for more detail.
 
 ## Example
 
@@ -22,7 +22,7 @@ The following response action returns a list of all users in your Organization.
 
 To utilize StrongDM's CLI capabilities, you will need:
 
-- An admin or service account token. More information on provisioning this token can be found [here](https://www.strongdm.com/docs/admin/tokens-and-keys/).
+- An admin or service account token. See StrongDM's [tokens and keys reference](https://www.strongdm.com/docs/admin/tokens-and-keys/) for provisioning details.
 - Create a secret in the secrets manager in the following format:
 
 ```text

--- a/docs/5-integrations/extensions/cloud-cli/sublime.md
+++ b/docs/5-integrations/extensions/cloud-cli/sublime.md
@@ -2,7 +2,7 @@
 
 The Sublime Security CLI brings the power of Sublime's email platform to the command-line. With this component of the Cloud CLI Extension, you can interact with Sublime's email platform directly from LimaCharlie.
 
-This extension makes use of Tailscale's native CLI, which can be found [here](https://docs.sublimesecurity.com/reference/analysis-api-cli). The CLI is a Python package - the source code can be found [here](https://github.com/sublime-security/sublime-cli).
+This extension uses [Sublime Security's native CLI](https://docs.sublimesecurity.com/reference/analysis-api-cli). The CLI is a Python package — its [source code](https://github.com/sublime-security/sublime-cli) is on GitHub.
 
 ## Example
 
@@ -22,7 +22,7 @@ The following response action returns information about the currently authentica
 
 To utilize Sublime's CLI capabilities, you will need:
 
-- You will need an API key. More information about provisioning an API key can be found [here](https://docs.sublimesecurity.com/reference/authentication).
+- You will need an API key. See Sublime Security's [authentication reference](https://docs.sublimesecurity.com/reference/authentication) for provisioning details.
 - Create a secret in the secrets manager in the following format:
 
 ```text

--- a/docs/5-integrations/extensions/cloud-cli/tailscale.md
+++ b/docs/5-integrations/extensions/cloud-cli/tailscale.md
@@ -2,7 +2,7 @@
 
 The Tailscale CLI brings Tailscale's powerful software-defined networking, based on WireGuard, to the command line. This Extension allows you to interact with a Tailscale network(s) from LimaCharlie.
 
-This extension makes use of Tailscale's native CLI, which can be found [here](https://tailscale.com/kb/1031/install-linux).
+This extension uses [Tailscale's native CLI](https://tailscale.com/kb/1031/install-linux).
 
 ## Example
 

--- a/docs/5-integrations/extensions/cloud-cli/vultr.md
+++ b/docs/5-integrations/extensions/cloud-cli/vultr.md
@@ -2,7 +2,7 @@
 
 The [Vultr](https://vultr.com/) CLI, or `vultr-cli`, is the official CLI for the Vultr API. With this component of the Cloud CLI Extension, you can interact with Vultr directly from LimaCharlie.
 
-This extension makes use of Vultr's official CLI tool, which can be found [here](https://github.com/vultr/vultr-cli). Reference documentation can be found [here](https://www.vultr.com/news/how-to-easily-manage-instances-with-vultr-cli/).
+This extension uses [Vultr's official CLI tool](https://github.com/vultr/vultr-cli). [Reference documentation](https://www.vultr.com/news/how-to-easily-manage-instances-with-vultr-cli/) is also available.
 
 ## Example
 
@@ -22,7 +22,7 @@ The following example of a response action will enumerate a list of instance wit
 
 To utilize `vultr-cli` capabilities, you will need:
 
-- A personal access token. To create one, click [here](https://my.vultr.com/settings/#settingsapi).
+- A personal access token from [Vultr's API settings page](https://my.vultr.com/settings/#settingsapi).
 - Your access token will need to have access control open to IPv6
   <!-- Screenshot of Vultr access control settings was unavailable during migration from document360 -->
 - Create a secret in the secrets manager in the following format:

--- a/docs/5-integrations/extensions/limacharlie/artifact.md
+++ b/docs/5-integrations/extensions/limacharlie/artifact.md
@@ -14,7 +14,7 @@ To enable the Artifact extension, navigate to the [Artifact extension page](http
 
 After clicking **Subscribe**, the Artifact extension should be available almost immediately.
 
-> Note that the Artifact extension first requires enabling of the Reliable Tasking extension. You can find more on that extension [here](reliable-tasking.md).
+> Note that the Artifact extension first requires enabling the [Reliable Tasking extension](reliable-tasking.md).
 
 ## Using the Artifact Extension
 

--- a/docs/5-integrations/extensions/limacharlie/infrastructure.md
+++ b/docs/5-integrations/extensions/limacharlie/infrastructure.md
@@ -4,7 +4,7 @@ The Infrastructure Extension allows you to perform infrastructure-as-code (IaC) 
 
 > Scaling Organization Management
 >
-> If you're an managed service company or need to manage a large number of Organizations, consider LimaCharlie's MSSP setup. You can find more information about this [here](https://github.com/refractionPOINT/mssp-demo).
+> If you're a managed service company or need to manage a large number of Organizations, consider LimaCharlie's [MSSP demo setup](https://github.com/refractionPOINT/mssp-demo).
 
 ## Enabling the Infrastructure Extension
 
@@ -16,7 +16,7 @@ After clicking **Subscribe**, the Infrastructure extension should be available a
 
 > Where to start?
 >
-> IaC can be a powerful tool for rapidly deploying and managing Organizations within LimaCharlie. To help you discover more possibilities, we have provided several example templates/configurations [here](https://github.com/refractionPOINT/templates).
+> IaC can be a powerful tool for rapidly deploying and managing Organizations within LimaCharlie. We provide [example templates and configurations](https://github.com/refractionPOINT/templates) on GitHub.
 
 ## Using the Infrastructure Extension
 

--- a/docs/5-integrations/extensions/limacharlie/lookup-manager.md
+++ b/docs/5-integrations/extensions/limacharlie/lookup-manager.md
@@ -8,7 +8,7 @@ Every 24 hours, LimaCharlie will sync all of the lookups in the configuration. L
 
 Lookup sources can be either direct links (URLs) to a given lookup or [ARLs](../../../8-reference/authentication-resource-locator.md).
 
-Example JSON lookup: [link](https://loldrivers.io/api/drivers.json)
+Example JSON lookup: [LOLDrivers API](https://loldrivers.io/api/drivers.json)
 
 ## Usage
 
@@ -16,7 +16,7 @@ Example JSON lookup: [link](https://loldrivers.io/api/drivers.json)
 
 LimaCharlie provides a curated list of several publicly available JSON lookups for use within your organization. These are provided in the lookup manager GUI.
 
-More details and the contents of each of these lookups can be found [here](https://github.com/refractionpoint/lc-public-lookups).
+See [lc-public-lookups](https://github.com/refractionpoint/lc-public-lookups) for the contents of each public lookup.
 
 ![image (1).png "Screenshot 2024 10 22 at 13.23.35(2).png"](../../../assets/images/image-(1).png "Screenshot 2024-10-22 at 13.23.35(2).png")
 

--- a/docs/5-integrations/extensions/third-party/atomic-red-team.md
+++ b/docs/5-integrations/extensions/third-party/atomic-red-team.md
@@ -2,7 +2,7 @@
 
 **Atomic Red Team** is a library of tests mapped to the MITRE ATT&CK framework, provided by Red Canary. With this Extension, LimaCharlie users can use Atomic Red Team to quickly, portably, and reproducibly test their environments.
 
-Find more information about it [here](https://atomicredteam.io/).
+See [the Atomic Red Team project site](https://atomicredteam.io/) for more information.
 
 ## Enabling the Atomic Red Team Extension
 

--- a/docs/5-integrations/extensions/third-party/govee.md
+++ b/docs/5-integrations/extensions/third-party/govee.md
@@ -4,7 +4,7 @@ The Govee Extension allows you to trigger color changes on your [supported Govee
 
 ## Setup
 
-1. Request an API key from Govee by following their instructions [here](https://developer.govee.com/reference/apply-you-govee-api-key)
+1. Request an API key from Govee by following their [Apply for a Govee API key instructions](https://developer.govee.com/reference/apply-you-govee-api-key)
 2. Get the Device ID (device) and model (sku) of the device you'd like to target by requesting a list of your supported devices from the Govee API:
 
 ```bash

--- a/docs/5-integrations/extensions/third-party/nims.md
+++ b/docs/5-integrations/extensions/third-party/nims.md
@@ -8,7 +8,7 @@ The LimaCharlie NIMS extension allows you to send detections from LimaCharlie to
 
 Once you subscribe an org to the extension, it creates a D&R rule that sends all detections from your org to your NIMS alert database. Because Notion databases do have a limit on the number of records, the extension also has the ability to purge old alerts that are 1) not associated with any incidents, and 2) older than the specified number of days. A D&R rule is also created to perform this cleanup automatically (or not) based on your configuration.
 
-More information about NIMS, including the template and corresponding docs, can be found [here](https://nims-template.notion.site/).
+[More information about NIMS, including the template and corresponding docs](https://nims-template.notion.site/), is available on the project's Notion page.
 
 ## Configuration
 
@@ -21,7 +21,7 @@ In order to use this extension, you will need 3 pieces of data:
 ### Find your database IDs
 
 1. Navigate to the Alert database within NIMS under `Databases`
-2. Right click on the database and click `Copy link`[![link](https://github.com/shortstack/nims-webhook/raw/main/screenshots/link.png)](https://github.com/shortstack/nims-webhook/blob/main/screenshots/link.png)
+2. Right click on the database and click `Copy link`[![NIMS database link button screenshot](https://github.com/shortstack/nims-webhook/raw/main/screenshots/link.png)](https://github.com/shortstack/nims-webhook/blob/main/screenshots/link.png)
 3. Locate the database ID in the URL
 
    - The database ID is the long string of letters and numbers in the URL after the last `/` and before the `?` or `#` if present

--- a/docs/5-integrations/extensions/third-party/otx.md
+++ b/docs/5-integrations/extensions/third-party/otx.md
@@ -2,11 +2,11 @@
 
 AlienVault's Open Threat Exchange (OTX) is the "neighborhood watch of the global intelligence community." It enables private companies, independent security researchers, and government agencies to openly collaborate and share the latest information about emerging threats, attack methods, and malicious actors, promoting greater security across the entire community.
 
-More information about OTX can be found [here](https://otx.alienvault.com/).
+[More information about OTX](https://otx.alienvault.com/) is available on the AlienVault site.
 
 ## Enabling the OTX Extension
 
-Before utilizing the OTX extension, you will need an AlienVault OTX API Key. This can be found in your AlienVault OTX account [here](https://otx.alienvault.com/).
+Before utilizing the OTX extension, you will need an AlienVault OTX API Key from your [AlienVault OTX account](https://otx.alienvault.com/).
 
 To enable the OTX extension, navigate to the [OTX extension page](https://app.limacharlie.io/add-ons/extension-detail/ext-otx). Select the Organization you wish to enable the extension for, and select **Subscribe**.
 

--- a/docs/5-integrations/extensions/third-party/pagerduty.md
+++ b/docs/5-integrations/extensions/third-party/pagerduty.md
@@ -2,7 +2,7 @@
 
 The PagerDuty Extension allows you to trigger events within PagerDuty. It requires you to setup the PagerDuty access token in the Integrations section of your Organization.
 
-Some more detailed information is available [here](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+See PagerDuty's [Events API v2 trigger reference](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/) for more detail.
 
 ## REST
 

--- a/docs/5-integrations/extensions/third-party/plaso.md
+++ b/docs/5-integrations/extensions/third-party/plaso.md
@@ -16,7 +16,7 @@ The primary tools in the Plaso suite used for this process are [log2timeline](ht
 - `psort` - builds timelines based on output from `log2timeline`
 - `psteal` - Simply a wrapper for `log2timeline` and `psort`
 
-The `ext-plaso` extension within LimaCharlie allows you to run `log2timeline` and `psort` (using the `psteal` wrapper) against artifacts obtained from an endpoint, such as event logs, registry hives, and various other forensic artifacts. When executed, Plaso will parse and extract information from all acquired evidence artifacts that it has support for. Supported parsers are found [here](https://plaso.readthedocs.io/en/latest/sources/user/Parsers-and-plugins.html).
+The `ext-plaso` extension within LimaCharlie allows you to run `log2timeline` and `psort` (using the `psteal` wrapper) against artifacts obtained from an endpoint, such as event logs, registry hives, and various other forensic artifacts. When executed, Plaso will parse and extract information from all acquired evidence artifacts that it has support for. See the [Plaso parsers and plugins reference](https://plaso.readthedocs.io/en/latest/sources/user/Parsers-and-plugins.html) for the full list of supported parsers.
 
 ## Extension Configuration
 

--- a/docs/5-integrations/extensions/third-party/secureannex.md
+++ b/docs/5-integrations/extensions/third-party/secureannex.md
@@ -25,7 +25,7 @@ This is currently only supported on Windows, macOS, and Chrome sensors.
 
 ### Manually in the GUI
 
-You can trigger an extension request manually within the web app by clicking the `Get extensions from endpoint` button. This will allow you to choose a sensor, or sensors via a Sensor Selector, to get extensions from. More examples of sensor selectors can be found [here](../../../8-reference/sensor-selector-expressions.md).
+You can trigger an extension request manually within the web app by clicking the `Get extensions from endpoint` button. This will allow you to choose a sensor, or sensors via a Sensor Selector, to get extensions from. See [sensor selector expression examples](../../../8-reference/sensor-selector-expressions.md).
 
 The extensions are gathered from endpoints via the reliable tasking extension, which appends `secureannex_extensions` to the investigation ID of the `RECEIPT` or `OS_PACKAGES_REP` event in order to trigger an extension request to query Secure Annex. The results will be in the timeline of the `ext-secureannex` sensor.
 

--- a/docs/5-integrations/extensions/third-party/twilio.md
+++ b/docs/5-integrations/extensions/third-party/twilio.md
@@ -4,7 +4,7 @@
 
 The [Twilio](https://www.twilio.com/) Extension allows you to send messages within Twilio. It requires you to setup the Twilio authentication in the **Integrations** section of your Organization.
 
-Some more detailed information is available [here](https://www.twilio.com/docs/sms/send-messages).
+See Twilio's [SMS send-messages reference](https://www.twilio.com/docs/sms/send-messages) for more detail.
 
 ## Setup
 

--- a/docs/5-integrations/services/replay.md
+++ b/docs/5-integrations/services/replay.md
@@ -84,7 +84,7 @@ We invite you to look at the command line usage itself, as the tool evolves.
 ### REST API
 
 The Replay API is available to all DataCenter locations using a per-location URL.
- To get the appropriate URL for your organization, use the REST endpoint to retrieve the URLs found [here](https://api.limacharlie.io/static/swagger/#/Organizations/getOrgURLs) named `replay`.
+ To get the appropriate URL for your organization, use the [`getOrgURLs` REST endpoint](https://api.limacharlie.io/static/swagger/#/Organizations/getOrgURLs) and look for the URL named `replay`.
 
 Having per-location URLs will allow us to guarantee that processing occurs within the geographical area you chose. Currently, some locations are NOT guaranteed to be in the same area due to the fact we are using the Google Cloud Run product which is not available globally. For these cases, processing is currently done in the United States, but as soon as it becomes available in your area, the processing will be moved transparently.
 

--- a/docs/6-developer-guide/extensions/building-extensions.md
+++ b/docs/6-developer-guide/extensions/building-extensions.md
@@ -121,7 +121,7 @@ The `requirements` field references the field keys to define whether or not cert
 
 When getting started, we recommend utilizing the simplest data type applicable. This will enable you to get a grasp of the whole extensions framework and allow you to quickly test our your service. Such as `string`, `boolean`, `json`, etc.
 
-Afterwards, we recommend you define the data_type and other optional fields further, so that the UI may adapt to your defined data types. For more details, please see the [page on data types](schema-data-types.md) or review the code definitions [here](https://github.com/refractionPOINT/lc-extension/blob/master/common/config_schema.go).
+Afterwards, we recommend you define the data_type and other optional fields further, so that the UI may adapt to your defined data types. For more details, see the [data types reference](schema-data-types.md) or the [lc-extension SDK source](https://github.com/refractionPOINT/lc-extension/blob/master/common/config_schema.go).
 
 #### Config Schema (optional)
 

--- a/docs/6-developer-guide/grant-program.md
+++ b/docs/6-developer-guide/grant-program.md
@@ -4,4 +4,4 @@ The Developer Grant Program is designed to help fuel the growth of LimaCharlie a
 
 If you are looking to commercialize an idea we can help you get it into our marketplace and if there is traction there, we can further support you in growing.
 
-Interested parties can apply for the grant program [here](https://limacharlie.io/grant-program).
+Interested parties can [apply for the grant program](https://limacharlie.io/grant-program).

--- a/docs/7-administration/config-hive/lookups.md
+++ b/docs/7-administration/config-hive/lookups.md
@@ -73,7 +73,7 @@ LimaCharlie also provides several publicly available lookups for use in your Org
 
 ### Automatically via the Lookup Manager
 
-If your lookups change frequently and you wish to keep them up to date, LimaCharlie offers the lookup manager extension as a mechanism to automatically update your lookups every 24 hours. Documentation on the lookup manager can be found [here](../../5-integrations/extensions/limacharlie/lookup-manager.md).
+If your lookups change frequently and you wish to keep them up to date, LimaCharlie offers the lookup manager extension as a mechanism to automatically update your lookups every 24 hours. See the [Lookup Manager documentation](../../5-integrations/extensions/limacharlie/lookup-manager.md).
 
 ## Programmatic Management
 

--- a/docs/8-reference/edr-events.md
+++ b/docs/8-reference/edr-events.md
@@ -1340,7 +1340,7 @@ Generated when a process starts. It lists all environment variables associated w
 
 ### RECEIPT
 
-This event is used as a generic response to some commands. The contents of a `RECEIPT` event usually contain an `ERROR` code that you can use to determine if the command was successful (`ERROR` codes can be explored [here](error-codes.md)). It's often a good idea to issue the original command with an `investigation_id` which will get echoed in the `RECEIPT` related to that command to make it easier to track.
+This event is used as a generic response to some commands. The contents of a `RECEIPT` event usually contain an `ERROR` code that you can use to determine if the command was successful (see [Error Codes](error-codes.md) for the complete list). It's often a good idea to issue the original command with an `investigation_id` which will get echoed in the `RECEIPT` related to that command to make it easier to track.
 
 **Platforms:**
 
@@ -1445,7 +1445,7 @@ Emitted after a sensor is allowed network connectivity again (after it was previ
 
 Generated whenever a process opens a handle to another process with access flags like `VM_READ`, `VM_WRITE`, or `PROCESS_CREATE_THREAD`.
 
-The `ACCESS_FLAGS` is the access mask as defined [here](https://docs.microsoft.com/en-us/windows/desktop/procthread/process-security-and-access-rights).
+The `ACCESS_FLAGS` is the access mask as defined in Microsoft's [Process Security and Access Rights reference](https://docs.microsoft.com/en-us/windows/desktop/procthread/process-security-and-access-rights).
 
 **Platforms:**
 

--- a/docs/8-reference/faq/billing.md
+++ b/docs/8-reference/faq/billing.md
@@ -29,7 +29,7 @@ To understand the impact on your organization, check the **Metered Usage** secti
 
 ## What is Usage-Based Billing?
 
-Along with our predictable per endpoint pricing model, LimaCharlie offers a pure usage-based billing model for our Endpoint Detection & Response (EDR) capability. Pricing within this model is calculated solely on the time the Sensor is connected, events processed, and events stored. You can find more information about our billing options [here](../../7-administration/billing/options.md).
+Along with our predictable per endpoint pricing model, LimaCharlie offers a pure usage-based billing model for our Endpoint Detection & Response (EDR) capability. Pricing within this model is calculated solely on the time the Sensor is connected, events processed, and events stored. See [billing options](../../7-administration/billing/options.md) for more detail.
 
 We acknowledge that some might not need the entirety of available components all the time, and might benefit from having access to an Endpoint Agent on an ad-hoc basis. This approach enables the following:
 

--- a/docs/8-reference/faq/invoices.md
+++ b/docs/8-reference/faq/invoices.md
@@ -36,11 +36,11 @@ Customers who are set up on Unified Billing receive one invoice that contain a r
 
 #### Example Unified invoice
 
-Your browser does not support PDF. Click [here](../../assets/images/EXAMPLE---Unified---Invoice-ABC1234D-0011.pdf) to download.
+Your browser does not support PDF. [Download the example unified invoice](../../assets/images/EXAMPLE---Unified---Invoice-ABC1234D-0011.pdf).
 
 #### Example individual Tenant invoice
 
-Your browser does not support PDF. Click [here](../../assets/images/EXAMPLE---Alpha-Customer---Invoice-BCDE9876-0035.pdf) to download.
+Your browser does not support PDF. [Download the example tenant invoice](../../assets/images/EXAMPLE---Alpha-Customer---Invoice-BCDE9876-0035.pdf).
 
 In addition to the Unified Billing invoice, customers are also provided with a LimaCharlie Global Billing email. This email contains:
 

--- a/markdown-lint.md
+++ b/markdown-lint.md
@@ -79,15 +79,15 @@ changes. Examples:
   inconsistent code-block style. Disabling avoids the false
   positives.
 
-- `MD060` (table column alignment) and `MD059` (descriptive link
-  text) — both new in markdownlint v0.40.0 (the version CI's
-  `markdownlint-cli2-action@v22` bundles). Each fires on substantial
-  pre-existing content that wasn't part of the original cleanup
-  initiative — ~1,400 table-alignment violations and ~109
-  generic-link-text cases ("here", "click here", etc.). Disabled
-  for now so CI stays green on the stable backlog. Each is a good
-  candidate for a dedicated follow-up PR using the same per-rule
-  workflow described above.
+- `MD060` (table column alignment) — new in markdownlint v0.40.0
+  (the version CI's `markdownlint-cli2-action@v22` bundles). Fires
+  on ~1,400 cases across the docs' tables. Disabled for now so CI
+  stays green; a candidate for a dedicated follow-up PR using the
+  same per-rule workflow as the rest of the cleanup.
+
+`MD059` (descriptive link text) is also new in v0.40.0; it was
+cleared by rewriting all 109 generic `[here]` / `[link]` references
+to use descriptive text and is now enforced.
 
 **Tuned** — these rules are configured rather than at default settings:
 


### PR DESCRIPTION
## Summary

Clears all 109 MD059 (descriptive-link-text) violations and re-enables
the rule in CI. Rewrites every generic `[here](URL)` / `[link](URL)`
across the docs to use descriptive text that names what's at the URL.

This is the first per-rule cleanup of the new violations introduced
when CI moved to markdownlint v0.40.0. Same workflow as the original
MD040 / MD045 / MD051 PRs.

## Examples

| Before | After |
|---|---|
| `Adapter downloads can be found [here](../deployment.md).` | `[Adapter downloads](../deployment.md) are available on the deployment page.` |
| `This extension makes use of AWS's native CLI tool, which can be found [here](https://...).` | `This extension uses [AWS's native CLI tool](https://...).` |
| `Your browser does not support PDF. Click [here](...) to download.` | `Your browser does not support PDF. [Download the example unified invoice](...).` |

## Two largest patterns

- **`Adapter downloads can be found [here](../deployment.md)`** — the
  same line appearing across 12 adapter-type pages. Replaced
  uniformly with `[Adapter downloads](../deployment.md) are available
  on the deployment page.`
- **`This extension makes use of X's CLI, which can be found [here]`** —
  across all 13 Cloud CLI platform pages. Replaced with `This
  extension uses [X's CLI](URL).`

## Bonus content fix

While rewriting, found that `docs/5-integrations/extensions/cloud-cli/sublime.md`
said "Tailscale's native CLI" but linked to Sublime Security's CLI
(copy-paste bug). Updated the text to match the URL.

## Config

Re-enabled `MD059` in `.markdownlint-cli2.jsonc`. `MD060`
(table-column-style, ~1,400 violations) remains disabled — separate
cleanup PR.

## Verification

- `grep -rE '\[here\]\(|\[link\]\(' docs/` returns **0 matches**.
- `mkdocs build --strict`: 6 INFO/WARNING messages, identical to master.
- 78 HTML pages differ vs master (the rewrites); zero new
  `class="err"` markers anywhere.
- `llms.txt` byte-identical to master (27,947 bytes).
- All URLs unchanged — only visible link text changed. No internal
  cross-page links broken.

## Out of scope (next)

- `MD060` (table-column-style) — ~1,396 violations. Mostly mechanical
  table column alignment / width fixes. Will need its own PR.

## Test plan

- [ ] CI `check-markdown` reports 0 MD059 violations
- [ ] CI `Link Checker` (lychee) and `docs.yml` (mkdocs build) pass
- [ ] Visual spot-check of `cloud-cli/sublime.md` to confirm the
      "Sublime Security's native CLI" text reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)