### PR TITLE
docs(windows): document native ARM64 sensor and add ARM64 MSI download

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
@@ -52,7 +52,7 @@ Choose the correct download for your system architecture:
 | 32-bit (x86) | [https://downloads.limacharlie.io/sensor/windows/32](https://downloads.limacharlie.io/sensor/windows/32) |
 | ARM64 | [https://downloads.limacharlie.io/sensor/windows/arm64](https://downloads.limacharlie.io/sensor/windows/arm64) |
 
-> **Note:** ARM64 Windows devices currently use the x64 sensor running under emulation.
+> **Note:** A native ARM64 build is available for Windows on ARM devices (sensor 4.33.26 or later). Earlier sensor versions ran under x64 emulation; this is no longer required.
 
 ### MSI Installer Downloads
 
@@ -60,6 +60,7 @@ Choose the correct download for your system architecture:
 |--------------|---------------|
 | 64-bit (x64) | [https://downloads.limacharlie.io/sensor/windows/msi64](https://downloads.limacharlie.io/sensor/windows/msi64) |
 | 32-bit (x86) | [https://downloads.limacharlie.io/sensor/windows/msi32](https://downloads.limacharlie.io/sensor/windows/msi32) |
+| ARM64 | [https://downloads.limacharlie.io/sensor/windows/msiarm64](https://downloads.limacharlie.io/sensor/windows/msiarm64) |
 
 > **Note about downloaded filenames:** The downloaded file will have a versioned name like `hcp_win_x64_release_4.33.23.exe`. You can rename it to `rphcp.exe` for convenience, or use the original filename in commands.
 >


### PR DESCRIPTION
## Summary
- Replace the outdated \"ARM64 runs under x64 emulation\" note in the Windows install guide — native ARM64 support shipped in sensor 4.33.26.
- Add an ARM64 row to the MSI Installer Downloads table pointing at https://downloads.limacharlie.io/sensor/windows/msiarm64.

## Test plan
- [ ] Render the page and confirm the EXE and MSI tables both show all three architectures (x64, x86, ARM64).
- [ ] Confirm both download URLs (`/sensor/windows/arm64` and `/sensor/windows/msiarm64`) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)