### PR TITLE
docs(9-ai-sessions): document AI Skills and AI Memory

### DIFF
--- a/docs/9-ai-sessions/index.md
+++ b/docs/9-ai-sessions/index.md
@@ -85,6 +85,8 @@ respond:
 - [D&R-Driven Sessions](dr-sessions.md) - Automated sessions triggered by D&R rules
 - [User Sessions](user-sessions.md) - Interactive sessions via web UI or API
 - [Tool Permissions & Profiles](tool-permissions.md) - How `allowed_tools`, `denied_tools`, and `permission_mode` work
+- [AI Skills](skills.md) - Reusable Claude Code skill definitions stored in your org
+- [AI Memory](memory.md) - Per-agent persistent memory with partial-merge writes
 - [API Reference](api-reference.md) - REST API and WebSocket protocol
 - [TypeScript SDK](sdk.md) - SDK for programmatic access
 

--- a/docs/9-ai-sessions/memory.md
+++ b/docs/9-ai-sessions/memory.md
@@ -1,0 +1,134 @@
+# AI Memory
+
+AI Memory is a per-agent key/value store for content that should outlive a single AI Session. Where [Skills](skills.md) capture *how* an agent works, memory captures *what it has learned* — facts about the environment, prior decisions, ongoing investigations, anything the agent should be able to recall the next time it runs.
+
+Each agent owns one record, keyed by an agent identifier you pick. Inside that record, individual memories are addressed by filesystem-style names (`notes/today`, `cases/INC-123/timeline`, `runtime/last-seen-host`, …). Writes are partial: setting a single named memory does not require reading the rest of the record back, and concurrent writes against different memory names on the same agent do not need to coordinate.
+
+## How writes merge
+
+Memory uses a server-side partial-merge model so agents can update one entry at a time without round-tripping the whole record:
+
+- **Set** with `{"<name>": "<content>"}` replaces just that entry. Other memories on the agent are preserved.
+- **Set** with `{"<name>": null}` drops just that entry. Other memories are preserved.
+- **Delete the whole record** to remove every memory for an agent in one call.
+
+This means an agent can take notes incrementally throughout a session — `progress/step-1`, `progress/step-2` — without ever fetching the full record, and two agents (or two parallel turns) writing to disjoint memory names will not clobber each other.
+
+## Naming rules
+
+Memory names follow filesystem conventions:
+
+- Relative paths only — no leading `/`.
+- Forward slashes only — no `\`.
+- Canonical form — `./` and `../` segments are rejected.
+- No traversal above the record root.
+- Maximum 256 characters per name.
+
+Use the path structure to keep memories organised (`runtime/`, `notes/`, `cases/<id>/…`) — the store does not care about the segments, but a consistent layout makes it easier to enumerate or selectively wipe.
+
+## Limits
+
+- Memories per agent record: 1024
+- Memory name length: 256 characters
+- Total record size: 10 MB
+
+## Permissions
+
+| Operation | Permission |
+|---|---|
+| List / get | `ai_memory.get` |
+| Create / update / drop | `ai_memory.set` |
+| Delete a whole agent record | `ai_memory.del` |
+| Read metadata | `ai_memory.get.mtd` |
+| Update metadata | `ai_memory.set.mtd` |
+
+## Managing memory
+
+### CLI
+
+The `ai-memory` command group draws a clear line between operating on one memory entry (`get`, `set`, `delete`, with both `--key` and `--memory-name`) and operating on the whole agent record (`list-records`, `delete-record`).
+
+```bash
+# Enumerate every agent that has memory stored.
+limacharlie ai-memory list-records
+
+# List the memory entries on one agent.
+limacharlie ai-memory list --key triage-bot
+
+# Read one memory entry.
+limacharlie ai-memory get --key triage-bot --memory-name notes/today
+
+# Write or replace one memory entry (other memories preserved).
+limacharlie ai-memory set --key triage-bot \
+    --memory-name notes/today --content "wrote the cli wrapper"
+
+# Pipe content from a file or another command.
+cat findings.md | limacharlie ai-memory set \
+    --key triage-bot --memory-name cases/INC-123/timeline
+
+# Drop one memory entry (other memories preserved).
+limacharlie ai-memory delete --key triage-bot \
+    --memory-name notes/today --confirm
+
+# Drop every memory the agent has stored.
+limacharlie ai-memory delete-record --key triage-bot --confirm
+```
+
+### REST API
+
+Memory lives in the `ai_memory` Hive. To set or drop one entry without disturbing the others, send only that entry under the `memories` field — the merge happens server-side:
+
+```bash
+# Set one memory (other memories preserved).
+curl -s -X POST \
+  "https://api.limacharlie.io/v1/hive/ai_memory/$OID/triage-bot/data" \
+  -H "Authorization: Bearer $LC_JWT" \
+  --data-urlencode 'data={"memories":{"notes/today":"wrote the cli wrapper"}}'
+
+# Drop one memory (other memories preserved).
+curl -s -X POST \
+  "https://api.limacharlie.io/v1/hive/ai_memory/$OID/triage-bot/data" \
+  -H "Authorization: Bearer $LC_JWT" \
+  --data-urlencode 'data={"memories":{"notes/today":null}}'
+```
+
+Reading the record returns every memory under `data.memories`.
+
+### Python SDK
+
+The `AiMemory` client wraps the partial-merge semantics so callers can operate on one entry at a time:
+
+```python
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.ai_memory import AiMemory
+
+client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+org = Organization(client)
+am = AiMemory(org)
+
+# Write or replace one memory.
+am.set("triage-bot", "notes/today", "wrote the cli wrapper")
+
+# Read one memory.
+content = am.get("triage-bot", "notes/today")
+
+# Update many entries in one call (None drops the entry).
+am.set_many("triage-bot", {
+    "progress/step-1": "done",
+    "progress/step-2": "in flight",
+    "notes/today": None,
+})
+
+# Drop one memory; everything else on the agent is preserved.
+am.delete("triage-bot", "progress/step-1")
+
+# Wipe the agent record entirely.
+am.delete_record("triage-bot")
+```
+
+## Related
+
+- [AI Skills](skills.md) — companion store for reusable instruction sets.
+- [User Sessions](user-sessions.md) — interactive sessions that may write to and read from memory.
+- [D&R-Driven Sessions](dr-sessions.md) — automated sessions that can persist findings across runs.

--- a/docs/9-ai-sessions/skills.md
+++ b/docs/9-ai-sessions/skills.md
@@ -1,0 +1,174 @@
+# AI Skills
+
+AI Skills let you store reusable [Claude Code skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) definitions in your LimaCharlie organization. A skill is a self-contained instruction set — a `SKILL.md` document plus optional supporting files — that Claude can load on demand when its description matches the work at hand. Storing skills in LimaCharlie means every AI Session your organization runs (D&R-driven, CLI-launched, or interactive) starts out with the same library of operational know-how, without having to bake it into individual prompts or session profiles.
+
+Each skill record is a one-to-one mapping of an on-disk Claude Code skill directory: the `SKILL.md` body lives in the record's `content` field, the YAML frontmatter is broken out into typed fields with the same names as the official spec, and any bundled scripts or reference docs go under a `files` map keyed by their path relative to the skill root.
+
+## When to use a skill
+
+- **Codify operating procedures.** Capture "how we triage lateral-movement detections" or "how we close a phishing case" once and have every analyst session pick it up automatically.
+- **Bundle helper scripts and reference material.** A skill can ship its own shell helpers, queries, or markdown notes alongside the instructions; the agent reads them in when it loads the skill.
+- **Keep prompts terse.** Prompts and `ai_agent` records can stay focused on *what* to do; the *how* lives in the skill, where it can be reused.
+
+For the underlying skill model — when Claude decides to load a skill, the trigger budget for `description` + `when_to_use`, the `allowed-tools` grammar, etc. — see the upstream [Claude Code Skills documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview). The LimaCharlie store mirrors that schema verbatim.
+
+## Record format
+
+A skill record has one required field, `content`, plus the optional frontmatter fields below. Fields use the same names as the on-disk `SKILL.md` frontmatter, so a skill can move between a developer's filesystem and the LimaCharlie hive without renaming anything.
+
+### Required
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | string | The `SKILL.md` body — the markdown instructions Claude reads when the skill loads. |
+
+### Frontmatter
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Slug, `[a-z0-9-]{1,64}`. Optional — defaults to the record key. |
+| `description` | string | Short summary used to decide when to invoke the skill. |
+| `when_to_use` | string | Supplementary trigger context. Counts against the same budget as `description` (combined ≤ 1536 characters). |
+| `argument-hint` | string | Hint shown in slash-command autocomplete (e.g. `[issue-number]`). |
+| `arguments` | list / string | Named positional arguments for `$name` substitution in `content`. Accepts a list or a space-separated string. |
+| `disable-model-invocation` | boolean | When `true`, prevents Claude from auto-loading the skill (it can still be invoked explicitly). |
+| `user-invocable` | boolean | When `false`, the skill is background-knowledge only and does not appear in the slash-command menu. |
+| `allowed-tools` | list / string | Pre-approved tool list using the same grammar as session profiles (e.g. `Bash(git:*)`, `Read`). See [Tool Permissions & Profiles](tool-permissions.md). |
+| `model` | string | Model override while the skill is active. The literal `inherit` keeps the session's model. |
+| `effort` | string | One of `low`, `medium`, `high`, `xhigh`, `max`. |
+| `context` | string | Isolation mode. Only `fork` is accepted. |
+| `agent` | string | Subagent type used when `context: fork`. Ignored otherwise. |
+| `hooks` | object | Skill-lifecycle hooks. Pass-through to Claude Code — refer to its hooks documentation for the schema. |
+| `paths` | list / string | Glob patterns restricting auto-invocation to matching file paths. Accepts a list or a comma-separated string. |
+| `shell` | string | Shell used for `!` blocks. Either `bash` or `powershell`. |
+
+### Bundled files
+
+| Field | Type | Description |
+|---|---|---|
+| `files` | map | Supporting files keyed by path relative to the skill root (e.g. `scripts/helper.sh`, `reference/api.md`). Maximum 100 entries. The `SKILL.md` itself does not appear here — its body lives in `content`. |
+
+File paths must be relative, use forward slashes, be canonical (no `./` or `../` traversal), and must not be `SKILL.md` (which is reserved for `content`).
+
+### Limits
+
+- Combined `description` + `when_to_use`: 1536 characters
+- Bundled files: 100 entries
+- Total record size: 10 MB
+
+## Example
+
+A minimal skill that walks Claude through a triage workflow and ships one helper script:
+
+```yaml
+data:
+  content: |
+    # Triage a lateral-movement detection
+
+    1. Pull the process tree for the source host with `lc events`.
+    2. Cross-reference the destination host against the asset inventory.
+    3. Run `scripts/check_lateral.sh` to summarise authentication anomalies
+       on both hosts.
+    4. Open a case with the findings; link the original detection.
+
+  description: Triage a lateral-movement detection end to end.
+  when_to_use: >
+    Use when a detection in the `lateral-movement` category fires and you
+    need a single, repeatable workflow to investigate it.
+  allowed-tools:
+    - Bash(scripts/*:*)
+    - Read
+    - Grep
+  files:
+    scripts/check_lateral.sh: |
+      #!/bin/bash
+      set -euo pipefail
+      # ... helper body ...
+
+usr_mtd:
+  enabled: true
+```
+
+Disabled skills (`enabled: false` in `usr_mtd`) remain stored but are skipped when the session enumerates available skills.
+
+## Permissions
+
+| Operation | Permission |
+|---|---|
+| List / get | `ai_skill.get` |
+| Create / update | `ai_skill.set` |
+| Delete | `ai_skill.del` |
+| Read metadata | `ai_skill.get.mtd` |
+| Update metadata | `ai_skill.set.mtd` |
+
+## Managing skills
+
+### CLI
+
+```bash
+# List every skill in the org.
+limacharlie ai-skill list
+
+# Get one skill (frontmatter, content, and any bundled files).
+limacharlie ai-skill get --key triage-lateral
+
+# Create or replace a skill from a YAML file.
+limacharlie ai-skill set --key triage-lateral --input-file triage.yaml
+
+# Or pipe it in.
+cat triage.yaml | limacharlie ai-skill set --key triage-lateral
+
+# Toggle without deleting the record.
+limacharlie ai-skill disable --key triage-lateral
+limacharlie ai-skill enable  --key triage-lateral
+
+# Remove the skill entirely.
+limacharlie ai-skill delete  --key triage-lateral --confirm
+```
+
+The `set` payload uses the same `data` / `usr_mtd` envelope as any other Hive record. The format mirrors the on-disk Claude Code skill directory — the frontmatter keys go under `data` next to `content` and `files`.
+
+### REST API
+
+Skills live in the `ai_skill` Hive, so the standard Hive endpoints apply:
+
+```bash
+# List
+curl -s -X GET \
+  "https://api.limacharlie.io/v1/hive/ai_skill/$OID" \
+  -H "Authorization: Bearer $LC_JWT"
+
+# Set
+curl -s -X POST \
+  "https://api.limacharlie.io/v1/hive/ai_skill/$OID/triage-lateral/data" \
+  -H "Authorization: Bearer $LC_JWT" \
+  --data-urlencode "data=$(cat triage.json)"
+```
+
+### Python SDK
+
+```python
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.hive import Hive, HiveRecord
+
+client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+org = Organization(client)
+hive = Hive(org, "ai_skill")
+
+hive.set(HiveRecord("triage-lateral", data={
+    "content": "...SKILL.md body...",
+    "description": "Triage a lateral-movement detection end to end.",
+    "allowed-tools": ["Read", "Grep", "Bash(scripts/*:*)"],
+    "files": {
+        "scripts/check_lateral.sh": "#!/bin/bash\n...\n",
+    },
+}))
+```
+
+## Related
+
+- [User Sessions](user-sessions.md) — interactive sessions that pick up the org's skill library.
+- [D&R-Driven Sessions](dr-sessions.md) — automated sessions; the same skills apply.
+- [AI Memory](memory.md) — companion store for per-agent state that should persist across runs.
+- [Tool Permissions & Profiles](tool-permissions.md) — grammar for `allowed-tools` entries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -525,6 +525,8 @@ nav:
       - D&R-Driven Sessions: 9-ai-sessions/dr-sessions.md
       - User Sessions: 9-ai-sessions/user-sessions.md
       - Tool Permissions & Profiles: 9-ai-sessions/tool-permissions.md
+      - AI Skills: 9-ai-sessions/skills.md
+      - AI Memory: 9-ai-sessions/memory.md
       - Command Line Interface: 9-ai-sessions/cli.md
       - Alternative Providers: 9-ai-sessions/alternative-providers.md
       - API Reference: 9-ai-sessions/api-reference.md


### PR DESCRIPTION
## Summary

Adds two new pages under **AI Sessions** to cover the recently introduced
`ai_skill` and `ai_memory` stores, and wires them into the nav and the
AI Sessions overview.

- `docs/9-ai-sessions/skills.md` — schema for skill records (mirrors the
  Claude Code SKILL.md frontmatter one-to-one), bundled-files map, limits,
  permissions, and CLI / REST / Python SDK examples.
- `docs/9-ai-sessions/memory.md` — per-agent record model, partial-merge
  write semantics (set one entry, drop one entry, drop the whole record),
  naming rules, limits, permissions, and CLI / REST / Python SDK examples.
- `docs/9-ai-sessions/index.md` and `mkdocs.yml` — discoverability links.

Public-only: no internal source paths or implementation files referenced.

## Test plan

- [x] `markdownlint-cli2` clean on the new and modified pages.
- [ ] Reviewer eyeball: confirm the skills frontmatter table matches what
      the upstream Claude Code spec exposes.
- [ ] Reviewer eyeball: confirm the partial-merge wording matches user
      expectations for the memory hive.
- [ ] Local `mkdocs serve` render of both new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)