### PR TITLE
docs(9-ai-sessions): document Bedrock/Vertex provider blocks

### DIFF
--- a/docs/9-ai-sessions/alternative-providers.md
+++ b/docs/9-ai-sessions/alternative-providers.md
@@ -1,50 +1,31 @@
 # Alternative AI Providers
 
-By default, AI Sessions connects to Claude through Anthropic's API using your Anthropic API key. However, you can configure sessions to route Claude requests through alternative providers such as **Amazon Bedrock**.
+By default, AI Sessions connects to Claude through Anthropic's API using your Anthropic API key. You can also route Claude requests through **Amazon Bedrock** or **Google Cloud Vertex AI**.
 
 This is useful when:
 
-- Your organization already has an AWS agreement that includes Claude access
-- You need to keep AI traffic within specific AWS regions for compliance
-- You want to consolidate billing through your existing AWS account
+- Your organization already has an AWS or GCP agreement that includes Claude access
+- You need to keep AI traffic within specific regions for compliance
+- You want to consolidate billing through your existing cloud account
+
+## Two configuration formats
+
+There are two ways to point a session at a non-Anthropic provider:
+
+1. **Structured provider blocks** *(recommended)* — a top-level `bedrock:` or `vertex:` block on the `ai_agent` Hive record (or on a direct `SessionRequest`). The fields are validated by the schema, secrets are resolved from Hive, and the runner translates the block into the correct environment variables for the Claude subprocess.
+2. **Manual environment variables** — set `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` and the corresponding cloud-provider variables under the profile's `environment:` map. This is the original mechanism and still works, but you have to assemble the variable names yourself.
+
+Pick exactly one credential source per session: `anthropic_secret`, the `bedrock:` block, or the `vertex:` block. They are mutually exclusive — a session cannot mix providers.
 
 ## Amazon Bedrock
 
-[Amazon Bedrock](https://aws.amazon.com/bedrock/) provides access to Claude models through AWS infrastructure. To use Bedrock as the AI provider for your sessions, you configure AWS credentials and a feature flag via environment variables.
+[Amazon Bedrock](https://aws.amazon.com/bedrock/) provides access to Claude models through AWS infrastructure.
 
-### Requirements
+### Required AWS setup
 
-You need to configure both environment variables and a profile-level `model` setting.
+#### IAM permissions
 
-#### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_CODE_USE_BEDROCK` | Set to `1` to enable Bedrock as the AI provider. |
-| `AWS_ACCESS_KEY_ID` | Your AWS access key ID with Bedrock permissions. |
-| `AWS_SECRET_ACCESS_KEY` | Your AWS secret access key. |
-| `AWS_REGION` | The AWS region where Bedrock is available (e.g., `us-east-1`, `us-west-2`, `ap-southeast-2`). |
-
-#### Model
-
-You must also set the `model` field in the profile to a Bedrock model ID. Bedrock model IDs differ from standard Anthropic model IDs — they include a region prefix and version suffix:
-
-| Profile field | Example value |
-|---------------|---------------|
-| `model` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
-
-The general format is `<region-prefix>.anthropic.<model-name>-v<version>:<minor>`. Available model IDs can be found in the [Bedrock model IDs documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html). Common examples:
-
-- `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
-- `us.anthropic.claude-haiku-4-5-20251001-v1:0`
-- `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`
-- `ap.anthropic.claude-sonnet-4-5-20250929-v1:0`
-
-The region prefix in the model ID (e.g., `us`, `eu`, `ap`) should correspond to your `AWS_REGION`.
-
-### AWS IAM Permissions
-
-The AWS credentials must have permissions to invoke Claude models via Bedrock. At minimum, the IAM policy should include:
+The AWS credentials must have permissions to invoke Claude models via Bedrock. At minimum:
 
 ```json
 {
@@ -64,86 +45,195 @@ The AWS credentials must have permissions to invoke Claude models via Bedrock. A
 
 You must also ensure that the Claude models you intend to use are [enabled in your Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) for the selected region.
 
-### Configuration
+#### Model IDs
 
-Set the model and environment variables in your session profile. These can be configured in both interactive (user) and headless (D&R-driven) sessions.
+Bedrock model IDs differ from standard Anthropic model IDs — they include a region prefix and version suffix. Set the `model` field on the profile to one of:
 
-#### Interactive Sessions (Profile)
+- `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- `us.anthropic.claude-haiku-4-5-20251001-v1:0`
+- `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- `ap.anthropic.claude-sonnet-4-5-20250929-v1:0`
 
-Profiles can be configured through the LimaCharlie web app (under AI Sessions > Profiles) or via the API. When creating or updating a profile, set the Bedrock model and environment variables:
+The general format is `<region-prefix>.anthropic.<model-name>-v<version>:<minor>`. The region prefix (`us`, `eu`, `ap`, …) should correspond to your AWS region. Available IDs are listed in the [Bedrock model IDs documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
 
-```bash
-curl -X POST https://ai-sessions.limacharlie.io/v1/profiles \
-  -H "Authorization: Bearer $LC_JWT" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Bedrock Investigation",
-    "description": "Investigation profile using AWS Bedrock",
-    "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "environment": {
-      "CLAUDE_CODE_USE_BEDROCK": "1",
-      "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
-      "AWS_SECRET_ACCESS_KEY": "hive://secret/aws-secret-key",
-      "AWS_REGION": "us-east-1"
-    },
-    "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebFetch"],
-    "max_turns": 100
-  }'
-```
+### Configuration via the `bedrock:` block (recommended)
 
-#### D&R-Driven Sessions (Inline Profile)
-
-Include the environment variables in the inline profile of your D&R rule:
-
-```yaml
-respond:
-  - action: start ai agent
-    prompt: "Investigate this detection..."
-    anthropic_secret: hive://secret/anthropic-key
-    profile:
-      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
-      environment:
-        CLAUDE_CODE_USE_BEDROCK: "1"
-        AWS_ACCESS_KEY_ID: hive://secret/aws-access-key
-        AWS_SECRET_ACCESS_KEY: hive://secret/aws-secret-key
-        AWS_REGION: us-east-1
-```
-
-#### D&R-Driven Sessions (AI Agent Hive Record)
-
-When using definition mode with a Hive AI agent record, set the model and environment variables in the record:
+The `bedrock` block lives at the top of an `ai_agent` Hive record, alongside `prompt`. All credential fields end with `_secret` and accept either a literal value or a `hive://secret/<name>` reference; the endpoint resolves the reference before launching the session.
 
 ```yaml
 ai_agent:
   bedrock-investigator:
     data:
       prompt: "Investigate this detection..."
-      anthropic_secret: hive://secret/anthropic-key
+      lc_api_key_secret: hive://secret/lc-api-key
+      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+
+      bedrock:
+        region: us-east-1
+        access_key_id_secret: hive://secret/aws-access-key-id
+        secret_access_key_secret: hive://secret/aws-secret-access-key
+        # Optional — only when using STS / SSO temporary credentials:
+        session_token_secret: hive://secret/aws-session-token
+    usr_mtd:
+      enabled: true
+```
+
+#### `bedrock` field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `region` | Yes | AWS region where Bedrock is available (for example `us-east-1`, `us-west-2`, `eu-central-1`, `ap-southeast-2`). Sets `AWS_REGION` on the runner. |
+| `access_key_id_secret` | Conditional | AWS access key ID, or a `hive://secret/<name>` reference. Sets `AWS_ACCESS_KEY_ID`. Must be paired with `secret_access_key_secret`. |
+| `secret_access_key_secret` | Conditional | AWS secret access key, or a `hive://secret/<name>` reference. Sets `AWS_SECRET_ACCESS_KEY`. Must be paired with `access_key_id_secret`. |
+| `session_token_secret` | No | Temporary session token from STS or SSO, or a `hive://secret/<name>` reference. Sets `AWS_SESSION_TOKEN`. Requires the access-key pair. |
+| `bearer_token_secret` | Conditional | Bedrock API bearer token, or a `hive://secret/<name>` reference. Sets `AWS_BEARER_TOKEN_BEDROCK`. Used as an alternative to the access-key pair. |
+
+You must supply **either** `(access_key_id_secret + secret_access_key_secret)` **or** `bearer_token_secret`. The schema rejects records that set neither, and rejects setting only one of the access-key pair.
+
+When the runner accepts the block, it sets `CLAUDE_CODE_USE_BEDROCK=1` automatically — you do not need to add it yourself.
+
+### Direct `SessionRequest` (API and integrations)
+
+The same provider block is exposed on the AI Sessions `SessionRequest` type used by the org-scoped API and by integrations that build sessions programmatically. The field names drop the `_secret` suffix because the values are already-resolved literals at that point:
+
+```json
+{
+  "prompt": "Investigate this detection...",
+  "bedrock": {
+    "region": "us-east-1",
+    "access_key_id": "AKIA…",
+    "secret_access_key": "…",
+    "session_token": "…",
+    "bearer_token": "…"
+  },
+  "profile": {
+    "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "allowed_tools": ["Bash", "Read", "Grep", "Glob", "WebFetch"]
+  }
+}
+```
+
+Validation enforces exactly one of `anthropic_key`, `bedrock`, or `vertex` per request, plus the same per-block rules listed above.
+
+### Configuration via environment variables (manual mode)
+
+The original mechanism — setting AWS variables under the profile's `environment:` map — still works. The runner forwards every entry of `environment:` to the Claude subprocess as-is, so the cloud-provider variables get picked up there.
+
+Use this only if you cannot use the structured `bedrock:` block (for example, an older endpoint that does not yet honour the block).
+
+```yaml
+ai_agent:
+  bedrock-investigator:
+    data:
+      prompt: "Investigate this detection..."
+      anthropic_secret: hive://secret/anthropic-key  # placeholder, see note below
       lc_api_key_secret: hive://secret/lc-api-key
       model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
       environment:
         CLAUDE_CODE_USE_BEDROCK: "1"
-        AWS_ACCESS_KEY_ID: hive://secret/aws-access-key
-        AWS_SECRET_ACCESS_KEY: hive://secret/aws-secret-key
+        AWS_ACCESS_KEY_ID: hive://secret/aws-access-key-id
+        AWS_SECRET_ACCESS_KEY: hive://secret/aws-secret-access-key
         AWS_REGION: us-east-1
     usr_mtd:
       enabled: true
 ```
 
-### Storing Credentials Securely
+| Variable | Description |
+|---|---|
+| `CLAUDE_CODE_USE_BEDROCK` | Must be set to `1` to enable Bedrock. |
+| `AWS_ACCESS_KEY_ID` | AWS access key ID with Bedrock permissions. |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key. |
+| `AWS_REGION` | AWS region, matching the model ID's region prefix. |
+| `AWS_SESSION_TOKEN` | *(optional)* STS/SSO temporary session token. |
+| `AWS_BEARER_TOKEN_BEDROCK` | *(optional)* Bedrock API bearer token, alternative to access keys. |
 
-Always store AWS credentials in [Hive Secrets](../7-administration/config-hive/secrets.md) rather than hardcoding them in profiles or D&R rules:
+> When using the manual environment-variable form, the schema still requires `anthropic_secret` to be set on the record. Point it at a `hive://secret/<name>` containing any non-empty placeholder — the runner ignores it once `CLAUDE_CODE_USE_BEDROCK=1` is in the environment.
+
+## Google Cloud Vertex AI
+
+[Google Cloud Vertex AI](https://cloud.google.com/vertex-ai) provides access to Claude models through GCP. Authentication uses a service-account JSON key with the appropriate Vertex AI permissions.
+
+### Required GCP setup
+
+1. Enable the Vertex AI API in your project.
+2. Subscribe to the Claude models you intend to use in [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden).
+3. Create a service account with at least the `roles/aiplatform.user` role (or a custom role permitting `aiplatform.endpoints.predict`).
+4. Generate and download a JSON key for that service account.
+
+### Model IDs and region
+
+Vertex uses Claude model IDs in the form Anthropic ships them on the platform — typically `claude-<model>@<version>`, for example `claude-sonnet-4-5@20250929`. Confirm the IDs available in your project against the [Vertex Model Garden listings](https://console.cloud.google.com/vertex-ai/model-garden).
+
+The region you set must be one that Anthropic publishes models to (commonly `global`, `us-east5`, or `europe-west1`). Cross-check with the [Anthropic on Vertex AI documentation](https://docs.anthropic.com/en/api/claude-on-vertex-ai) for current region availability.
+
+### Configuration via the `vertex:` block (recommended)
 
 ```yaml
-environment:
-  CLAUDE_CODE_USE_BEDROCK: "1"
-  AWS_ACCESS_KEY_ID: hive://secret/aws-access-key-id
-  AWS_SECRET_ACCESS_KEY: hive://secret/aws-secret-access-key
-  AWS_REGION: us-east-1
+ai_agent:
+  vertex-investigator:
+    data:
+      prompt: "Investigate this detection..."
+      lc_api_key_secret: hive://secret/lc-api-key
+      model: claude-sonnet-4-5@20250929
+
+      vertex:
+        project_id: my-gcp-project
+        region: us-east5
+        service_account_json_secret: hive://secret/vertex-service-account
+    usr_mtd:
+      enabled: true
 ```
 
-### Notes
+#### `vertex` field reference
 
-- When using Bedrock, you do **not** need to store an Anthropic API key for user sessions. However, for D&R-driven sessions the `anthropic_secret` field is still required by the schema — you can set it to a placeholder value in your Hive secret.
-- Claude model availability varies by AWS region. Check the [Bedrock model availability page](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html) to confirm your desired model is available in your selected region.
-- Billing for Claude usage goes through your AWS account when using Bedrock, not through Anthropic directly.
+| Field | Required | Description |
+|---|---|---|
+| `project_id` | Yes | GCP project ID hosting the Vertex AI subscription. Sets `ANTHROPIC_VERTEX_PROJECT_ID`. |
+| `region` | Yes | Vertex region (`global`, `us-east5`, `europe-west1`, …). Sets `CLOUD_ML_REGION`. |
+| `service_account_json_secret` | Yes | Full service-account JSON key contents, or a `hive://secret/<name>` reference to a secret holding the JSON. |
+
+The runner writes the resolved service-account JSON to a per-session temporary file (mode `0600`, removed when the process exits) and points `GOOGLE_APPLICATION_CREDENTIALS` at it. It also sets `CLAUDE_CODE_USE_VERTEX=1` automatically.
+
+> Store the entire service-account JSON in a single Hive Secret and reference it via `hive://secret/<name>`. The JSON contains a private key — never paste it as a literal into a record or D&R rule.
+
+### Direct `SessionRequest` (API and integrations)
+
+```json
+{
+  "prompt": "Investigate this detection...",
+  "vertex": {
+    "project_id": "my-gcp-project",
+    "region": "us-east5",
+    "service_account_json": "{\"type\":\"service_account\",\"project_id\":\"…\",\"private_key\":\"…\"}"
+  },
+  "profile": {
+    "model": "claude-sonnet-4-5@20250929"
+  }
+}
+```
+
+`service_account_json` is the literal JSON document for the service-account key — typically the entire contents of the file you downloaded from GCP, embedded as a JSON string.
+
+### Configuration via environment variables (manual mode)
+
+If you must configure Vertex through the profile `environment:` map instead of the structured `vertex:` block, set the variables the runner would otherwise set on your behalf. Note that you cannot inline the service-account JSON as an environment variable — you have to mount it as a file at a known path inside the runner image and point `GOOGLE_APPLICATION_CREDENTIALS` at that path. Most users do not have a way to do that, which is why the structured `vertex:` block is the supported path.
+
+| Variable | Description |
+|---|---|
+| `CLAUDE_CODE_USE_VERTEX` | Must be set to `1` to enable Vertex. |
+| `ANTHROPIC_VERTEX_PROJECT_ID` | GCP project ID for the Vertex subscription. |
+| `CLOUD_ML_REGION` | Vertex region. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Filesystem path to the service-account JSON key. |
+
+## Storing credentials securely
+
+Always store cloud-provider credentials in [Hive Secrets](../7-administration/config-hive/secrets.md) and reference them via `hive://secret/<name>`. Treat the Vertex service-account JSON as a single secret (don't try to split it into multiple fields). For Bedrock, store the access key, secret key, and any session token as separate secrets.
+
+The endpoint resolves `hive://secret/<name>` references just before sending the request to AI Sessions, so secret contents never appear in D&R rules, `argv`, or session metadata.
+
+## Notes
+
+- When using Bedrock or Vertex through the structured block, you do **not** need to set `anthropic_secret`. The schema accepts a record with `bedrock:` or `vertex:` and no `anthropic_secret`. Only the manual environment-variable mode still requires a placeholder `anthropic_secret`.
+- Claude model availability varies by AWS region and Vertex region. Check the [Bedrock model availability page](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html) and [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden) before picking a region.
+- Billing for Claude usage goes through your AWS or GCP account when using these providers, not through Anthropic directly.
+- The provider you choose only affects the Claude API path. LimaCharlie data, MCP servers, the LC CLI, tool execution, and session storage are unaffected.

--- a/docs/9-ai-sessions/dr-sessions.md
+++ b/docs/9-ai-sessions/dr-sessions.md
@@ -32,7 +32,7 @@ respond:
 | Parameter | Description |
 |-----------|-------------|
 | `prompt` | The instructions for Claude. Supports [template strings](../4-data-queries/template-transforms.md) to include event data. |
-| `anthropic_secret` | Your Anthropic API key. Use `hive://secret/<name>` to reference a [Hive Secret](../7-administration/config-hive/secrets.md). |
+| `anthropic_secret` | Your Anthropic API key. Use `hive://secret/<name>` to reference a [Hive Secret](../7-administration/config-hive/secrets.md). To route through AWS Bedrock or Google Cloud Vertex AI instead, use definition mode with the `bedrock:` / `vertex:` blocks on an `ai_agent` Hive record — see [Alternative AI Providers](alternative-providers.md). |
 
 #### Optional Parameters (Inline Mode)
 
@@ -476,7 +476,9 @@ This approach keeps D&R rules clean and lets you update the agent's behavior (pr
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `prompt` | string | Yes | Instructions for Claude. |
-| `anthropic_secret` | string | No | Anthropic API key or `hive://secret/` reference. |
+| `anthropic_secret` | string | Conditional | Anthropic API key or `hive://secret/` reference. Required unless `bedrock:` or `vertex:` is set. See [Alternative AI Providers](alternative-providers.md). |
+| `bedrock` | object | Conditional | AWS Bedrock provider block (`region`, `access_key_id_secret`, `secret_access_key_secret`, `session_token_secret`, `bearer_token_secret`). Mutually exclusive with `anthropic_secret` and `vertex`. See [Alternative AI Providers](alternative-providers.md#amazon-bedrock). |
+| `vertex` | object | Conditional | Google Cloud Vertex AI provider block (`project_id`, `region`, `service_account_json_secret`). Mutually exclusive with `anthropic_secret` and `bedrock`. See [Alternative AI Providers](alternative-providers.md#google-cloud-vertex-ai). |
 | `lc_api_key_secret` | string | No | LimaCharlie API key or `hive://secret/` reference. |
 | `lc_uid_secret` | string | No | LimaCharlie User ID or `hive://secret/` reference. Required when `lc_api_key_secret` is a user API key. |
 | `name` | string | No | Session name. Supports template strings. |
@@ -484,7 +486,7 @@ This approach keeps D&R rules clean and lets you update the agent's behavior (pr
 | `allowed_tools` | list | No | Tools Claude can use. |
 | `denied_tools` | list | No | Tools Claude cannot use. |
 | `permission_mode` | string | No | `acceptEdits`, `plan`, or `bypassPermissions`. |
-| `model` | string | No | Claude model identifier. |
+| `model` | string | No | Claude model identifier. When using Bedrock or Vertex, use the provider-specific model ID format (see [Alternative AI Providers](alternative-providers.md)). |
 | `max_turns` | integer | No | Maximum conversation turns. |
 | `max_budget_usd` | float | No | Maximum spend limit in USD. |
 | `ttl_seconds` | integer | No | Maximum session lifetime in seconds. |


### PR DESCRIPTION
## Summary

The ai-sessions runner now translates structured `bedrock:` / `vertex:` blocks (defined on `ai_agent` Hive records in `legion_config_hive`, and on the `SessionRequest` API surface) into the right `CLAUDE_CODE_USE_*`, `AWS_*`, and `ANTHROPIC_VERTEX_*` environment variables on the Claude subprocess. The previous `alternative-providers.md` only described the legacy approach of hand-setting those variables under the profile's `environment:` map and did not mention Vertex AI at all.

This PR rewrites `alternative-providers.md` and updates `dr-sessions.md`:

- **Bedrock**: cover the new `bedrock:` block (`region`, `access_key_id_secret`, `secret_access_key_secret`, `session_token_secret`, `bearer_token_secret`) on Hive `ai_agent` records, the matching block on `SessionRequest`, and the per-block validation rules. Also surfaces `AWS_SESSION_TOKEN` and `AWS_BEARER_TOKEN_BEDROCK`, which the runner already accepts but which the doc didn't mention.
- **Vertex AI**: new section covering `project_id`, `region`, and `service_account_json_secret`, plus the temp-file mechanism the runner uses for `GOOGLE_APPLICATION_CREDENTIALS` (mode `0600`, removed at process exit).
- **Legacy mode**: keeps the original `environment:`-map approach documented as a fallback, and notes that with Bedrock/Vertex blocks set, `anthropic_secret` is no longer required.
- **`dr-sessions.md`**: adds `bedrock` and `vertex` rows to the AI Agent Record fields table; updates the inline-mode `anthropic_secret` row to cross-link the alternative-providers page; notes provider mutual exclusion.

Drafted because the bridge in `legion_endpoint-go` (`ShootAISessionRequest` in `endpoint/analytics/analysis.go`) only reads `aiAgent.AnthropicSecret` today and does not yet propagate `aiAgent.Bedrock` / `aiAgent.Vertex` from the hive record into the outbound `SessionRequest`. The `ai-sessions` runner and API and the `legion_config_hive` schema all support the new format; the D&R bridge is the missing piece. Hold this PR until the bridge ships, or merge ahead of the bridge if we want the schema documented as-of-now.

## Test plan

- [ ] `npx markdownlint-cli2 docs/9-ai-sessions/alternative-providers.md docs/9-ai-sessions/dr-sessions.md` — passes locally
- [ ] Render in mkdocs and review the alternative-providers.md page for correct headings, code-fence languages, and table formatting
- [ ] Verify all internal links resolve: `../7-administration/config-hive/secrets.md`, `alternative-providers.md#amazon-bedrock`, `alternative-providers.md#google-cloud-vertex-ai`
- [ ] Spot-check that the `bedrock:` and `vertex:` block field names match `legion_config_hive/hives/def_ai_agent.go` (`AiAgentBedrockConfig`, `AiAgentVertexConfig`) and that the API field names match `ai-sessions/pkg/api/types.go` (`BedrockConfig`, `VertexConfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)