### PR TITLE
docs(endpoint-commands): fix reg_list event name and parameter syntax

### DIFF
--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -46,6 +46,7 @@ For commands which emit a report/reply event type from the agent, the correspond
 | os\_users | [OS\_USERS\_REP](edr-events.md#os_users_rep) |  | ☑️ |  |  |  |
 | [os\_version](#os_version) | [OS\_VERSION\_REP](edr-events.md#os_version_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | put | [RECEIPT](edr-events.md#receipt) | ☑️ | ☑️ | ☑️ |  |  |
+| [reg\_list](#reg_list) | [REGISTRY\_LIST\_REP](edr-events.md#registry_list_rep) |  | ☑️ |  |  |  |
 | [rejoin\_network](#rejoin_network) | [REJOIN\_NETWORK](edr-events.md#rejoin_network) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | restart | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | [run](#run) | N/A | ☑️ | ☑️ | ☑️ |  |  |
@@ -1031,20 +1032,22 @@ limacharlie sensor task <SID> pcap_stop
 
 ### reg_list
 
-List Windows registry keys and values.
+List Windows registry keys and values at the specified path.
 
 **Platforms:** Windows
 
 **Parameters:**
 
-- `reg_path` (required): Registry path to list (e.g., "HKEY_LOCAL_MACHINE\\SOFTWARE")
+- `<path>` (required, positional): Registry path to list. Use short hive prefixes such as `hklm`, `hku`, `hkcu`, `hkcr`, `hkcc`.
 
-**Response Event:** REG_LIST_REP
+**Response Event:** REGISTRY_LIST_REP
 
-**Usage Example:**
+**Usage Examples:**
 
 ```bash
-limacharlie sensor task <SID> reg_list --reg_path "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
+limacharlie sensor task <SID> reg_list hklm\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging
+limacharlie sensor task <SID> reg_list hklm\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging
+limacharlie sensor task <SID> reg_list hklm\Software\Policies\Microsoft\Windows\PowerShell\Transcription
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes the `reg_list` entry in `docs/8-reference/endpoint-commands.md`. As written, the documented invocation does not work in production.

- **Response event** was `REG_LIST_REP` — actual event is `REGISTRY_LIST_REP` (matches `docs/8-reference/edr-events.md` and `docs/8-reference/faq/privacy.md`).
- **Parameter syntax** was documented as `--reg_path "<path>"`. Confirmed in production: passing `--reg_path` causes the command to fail; the path must be passed as a positional argument. Replaced the example with three confirmed-working invocations using short hive prefixes (`hklm`).
- Added `reg_list` to the platform-support table at the top of the file (it was missing).

## Test plan

- [x] `reg_list <path>` examples copy/paste cleanly and match the form confirmed working in production
- [x] `REGISTRY_LIST_REP` exists as a heading in `docs/8-reference/edr-events.md`
- [x] Top-of-file platform-support table includes `reg_list` with a working anchor link