### PR TITLE
docs(access): document session lifetime enforcement

### DIFF
--- a/docs/7-administration/access/session-lifetime.md
+++ b/docs/7-administration/access/session-lifetime.md
@@ -1,0 +1,36 @@
+# Session Lifetime Enforcement
+
+LimaCharlie can enforce a maximum lifetime on web-app sessions for users in a specific email domain. Once enabled, users are automatically signed out of the web app after the configured duration, measured from the moment they last entered their credentials. They must then sign in again to continue.
+
+This is typically used by enterprise and regulated customers who require periodic re-authentication, regardless of whether a user is actively using the web app.
+
+## How It Works
+
+- The configured maximum lifetime is applied to every user whose email belongs to the enrolled domain.
+- The countdown starts when the user authenticates (entering password, completing SSO, or completing MFA). Background token refreshes do **not** reset it.
+- When the limit is reached, the web app shows a brief notice and signs the user out. The user can sign back in immediately and a new countdown begins.
+- The control affects the web app only. API tokens, sensor enrollment, and integrations are not impacted.
+
+## Scope
+
+- The setting is configured per email domain. All users authenticating with an email in the enrolled domain are subject to the same limit.
+- Customers with multiple email domains (for example, primary and secondary brands) can enroll each domain independently.
+- The setting can be combined with [Strict SSO Enforcement](sso.md) and other per-domain authentication controls.
+
+## User Experience
+
+- During the session, no banner or countdown is shown — the experience is identical to a normal session.
+- At expiry, the user sees a short message indicating that the session has reached its maximum lifetime, and is redirected to the sign-in page.
+- For users who are already signed in at the moment the policy is first enabled for their domain, the countdown applies from their most recent sign-in. They will typically be signed out shortly after enablement and asked to sign in once; subsequent sessions follow the configured limit.
+
+## Requesting Enrollment
+
+Session lifetime enforcement is configured by LimaCharlie staff. To enable it for your domain, contact your LimaCharlie account team or open a support request including:
+
+- The email domain (or domains) to enroll.
+- The maximum session duration (for example, "8 hours" or "7 days").
+
+## Related Articles
+
+- [Single Sign-On](sso.md)
+- [User Access](user-access.md)

--- a/docs/7-administration/access/sso.md
+++ b/docs/7-administration/access/sso.md
@@ -31,6 +31,7 @@ In LimaCharlie, an Organization represents a tenant within the Agentic SecOps Wo
 ## Related Articles
 
 - [User Access](user-access.md)
+- [Session Lifetime Enforcement](session-lifetime.md)
 
 ## What's Next
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -481,6 +481,7 @@ nav:
           - User Access: 7-administration/access/user-access.md
           - Designing Access: 7-administration/access/designing-access.md
           - SSO: 7-administration/access/sso.md
+          - Session Lifetime Enforcement: 7-administration/access/session-lifetime.md
       - Billing:
           - Options: 7-administration/billing/options.md
           - Custom Plans: 7-administration/billing/custom-plans.md


### PR DESCRIPTION
## Summary
New customer-facing page under **Administration > Access > Session Lifetime Enforcement** describing the optional per-email-domain maximum web-app session lifetime. Covers what the feature does, who it applies to, the user experience (including the behavior for users who are already signed in at the moment the policy is first enabled), and how customers request enrollment. Adds a cross-link from the SSO page and a nav entry in `mkdocs.yml`.

## Related
- Tracking issue: refractionPOINT/tracking#4281
- Backend: refractionPOINT/billing-services#220
- Frontend: refractionPOINT/web-app-frontend#3737

## Test plan
- [ ] `mkdocs serve` renders the new page under Administration > Access
- [ ] SSO page shows the new "Session Lifetime Enforcement" link under Related Articles
- [ ] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)