### PR TITLE
docs: correct MCP-server implications to reflect CLI-based access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,35 +1,52 @@
 # Using LimaCharlie
 
-## Required Skill
+## Required Tool
 
-**ALWAYS load the `lc-essentials:limacharlie-call` skill** before any LimaCharlie API operation. Never call LimaCharlie MCP tools directly.
+**ALWAYS use the `limacharlie` CLI via Bash** for all LimaCharlie API operations. The CLI is automatically installed on session start and handles authentication. Never call MCP tools directly.
+
+If auto-install failed, install manually:
+
+```bash
+pipx install limacharlie   # preferred (isolated environment)
+uv tool install limacharlie # alternative
+pip install --user limacharlie # fallback
+```
+
+On first use, verify authentication with `limacharlie auth whoami --output yaml`; if not authenticated, guide the user through `limacharlie auth login`.
 
 ## Critical Rules
 
-### 1. Never Call MCP Tools Directly
+### 1. Use the CLI Directly
 
-- **WRONG**: `mcp__plugin_lc-essentials_limacharlie__lc_call_tool(...)`
-- **CORRECT**: Use Task tool with `subagent_type="lc-essentials:limacharlie-api-executor"`
+- **WRONG**: `mcp__plugin_lc-essentials_limacharlie__lc_call_tool(...)` or spawning an api-executor agent
+- **CORRECT**: `Bash("limacharlie <noun> <verb> --oid <oid> --output yaml")`
+
+Always pass `--output yaml` for token-efficient, machine-readable output. Use `limacharlie <command> --ai-help` to discover a command's flags. Use `limacharlie api <endpoint>` only as an escape hatch for endpoints with no dedicated CLI command.
 
 ### 2. Never Write LCQL Queries Manually
 
-LCQL uses unique pipe-based syntax validated against org-specific schemas.
+LCQL uses unique pipe-based syntax validated against org-specific schemas. Manual queries WILL fail or produce incorrect results.
 
-- **ALWAYS**: `generate_lcql_query()` first, then `run_lcql_query()` with the generated query
-- Manual queries WILL fail or produce incorrect results
+1. `limacharlie ai generate-query --prompt "..." --oid <oid> --output yaml` — convert natural language to LCQL
+2. `limacharlie search validate --query "..." --oid <oid> --output yaml` — mandatory for ALL queries before execution
+3. `limacharlie search run --query "..." --start <ts> --end <ts> --oid <oid> --output yaml` — execute only after validation passes
+
+On validation failure, re-run the generate command with the error message — never fix queries manually.
 
 ### 3. Never Generate D&R Rules Manually
 
-Use AI generation tools:
-1. `generate_dr_rule_detection()` - Generate detection YAML
-2. `generate_dr_rule_respond()` - Generate response YAML
-3. `validate_dr_rule_components()` - Validate before deploy
+Use AI generation commands:
+
+1. `limacharlie ai generate-detection --description "..." --oid <oid> --output yaml` — generate detection YAML
+2. `limacharlie ai generate-response --description "..." --oid <oid> --output yaml` — generate response YAML
+3. `limacharlie dr validate --detect detect.yaml --respond respond.yaml --oid <oid>` — validate before deploy
 
 ### 4. Never Calculate Timestamps Manually
 
 LLMs consistently produce incorrect timestamp values.
 
 **ALWAYS use bash:**
+
 ```bash
 date +%s                           # Current time (seconds)
 date -d '1 hour ago' +%s           # 1 hour ago
@@ -39,14 +56,14 @@ date -d '2025-01-15 00:00:00 UTC' +%s  # Specific date
 
 ### 5. OID is UUID, NOT Organization Name
 
-- **WRONG**: `oid: "my-org-name"`
-- **CORRECT**: `oid: "c1ffedc0-ffee-4a1e-b1a5-abc123def456"`
-- Use `list_user_orgs` to map org names to UUIDs
+- **WRONG**: `--oid "my-org-name"`
+- **CORRECT**: `--oid "c1ffedc0-ffee-4a1e-b1a5-abc123def456"`
+- Use `limacharlie org list --output yaml` to map org names to UUIDs
 
 ### 6. Timestamp Milliseconds vs Seconds
 
 - Detection/event data: **milliseconds** (13 digits)
-- API parameters (`get_historic_events`, `get_historic_detections`): **seconds** (10 digits)
+- API parameters: **seconds** (10 digits)
 - **ALWAYS** divide by 1000 when using detection timestamps for API queries
 
 ### 7. Never Fabricate Data
@@ -59,6 +76,7 @@ date -d '2025-01-15 00:00:00 UTC' +%s  # Specific date
 ### 8. Spawn Agents in Parallel
 
 When processing multiple organizations or items:
+
 - Use a SINGLE message with multiple Task calls
 - Do NOT spawn agents sequentially
 - Each agent handles ONE item, parent aggregates results
@@ -71,11 +89,11 @@ Organizations can define SOPs (Standard Operating Procedures) in LimaCharlie tha
 
 At the beginning of every conversation involving LimaCharlie operations:
 
-1. **List all SOPs** using `list_sops` for each organization in scope
+1. **List all SOPs** using `limacharlie sop list --oid <oid> --output yaml` for each organization in scope
 2. **Store ONLY the name and description** of each SOP (ignore the `text` field - it may be truncated or large)
 3. Use this index to identify when an SOP might apply to current work
 
-**Important:** Do NOT read or use the full SOP content at this stage. The `list_sops` response may include a `text` field, but ignore it - always call `get_sop` when you need the actual procedure.
+**Important:** Do NOT read or use the full SOP content at this stage. The `sop list` response may include a `text` field, but ignore it - always call `limacharlie sop get` when you need the actual procedure.
 
 ### When Performing Tasks (Load Full Content)
 
@@ -84,16 +102,16 @@ Before executing any significant operation:
 1. **Check SOP relevance**: Compare the current task against stored SOP descriptions
 2. **If a match is found**:
    - Announce: "Following SOP: [sop-name] - [description]"
-   - **MUST call `get_sop`** to retrieve the full SOP content (do not skip this step)
+   - **MUST call `limacharlie sop get --key <name> --oid <oid> --output yaml`** to retrieve the full SOP content (do not skip this step)
    - Follow the procedure defined in the SOP
-3. **If multiple SOPs match**: Announce all matching SOPs, call `get_sop` for each, and follow all applicable procedures
+3. **If multiple SOPs match**: Announce all matching SOPs, fetch each with `limacharlie sop get`, and follow all applicable procedures
 
 ### Example Workflow
 
 1. User asks to investigate a malware alert
 2. LLM checks stored SOP index: "malware-response" matches (description: "Standard procedure for malware incidents")
 3. LLM announces: "Following SOP: malware-response - Standard procedure for malware incidents"
-4. LLM calls `get_sop(name="malware-response")` to load the full procedure
+4. LLM calls `limacharlie sop get --key malware-response --oid <oid> --output yaml` to load the full procedure
 5. LLM follows the documented steps from the loaded SOP content
 
 ## Sensor Selector Reference
@@ -137,7 +155,7 @@ Sensor selectors use [bexpr](https://github.com/hashicorp/go-bexpr) syntax to fi
 
 ### Example Selectors
 
-```
+```text
 plat == windows                           # All Windows sensors
 plat == windows and arch == x64           # 64-bit Windows only
 plat == linux and hostname contains "web" # Linux with "web" in hostname

--- a/docs/8-reference/response-actions.md
+++ b/docs/8-reference/response-actions.md
@@ -397,7 +397,7 @@ This action supports two modes: **inline mode** (all parameters in the rule) and
   definition: hive://ai_agent/my-triage-bot
 ```
 
-This action launches a fully-managed Claude Code session that can investigate events, query data via MCP servers, and generate reports.
+This action launches a fully-managed Claude Code session that can investigate events, query LimaCharlie data via the auto-installed `limacharlie` CLI, and generate reports.
 
 #### Required Parameters (Inline Mode)
 
@@ -422,7 +422,7 @@ This action launches a fully-managed Claude Code session that can investigate ev
 | `idempotent_key` | Unique key to prevent duplicate sessions. Supports template strings. (Inline mode only.) |
 | `debounce_key` | Serializes sessions: only one active session per key. New requests queue behind the active session and re-fire when it ends. Supports template strings. (Both modes.) |
 | `data` | Extract event fields to include in the prompt as JSON. (Inline mode only.) |
-| `profile` | Inline session configuration (tools, model, limits, MCP servers). (Inline mode only.) |
+| `profile` | Inline session configuration (tools, model, limits, external MCP servers). (Inline mode only.) |
 | `profile_name` | Reference a saved profile by name. (Inline mode only.) |
 
 #### Example: Inline Mode
@@ -457,12 +457,6 @@ respond:
       max_turns: 50
       max_budget_usd: 5.0
       one_shot: true
-      mcp_servers:
-        limacharlie:
-          type: http
-          url: https://mcp.limacharlie.io
-          headers:
-            Authorization: hive://secret/lc-mcp-token
 ```
 
 #### Example: Definition Mode

--- a/docs/9-ai-sessions/api-reference.md
+++ b/docs/9-ai-sessions/api-reference.md
@@ -260,11 +260,11 @@ POST /v1/profiles
   "max_turns": 100,
   "max_budget_usd": 10.0,
   "mcp_servers": {
-    "limacharlie": {
+    "virustotal": {
       "type": "http",
-      "url": "https://mcp.limacharlie.io",
+      "url": "https://vt-mcp.example.com",
       "headers": {
-        "Authorization": "Bearer token"
+        "x-apikey": "hive://secret/vt-api-key"
       }
     }
   },

--- a/docs/9-ai-sessions/dr-sessions.md
+++ b/docs/9-ai-sessions/dr-sessions.md
@@ -7,7 +7,7 @@ D&R-Driven AI Sessions allow you to automatically spawn Claude AI sessions in re
 When a D&R rule matches, the `start ai agent` response action launches a Claude session with:
 
 - A prompt containing the context you specify
-- Access to tools and MCP servers you configure
+- The auto-installed `limacharlie` CLI for LimaCharlie operations (authenticated via `lc_api_key_secret`), plus any built-in tools and external MCP servers you configure
 - Optional event data extracted and included automatically
 
 The session runs autonomously, performing the investigation or analysis you've defined, and the results can be captured via outputs or stored for later review.
@@ -200,19 +200,13 @@ Profiles let you configure Claude's behavior, available tools, and resource limi
     environment:
       LOG_LEVEL: debug
       API_KEY: hive://secret/external-api-key
-
-    # MCP servers
-    mcp_servers:
-      limacharlie:
-        type: http
-        url: https://mcp.limacharlie.io
-        headers:
-          Authorization: hive://secret/lc-mcp-token
 ```
+
+> LimaCharlie itself does **not** need an `mcp_servers` entry — the session reaches LimaCharlie through the auto-installed `limacharlie` CLI, authenticated by the `lc_api_key_secret` you provide. The `mcp_servers` map below is only for *external/third-party* tools (threat-intel, ticketing, etc.).
 
 #### Profile Options
 
-> The full pattern grammar for `allowed_tools` and `denied_tools` (built-in Claude Code tool names, `Bash(prefix:*)` scoping, MCP `mcp__server__tool` names, and the `lc_call_tool` meta-tool form), along with the precedence rules and `permission_mode` semantics, lives on the dedicated [Tool Permissions & Profiles](tool-permissions.md) page. Unattended D&R agents typically want `permission_mode: bypassPermissions` so tool calls don't block on approval prompts.
+> The full pattern grammar for `allowed_tools` and `denied_tools` (built-in Claude Code tool names, `Bash(prefix:*)` scoping, and MCP `mcp__server__tool` names), along with the precedence rules and `permission_mode` semantics, lives on the dedicated [Tool Permissions & Profiles](tool-permissions.md) page. Unattended D&R agents typically want `permission_mode: bypassPermissions` so tool calls don't block on approval prompts.
 
 | Option | Type | Description |
 |--------|------|-------------|
@@ -225,21 +219,23 @@ Profiles let you configure Claude's behavior, available tools, and resource limi
 | `one_shot` | boolean | When `true`, session completes all work for the initial prompt (including tools, skills, and subagents) then terminates automatically. Default: `true` for D&R-triggered sessions. |
 | `ttl_seconds` | integer | Maximum session lifetime in seconds. Capped at 24 hours. |
 | `environment` | map | Environment variables. Values can use `hive://secret/` |
-| `mcp_servers` | map | MCP server configurations (see below) |
+| `mcp_servers` | map | External/third-party MCP server configurations (see below). Not needed for LimaCharlie access. |
 
 ### MCP Server Configuration
 
-MCP (Model Context Protocol) servers extend Claude's capabilities by providing additional data sources and tools.
+MCP (Model Context Protocol) servers extend Claude's capabilities with *external/third-party* data sources and tools.
+
+> You do **not** configure LimaCharlie here. The session already has the auto-installed `limacharlie` CLI for all LimaCharlie operations (authenticated by `lc_api_key_secret`). Reserve `mcp_servers` for outside services such as threat-intel, ticketing, or custom enrichment tools.
 
 #### HTTP MCP Server
 
 ```yaml
 mcp_servers:
-  limacharlie:
+  virustotal:
     type: http
-    url: https://mcp.limacharlie.io
+    url: https://vt-mcp.example.com
     headers:
-      Authorization: hive://secret/lc-mcp-token
+      x-apikey: hive://secret/vt-api-key
 ```
 
 #### Stdio MCP Server
@@ -286,9 +282,9 @@ respond:
       user: "{{ .event.USER_NAME }}"
 ```
 
-### Example 2: Automated Triage with LimaCharlie MCP
+### Example 2: Automated Triage with the LimaCharlie CLI
 
-Use the LimaCharlie MCP server to query additional context:
+The session reaches LimaCharlie through the auto-installed `limacharlie` CLI — just provide `lc_api_key_secret` so the CLI is authenticated. No `mcp_servers` entry is needed for LimaCharlie itself:
 
 ```yaml
 detect:
@@ -301,7 +297,7 @@ detect:
 respond:
   - action: start ai agent
     prompt: |
-      A high-priority detection was triggered. Use the LimaCharlie MCP tools to:
+      A high-priority detection was triggered. Use the `limacharlie` CLI to:
 
       1. Get information about the sensor where this occurred
       2. Query recent events from the same sensor
@@ -319,12 +315,6 @@ respond:
     profile:
       max_turns: 100
       max_budget_usd: 10.0
-      mcp_servers:
-        limacharlie:
-          type: http
-          url: https://mcp.limacharlie.io
-          headers:
-            Authorization: hive://secret/lc-mcp-token
 ```
 
 ### Example 3: Threat Hunting Automation
@@ -457,13 +447,9 @@ ai_agent:
         - Write
         - Edit
 
-      # MCP servers
-      mcp_servers:
-        limacharlie:
-          type: http
-          url: https://mcp.limacharlie.io
-          headers:
-            Authorization: hive://secret/lc-mcp-token
+      # No mcp_servers entry is needed for LimaCharlie access — the
+      # auto-installed `limacharlie` CLI uses lc_api_key_secret above.
+      # Add mcp_servers only for external/third-party tools.
 
     usr_mtd:
       enabled: true
@@ -516,7 +502,7 @@ This approach keeps D&R rules clean and lets you update the agent's behavior (pr
 | `ttl_seconds` | integer | No | Maximum session lifetime in seconds. |
 | `one_shot` | boolean | No | Auto-terminate after initial task. |
 | `environment` | map | No | Environment variables (values can use `hive://secret/`). |
-| `mcp_servers` | map | No | MCP server configurations. |
+| `mcp_servers` | map | No | External/third-party MCP server configurations. Not needed for LimaCharlie access (handled by the auto-installed CLI). |
 
 ## Best Practices
 

--- a/docs/9-ai-sessions/user-sessions.md
+++ b/docs/9-ai-sessions/user-sessions.md
@@ -147,7 +147,7 @@ curl -X POST https://ai-sessions.limacharlie.io/v1/profiles \
 | `one_shot` | boolean | When `true`, session terminates after completing its initial work. Default: `false` for user sessions. |
 | `ttl_seconds` | integer | Maximum session lifetime in seconds |
 | `environment` | map | Environment variables passed to the session |
-| `mcp_servers` | map | MCP server configurations |
+| `mcp_servers` | map | External/third-party MCP server configurations. LimaCharlie access is handled by the auto-installed `limacharlie` CLI and does not need an entry here. |
 
 ### Setting a Default Profile
 


### PR DESCRIPTION
## Context

`CLAUDE.md`'s **Never Call MCP Tools Directly** section (and several docs pages) still implied that the `lc-essentials` plugin / managed AI Sessions talk to LimaCharlie via the **LimaCharlie MCP server**. That's no longer true: those paths use the auto-installed `limacharlie` CLI, authenticated via `lc_api_key_secret`. The `limacharlie-call` skill and `limacharlie-api-executor` agent referenced in `CLAUDE.md` were removed in lc-ai #85 with no replacement.

The standalone MCP server **still exists** as a product for non-Claude-Code MCP clients, so `docs/6-developer-guide/mcp-server.md` (which already distinguishes Option 1 = plugin/CLI from Options 2–3 = HTTP MCP) is intentionally left unchanged.

## Changes

- **`CLAUDE.md`** — reframe "Required Skill"/Rule 1 around the CLI (`limacharlie <noun> <verb> --oid <oid> --output yaml`); convert the LCQL, D&R, and SOP rules to their `limacharlie` CLI equivalents. Aligned with the authoritative `lc-essentials/AUTOINIT.md`.
- **`docs/9-ai-sessions/dr-sessions.md`** — drop the `mcp_servers: limacharlie` blocks from the inline profile, Example 2, and the `ai_agent` record; rename Example 2 to the CLI; switch the generic MCP HTTP example to a third-party server; remove the stale `lc_call_tool` meta-tool reference; clarify `mcp_servers` is for external tools only.
- **`docs/8-reference/response-actions.md`** — "query data via MCP servers" → via the CLI; remove the LimaCharlie `mcp_servers` block from the inline example.
- **`docs/9-ai-sessions/api-reference.md`** — point the `mcp_servers` profile example at an external service instead of `mcp.limacharlie.io`.
- **`docs/9-ai-sessions/user-sessions.md`** — clarify the `mcp_servers` profile field is for external tools, not LimaCharlie.

## Verification

- `markdownlint-cli2` clean across all 306 docs files.
- No remaining `mcp.limacharlie.io` / `lc-mcp-token` / `lc_call_tool` / `limacharlie-call` references outside the intentional product doc (`mcp-server.md`) and the `CLAUDE.md` "WRONG" anti-example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)