### PR TITLE
PagerDuty: document parameters passthrough and templating gotcha

### DIFF
--- a/docs/3-detection-response/alternate-targets.md
+++ b/docs/3-detection-response/alternate-targets.md
@@ -38,9 +38,9 @@ rules:
 
 # Response
 - action: extension request
-  extension name: pagerduty
+  extension name: ext-pagerduty
   extension action: run
-  request:
+  extension request:
     group: '{{ "lc-alerts" }}'
     severity: '{{ "critical" }}'
     component: '{{ "vip-alert" }}'

--- a/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
+++ b/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
@@ -1375,11 +1375,12 @@ respond:
       escalation_reason: Detection on VIP endpoint
 
   - action: extension request
-    extension name: pagerduty
+    extension name: ext-pagerduty
     extension action: run
     extension request:
       severity: '{{ "critical" }}'
       summary: '{{ "Alert on VIP endpoint" }}'
+      source: '{{ "limacharlie.io" }}'
 ```
 
 #### Example 6: Alert Threshold Escalation

--- a/docs/5-integrations/extensions/third-party/pagerduty.md
+++ b/docs/5-integrations/extensions/third-party/pagerduty.md
@@ -46,6 +46,52 @@ From this point on, you may use a rule to trigger a PagerDuty event. For example
        details: '{{ .event }}'
 ```
 
+> **Important — wrap literal strings in `{{ "..." }}`.**
+> Values under `extension request` are evaluated as templates. A bare string without `{{ }}` is interpreted as a [gjson](https://github.com/tidwall/gjson) path against the event and, if it doesn't resolve, the key is silently dropped from the payload. That's why every literal above is written as `'{{ "..." }}'`. For required fields (`summary`, `source`, `severity`) this matters most — a dropped key will cause the request to be rejected with `missing one of <field>`.
+
+### Pass-through `parameters` block
+
+For richer PagerDuty incidents you can supply an optional `parameters` block alongside the flat fields. Recognized keys are mapped to their proper place in the [V2 event payload](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/); any key that isn't recognized is merged into `custom_details` so nothing is lost.
+
+| Key | Type | Where it goes |
+| --- | --- | --- |
+| `custom_details` | object | `payload.custom_details` |
+| `links` | list of `{ href, text }` | top-level `links` |
+| `images` | list | top-level `images` |
+| `timestamp` | string (ISO 8601) | `payload.timestamp` |
+| `client` | string | top-level `client` |
+| `client_url` | string | top-level `client_url` |
+| `dedup_key` | string | top-level `dedup_key` |
+
+Example with a clickable link back to LimaCharlie and a dedup key tied to the detection:
+
+```yaml
+- action: extension request
+  extension action: run
+  extension name: ext-pagerduty
+  extension request:
+    severity: '{{ "warning" }}'
+    source: '{{ "limacharlie.io" }}'
+    summary: '{{ .cat }} - {{ .routing.hostname }} - Threat level {{ .detect_mtd.level }}'
+    parameters:
+      custom_details:
+        oid:   '{{ .routing.oid }}'
+        sid:   '{{ .routing.sid }}'
+        event: '{{ .detect.event }}'
+      links:
+        - href: '{{ .link }}'
+          text: '{{ "Open in LimaCharlie" }}'
+      client:     '{{ "LimaCharlie" }}'
+      client_url: '{{ .link }}'
+      dedup_key:  '{{ .cat }}-{{ .routing.sid }}'
+  suppression:
+    is_global: true
+    keys:
+      - '{{ .cat }}'
+    max_count: 30
+    period: 1h
+```
+
 ### Migrating D&R Rule from legacy Service to new Extension
 
 ***Note: LimaCharlie has migrated from Services to Extensions. Legacy services are no longer supported.***


### PR DESCRIPTION
## Summary

Updates the PagerDuty extension page with two things that came out of a recent incident:

- A callout explaining the templating gotcha: bare strings under `extension request` are evaluated as [gjson](https://github.com/tidwall/gjson) paths and silently dropped if they don't resolve. Wrap literals in `{{ "..." }}`. This is what caused customers to hit `missing one of source` even though the rule clearly had `source: limacharlie.io`.
- A new section describing the `parameters` passthrough block being added in [ext-pagerduty#35](https://github.com/refractionPOINT/ext-pagerduty/pull/35) — `custom_details`, `links`, `images`, `timestamp`, `client`, `client_url`, `dedup_key` — with a worked example showing a clickable link back to LimaCharlie and a dedup_key tied to the detection.

Depends on ext-pagerduty#35 landing first.

## Test plan

- [ ] mkdocs builds locally without errors
- [ ] Table renders correctly in mkdocs-material theme
- [ ] Callout admonition renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)