### PR TITLE
docs: list Watch Rule operators and clarify no regex support

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/exfil.md
+++ b/docs/5-integrations/extensions/limacharlie/exfil.md
@@ -42,6 +42,24 @@ Value: wininet.dll
 
 The above rule would configures the sensor(s) to send *only* `MODULE_LOAD` events where the `FILE_PATH` ends with the value `wininet.dll`.
 
+### Watch Rule Operators
+
+Watch Rules support exactly four operators. The configured `value` is compared **literally** (not as a pattern) against the string at `path` in the event:
+
+| Operator      | Match condition                                                |
+|---------------|----------------------------------------------------------------|
+| `is`          | The field value exactly equals the configured value.            |
+| `contains`    | The configured value appears anywhere in the field value.       |
+| `starts with` | The field value begins with the configured value.               |
+| `ends with`   | The field value ends with the configured value.                 |
+
+Additional behavior to be aware of:
+
+- **No regular expressions, globs, or wildcards.** A value such as `^/Users/[^/]+/(Downloads|Desktop)/` is matched character-for-character — including the `^`, `[`, `(`, etc. — and will not behave as a regex.
+- **Case-insensitive.** Both the configured value and the event field are lowercased before comparison, so `wininet.dll` and `WININET.DLL` match.
+- **String fields only.** Only string-typed event fields are evaluated; numeric fields at the configured `path` are skipped.
+- **Unknown operators are dropped silently.** A Watch Rule whose `operator` is anything other than the four values above will not match any event. Use one of the supported operators above (or combine multiple Watch Rules) to express the condition you need.
+
 > Performance Rules
 >
 > Performance rules, applied via tag to a set of Sensors, are useful for high I/O systems. These rules can be set via the web application or REST API.


### PR DESCRIPTION
## Summary

- A customer in [#help](https://refractionpoint.slack.com/archives/C02G3J27URZ/p1779376672009649) tried to use `operator: matches` with a regex `value`. The Exfil docs describe the four Watch Rule **fields** (event/path/operator/value) but never list which operators actually exist or how the value is matched, so the misuse was easy to land in.
- The sensor (`sensor/modules/hbs/exfil_engine.c`) and the cloud extension (`ext-exfil/ext/defaults.go` `ExfilWatchOperators`) agree on exactly four operators: `is`, `contains`, `starts with`, `ends with`. All four do **literal, case-insensitive** string matching — values are lowercased on both sides before comparison and there is no regex/glob engine anywhere. An unknown operator string maps to 0 server-side, which the sensor's `exfilEngine_new` switch treats as invalid and drops the rule entirely.
- This PR adds a `Watch Rule Operators` subsection under `## Using the Exfil Extension` with the operator table and a short list of the surprising behaviors (no regex, case-insensitive, string-only fields, unknown operators silently dropped).

## Test plan

- [x] `npx --yes markdownlint-cli2 "docs/5-integrations/extensions/limacharlie/exfil.md"` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)