### PR TITLE
docs: add otel, cortex_xdr, harmony, threatlocker, halopsa platforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Sensor selectors use [bexpr](https://github.com/hashicorp/go-bexpr) syntax to fi
 
 **EDR Platforms:** `windows`, `linux`, `macos`, `ios`, `android`, `chrome`, `vpn`
 
-**Adapter/USP Platforms:** `text`, `json`, `gcp`, `aws`, `carbon_black`, `1password`, `office365`, `sophos`, `crowdstrike`, `msdefender`, `sentinel_one`, `okta`, `duo`, `github`, `slack`, `azure_ad`, `azure_monitor`, `entraid`, `zeek`, `cef`, `wel`, `xml`, `guard_duty`, `k8s_pods`, `wiz`, `proofpoint`, `box`, `cylance`, `fortigate`, `netscaler`, `paloalto_fw`, `iis`, `trend_micro`, `trend_worryfree`, `bitwarden`, `mimecast`, `hubspot`, `zendesk`, `pandadoc`, `falconcloud`, `sublime`, `itglue`, `canary_token`, `lc_event`, `email`, `mac_unified_logging`, `azure_event_hub_namespace`, `azure_key_vault`, `azure_kubernetes_service`, `azure_network_security_group`, `azure_sql_audit`
+**Adapter/USP Platforms:** `text`, `json`, `gcp`, `aws`, `carbon_black`, `1password`, `office365`, `sophos`, `crowdstrike`, `msdefender`, `sentinel_one`, `okta`, `duo`, `github`, `slack`, `azure_ad`, `azure_monitor`, `entraid`, `zeek`, `cef`, `wel`, `xml`, `guard_duty`, `k8s_pods`, `wiz`, `proofpoint`, `box`, `cylance`, `fortigate`, `netscaler`, `paloalto_fw`, `iis`, `trend_micro`, `trend_worryfree`, `bitwarden`, `mimecast`, `hubspot`, `zendesk`, `pandadoc`, `falconcloud`, `sublime`, `itglue`, `canary_token`, `lc_event`, `email`, `mac_unified_logging`, `azure_event_hub_namespace`, `azure_key_vault`, `azure_kubernetes_service`, `azure_network_security_group`, `azure_sql_audit`, `otel`, `cortex_xdr`, `harmony`, `threatlocker`, `halopsa`
 
 ### Architecture Values (`arch`)
 

--- a/docs/8-reference/detection-logic-operators.md
+++ b/docs/8-reference/detection-logic-operators.md
@@ -231,12 +231,15 @@ Takes a `name` parameter for the platform name. The current platforms are:
 **Security Products:**
 
 - `carbon_black`
+- `cortex_xdr` (Palo Alto Cortex XDR)
 - `crowdstrike`
 - `cylance`
 - `falconcloud`
+- `harmony` (Check Point Harmony)
 - `msdefender` (Microsoft Defender)
 - `sentinel_one`
 - `sophos`
+- `threatlocker`
 - `trend_micro`
 - `trend_worryfree`
 - `wiz`
@@ -251,6 +254,7 @@ Takes a `name` parameter for the platform name. The current platforms are:
 
 **IT & Business Services:**
 
+- `halopsa` (HaloPSA)
 - `hubspot`
 - `itglue`
 - `mimecast`
@@ -276,6 +280,7 @@ Takes a `name` parameter for the platform name. The current platforms are:
 - `cef` (Common Event Format)
 - `wel` (Windows Event Log)
 - `mac_unified_logging`
+- `otel` (OpenTelemetry)
 
 **Other:**
 

--- a/docs/8-reference/id-schema.md
+++ b/docs/8-reference/id-schema.md
@@ -100,6 +100,11 @@ The platform is a 32-bit integer (in its hex format) which identifies the exact 
 | 0x2B000000 | 721420288  | wiz                          | Wiz                          |
 | 0x2C000000 | 738197504  | bitwarden                    | Bitwarden                    |
 | 0x2D000000 | 754974720  | trend_micro                  | Trend Micro                  |
+| 0x2E000000 | 771751936  | otel                         | OpenTelemetry                |
+| 0x2F000000 | 788529152  | cortex_xdr                   | Cortex XDR                   |
+| 0x31000000 | 822083584  | harmony                      | Check Point Harmony          |
+| 0x32000000 | 838860800  | threatlocker                 | ThreatLocker                 |
+| 0x33000000 | 855638016  | halopsa                      | HaloPSA                      |
 | 0x10000000 | 268435456  | windows                      | Windows                      |
 | 0x20000000 | 536870912  | linux                        | Linux                        |
 | 0x30000000 | 805306368  | macos                        | MacOS                        |


### PR DESCRIPTION
## Summary

`go-essentials` (`lc/agentid.go`, the source of truth for platform definitions) has registered five platforms that were not yet reflected in this repo's platform reference material:

| API name | Platform | Hex ID | Decimal |
|---|---|---|---|
| `otel` | OpenTelemetry | 0x2E000000 | 771751936 |
| `cortex_xdr` | Cortex XDR | 0x2F000000 | 788529152 |
| `harmony` | Check Point Harmony | 0x31000000 | 822083584 |
| `threatlocker` | ThreatLocker | 0x32000000 | 838860800 |
| `halopsa` | HaloPSA | 0x33000000 | 855638016 |

## Changes

- **`docs/8-reference/id-schema.md`** — five rows added to the platform ID table.
- **`docs/8-reference/detection-logic-operators.md`** — added to the `is platform` operator list (`cortex_xdr`/`harmony`/`threatlocker` under Security Products, `halopsa` under IT & Business Services, `otel` under Data Formats).
- **`CLAUDE.md`** — added to the Sensor Selector Reference adapter/USP platform list.

Hex IDs and API name strings copied verbatim from `go-essentials@2fd652c`; decimal values computed from the hex IDs.

Scope is the reference lists only — no new adapter type pages are added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)