### PR TITLE
docs(search): document include_facets/include_histogram opt-in toggles

### DIFF
--- a/docs/4-data-queries/index.md
+++ b/docs/4-data-queries/index.md
@@ -17,6 +17,11 @@ Query and analyze your security telemetry using LimaCharlie Query Language (LCQL
 
 ### Run an LCQL Query
 
+!!! info "Facets and histogram are opt-in"
+    The search API supports two optional boolean request body fields, `include_facets` and `include_histogram`. Both default to `false`: when they are omitted (or sent as `false`), the response is returned without facet aggregations and without the time-distribution histogram, and the matching response keys come back empty. Send `true` to request either block.
+
+    The web Query Console always opts in, so its facets sidebar and histogram render unchanged. This only affects callers using the REST API, the SDKs, or `lc-cli` directly.
+
 === "REST API"
 
     ```bash
@@ -33,7 +38,9 @@ Query and analyze your security telemetry using LimaCharlie Query Language (LCQL
         "query": "event.FILE_PATH ends with .exe",
         "startTime": "'"$START"'",
         "endTime": "'"$END"'",
-        "stream": "event"
+        "stream": "event",
+        "include_facets": true,
+        "include_histogram": true
       }'
     ```
 

--- a/docs/8-reference/story-tags.md
+++ b/docs/8-reference/story-tags.md
@@ -40,7 +40,7 @@ Every segment that isn't a fixed keyword has a strict regex:
 | `TARGET_NAME` | `^[a-z0-9][a-z0-9_.-]{0,127}$`     | Same as `STORY_NAME` plus `.` (covers Hive record keys with dots).   |
 | `LABEL_SLUG`  | `^[a-z0-9][a-z0-9_-]{0,63}$`       | Same as `STORY_NAME`. Rendered with `-` and `_` turned into spaces. |
 
-Tags that violate any gate are **silently dropped** by the assembler — they never produce phantom nodes or edges. This matches the [`lc:asset:*`](asset-tags.md) convention: malformed metadata must never show up in a dashboard.
+Tags that violate any gate are **silently dropped** by the assembler — they never produce phantom nodes or edges. This matches the [`lc:asset:*`](../2-sensors-deployment/asset-tags.md) convention: malformed metadata must never show up in a dashboard.
 
 ### Canonical type slugs
 


### PR DESCRIPTION
## Summary

- Document the two new optional search API body fields, `include_facets` and `include_histogram`, on the Query Console REST API examples page. Both default to `false`; callers that omit them now get an empty `facets` block and no histogram.
- Update the *Run an LCQL Query* curl example to set both toggles to `true` so users see how to opt in.
- The web Query Console always opts in (per [web-app-frontend#3767](https://github.com/refractionPOINT/web-app-frontend/pull/3767)), so the UI behavior is unchanged — the docs note this so REST/SDK/CLI users understand who is affected.

Reflects backend change in [replay#442](https://github.com/refractionPOINT/replay/pull/442) and the matching webapp change in [web-app-frontend#3767](https://github.com/refractionPOINT/web-app-frontend/pull/3767) (both merged 2026-05-22).

## Test plan

- [x] `mkdocs build` — no new warnings introduced (the pre-existing `8-reference/story-tags.md → asset-tags.md` warning is unrelated and present on master).
- [x] Audited rendered `site/4-data-queries/index.html` — admonition + curl tab render correctly with both new fields visible.
- [ ] Reviewer sanity-check the wording against the API contract in replay#442 (`ResolveIncludeToggle`: `nil → false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)