### PR TITLE
docs(linux): add RPM download URLs and uninstall section

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
@@ -131,9 +131,14 @@ sudo dnf remove limacharlie
 
 Uninstall stops the service and removes the sensor binary, identity files, and the package staging directory.
 
+RPM packages are offered for the architectures the Linux sensor supports, like:
+
+- **x64**: <https://downloads.limacharlie.io/sensor/linux/rpm64>
+- **arm64**: <https://downloads.limacharlie.io/sensor/linux/rpmarm64>
+
 ### Custom Installation
 
-For non-Debian systems, download the installer using the following command:
+For systems where neither the `.deb` nor the `.rpm` package fits (e.g. distributions without `dpkg` or `rpm`, or installs that need a non-standard layout), download the installer directly using the following command:
 
 ```python
 wget https://downloads.limacharlie.io/sensor/linux/64 -O /tmp/lc_sensor
@@ -170,7 +175,7 @@ By default, when running on a kernel where eBPF is unavailable, the Linux sensor
 
 For additional agent uninstall options, see [Endpoint Agent Uninstallation](../uninstallation.md)
 
-Linux agent uninstallation depends on how the sensor was installed. For example, if installed via a Debian package (`dpkg` file), you should uninstall via the same mechanism. If you installed via the SystemV installation method, please utilize the bottom of [this script](https://github.com/refractionPOINT/lce_doc/blob/master/docs/lc_linux_installer.sh#L97).
+Linux agent uninstallation depends on how the sensor was installed. For example, if installed via a Debian package (`dpkg` file) or an RPM package (`rpm` / `dnf` / `yum`), you should uninstall via the same package manager. If you installed via the SystemV installation method, please utilize the bottom of [this script](https://github.com/refractionPOINT/lce_doc/blob/master/docs/lc_linux_installer.sh#L97).
 
 ### Sensor Command
 
@@ -188,4 +193,18 @@ If the sensor was originally installed with the .deb file, this option is the cl
 
 ```bash
 apt remove limacharlie
+```
+
+### RPM-based Systems
+
+If the sensor was originally installed with the .rpm file, use the matching package manager:
+
+```bash
+sudo dnf remove limacharlie
+```
+
+or
+
+```bash
+sudo rpm -e limacharlie
 ```

--- a/docs/8-reference/story-tags.md
+++ b/docs/8-reference/story-tags.md
@@ -40,7 +40,7 @@ Every segment that isn't a fixed keyword has a strict regex:
 | `TARGET_NAME` | `^[a-z0-9][a-z0-9_.-]{0,127}$`     | Same as `STORY_NAME` plus `.` (covers Hive record keys with dots).   |
 | `LABEL_SLUG`  | `^[a-z0-9][a-z0-9_-]{0,63}$`       | Same as `STORY_NAME`. Rendered with `-` and `_` turned into spaces. |
 
-Tags that violate any gate are **silently dropped** by the assembler — they never produce phantom nodes or edges. This matches the [`lc:asset:*`](asset-tags.md) convention: malformed metadata must never show up in a dashboard.
+Tags that violate any gate are **silently dropped** by the assembler — they never produce phantom nodes or edges. This matches the [`lc:asset:*`](../2-sensors-deployment/asset-tags.md) convention: malformed metadata must never show up in a dashboard.
 
 ### Canonical type slugs
 


### PR DESCRIPTION
## Summary
- Add per-architecture `.rpm` download URLs (`rpm64`, `rpmarm64`) to the Linux RPM Package section, mirroring the existing `.deb` URL list.
- Reword the "Custom Installation" intro so it no longer says "non-Debian" (now that `.rpm` is also a first-class option).
- Add an "RPM-based Systems" entry under uninstallation, mirroring the existing Debian Systems entry.

Companion to lc_sensor#695 which makes the `.rpm` artifacts available in the release bucket.

## Test plan
- [ ] Render the page locally (`mkdocs serve`) and confirm the new section reads cleanly next to the existing Deb section.
- [ ] Verify the `rpm64` / `rpmarm64` URLs once the matching redirect routes are added in the downloads-service datastore (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)