### PR TITLE
docs: add ThreatLocker adapter and extension pages

### DIFF
--- a/docs/2-sensors-deployment/adapters/index.md
+++ b/docs/2-sensors-deployment/adapters/index.md
@@ -34,6 +34,7 @@ Adapters enable log ingestion from external sources into LimaCharlie. They trans
 - [SentinelOne](types/sentinelone.md)
 - [Sophos](types/sophos.md)
 - [Carbon Black](types/carbon-black.md)
+- [ThreatLocker](types/threatlocker.md)
 
 ### Generic Formats
 

--- a/docs/2-sensors-deployment/adapters/types/threatlocker.md
+++ b/docs/2-sensors-deployment/adapters/types/threatlocker.md
@@ -1,0 +1,209 @@
+# ThreatLocker
+
+## Overview
+
+This Adapter ingests events from the [ThreatLocker](https://threatlocker.com) Portal API into LimaCharlie. Events are forwarded in their original ThreatLocker JSON form — the adapter does not reshape payloads.
+
+The adapter is **generic by design**. The ThreatLocker Portal API is uniform: every queryable resource exposes a `<Resource>GetByParameters` endpoint that takes a `POST` with a JSON filter body. The adapter models each such endpoint as a *feed* — adding a new event type is a configuration change, not a code change.
+
+It pairs naturally with the [ThreatLocker extension](../../../5-integrations/extensions/third-party/threatlocker.md): the adapter delivers Application Control approval-request events into LimaCharlie, and the extension provides the actions an AI agent (or a Playbook) calls to enrich those events and write the decision back.
+
+## Deployment Configurations
+
+All adapters support the same `client_options`, which you should always specify if using the binary adapter or creating a webhook adapter. If you use any of the Adapter helpers in the web app, you will not need to specify these values.
+
+- `client_options.identity.oid`: the LimaCharlie Organization ID (OID) this adapter is used with.
+- `client_options.identity.installation_key`: the LimaCharlie Installation Key this adapter should use to identify with LimaCharlie.
+- `client_options.platform`: the type of data ingested through this adapter, like `text`, `json`, `gcp`, `carbon_black`, etc.
+- `client_options.sensor_seed_key`: an arbitrary name for this adapter which Sensor IDs (SID) are generated from, see below.
+
+### Adapter-specific Options
+
+Adapter Type: `threatlocker`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `api_key` | yes | ThreatLocker API token (see [Authentication](#authentication) below). Sent verbatim in the `Authorization` header — no `Bearer ` prefix. |
+| `instance` | yes* | ThreatLocker instance letter (`b`, `c`, …, `g`, `h`, …). *Required unless `base_url` is set. |
+| `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. Use to point the adapter at a non-standard endpoint; otherwise prefer `instance`. |
+| `managed_organization_id` | no | UUID of the managed (child) organization. Sent as the `managedOrganizationId` header — used by MSP **parent** tokens to scope every request to a specific child tenant. |
+| `feeds` | no | List of feeds to poll (see [Feed fields](#feed-fields) below). When omitted the adapter polls the three default feeds described under [Default feeds](#default-feeds). |
+| `page_size` | no | Records per page. Default `100`, maximum `1000`. |
+| `poll_interval` | no | Wait between polls of a feed, as a Go duration in **nanoseconds**. Default `60000000000` (1 minute). |
+| `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
+
+### Feed fields
+
+Each entry in `feeds` describes one ThreatLocker `*GetByParameters` endpoint to poll.
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `name` | yes | Labels the feed and becomes the `EventType` of every shipped event. Must be unique within `feeds`. |
+| `url` | yes | API path of the `*GetByParameters` endpoint, **relative to the API root** (e.g. `ApprovalRequest/ApprovalRequestGetByParameters`). |
+| `parameters` | no | JSON object merged into the request body — resource-specific filters such as `statusId`, `showChildOrganizations`, ThreatLocker query DTOs. |
+| `order_by` | no | Sort field. Default `dateTime`. The default request is newest-first (`isAscending = false`). |
+| `items_path` | no | Key holding the records array when the response is an object envelope. Auto-detected (`data`, `pageItems`, …) when empty. |
+| `timestamp_field` | no | Path to the record's event time, supports `/`-separated nested paths. Default `dateTime`. |
+| `id_field` | no | Path to the record's stable identifier, used for deduplication. Falls back to common id fields, then a content hash. |
+| `max_pages` | no | Caps pages fetched per poll. Default `100`. |
+| `window` | no | When set (e.g. `5m`), rewrites `startDate` / `endDate` in the request body on every poll to a rolling `[now-window-poll_interval, now]` range. **Required** for endpoints that mandate a date range (`ActionLog`, `SystemAudit`). The overlap with the previous poll is absorbed by the deduper. |
+| `start_date_field` / `end_date_field` | no | Override the request-body field names used by `window`. Defaults: `startDate` / `endDate`. |
+
+### Default feeds
+
+With no `feeds` configured, the adapter polls three feeds that together cover ThreatLocker's primary telemetry surfaces:
+
+| Default feed | ThreatLocker endpoint | What it carries |
+| --- | --- | --- |
+| `approval_request` | `ApprovalRequest/ApprovalRequestGetByParameters` (`statusId = 1`) | Pending Application Control whitelist requests — one event per new request, shipped exactly once. The intended input to AI-driven triage via the [ThreatLocker extension](../../../5-integrations/extensions/third-party/threatlocker.md). |
+| `unified_audit` | `ActionLog/ActionLogGetByParametersV2` | The **Unified Audit** — ThreatLocker's combined event stream of `execute` / `install` / `network` / `registry` / `read` / `write` / `move` / `delete` / `baseline` / `powershell` / `elevate` / web activity across every module. Polled on a 5-minute rolling window. |
+| `system_audit` | `SystemAudit/SystemAuditGetByParameters` | Portal / administrator activity — logins, policy edits, approval decisions, organization changes. Polled on a 5-minute rolling window. |
+
+`unified_audit` and `system_audit` both *require* a `startDate`/`endDate` filter on every request; the adapter sets those automatically via the feed's `window`. The overlap between consecutive windows is absorbed by the per-feed deduper, preserving at-least-once delivery semantics.
+
+## Authentication
+
+Create an API token under **Portal → Administration → API Users** in the ThreatLocker Portal. The token is sent verbatim in the `Authorization` header — there is no `Bearer ` prefix and no OAuth handshake.
+
+### Finding your instance
+
+ThreatLocker hosts each tenant on one of several lettered instances (`b`, `c`, `d`, …, `g`, `h`, …) and API tokens are scoped to the instance that minted them. To find yours, open the ThreatLocker Portal, click the **Help** button in the top-right corner of any page, and read the letter in parentheses next to **ThreatLocker Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
+
+> ⚠️ **A token from one instance returns `403 TOKEN_REVOKED` on every other instance** — the API does not distinguish "wrong instance" from a genuinely revoked token. If you are confident the token is active and still see `TOKEN_REVOKED`, double-check the instance letter before assuming the token was revoked. An authentication failure stops the adapter so the misconfiguration is surfaced loudly.
+
+## How polling works
+
+On every poll the adapter walks a feed's pages (`pageNumber` / `pageSize`) until the result set is exhausted (a short or empty page) or the feed's `max_pages` cap is reached. An in-memory deduper, keyed per feed, guarantees each record is shipped to LimaCharlie exactly once even though pages are re-fetched on every poll.
+
+Transient API failures (HTTP 5xx, 429, network errors) are retried with exponential backoff. An authentication failure (401/403) stops the adapter rather than burning the token via repeated retries.
+
+The adapter deliberately re-walks every page rather than stopping at the first page of already-seen records: the Portal API paginates by offset over a live, mutable list, so a record can shift across a page boundary between two page fetches. Re-walking costs more requests but is correct.
+
+For a large or high-churn feed, bound each poll's work with the feed's `parameters` (e.g. a date-range filter) and a `max_pages` that comfortably exceeds the feed's expected size. Querying newest-first (`isAscending = false`, the default) keeps the most recent records when `max_pages` truncates.
+
+## CLI Deployment
+
+[Adapter downloads](../deployment.md) are available on the deployment page. The defaults are usually sufficient — supplying `api_key` and `instance` is enough to pull the three default feeds.
+
+```bash
+chmod +x /path/to/lc_adapter
+
+/path/to/lc_adapter threatlocker \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=threatlocker \
+  api_key=$THREATLOCKER_API_TOKEN \
+  instance=g
+```
+
+## Infrastructure as Code Deployment
+
+```yaml
+# For cloud sensor deployment, store credentials as hive secrets:
+#
+#   api_key: "hive://secret/threatlocker-api-token"
+
+sensor_type: "threatlocker"
+threatlocker:
+  api_key: "hive://secret/threatlocker-api-token"
+  instance: "g"
+  # Optional: MSP parent tokens — scope every request to a child tenant
+  # managed_organization_id: "00000000-0000-0000-0000-000000000000"
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_THREATLOCKER"
+    hostname: "threatlocker-adapter"
+    platform: "json"
+    sensor_seed_key: "threatlocker-sensor"
+    mapping:
+      event_type_path: "_lc_threatlocker_feed"
+      event_time_path: "dateTime"
+    indexing: []
+```
+
+### Custom feeds
+
+Override `feeds` to add new feeds or replace the defaults entirely. The list is **replacing**, not merging — re-declare the defaults you want to keep alongside any custom feed.
+
+The example below keeps the three defaults and adds a fourth feed that ships *denied* approval requests:
+
+```yaml
+threatlocker:
+  api_key: "hive://secret/threatlocker-api-token"
+  instance: "g"
+  feeds:
+    - name: approval_request
+      url: ApprovalRequest/ApprovalRequestGetByParameters
+      parameters:
+        statusId: 1            # pending
+        showChildOrganizations: false
+      id_field: approvalRequestId
+    - name: unified_audit
+      url: ActionLog/ActionLogGetByParametersV2
+      window: 5m
+      parameters:
+        paramsFieldsDto: []
+        groupBys: []
+        exportMode: false
+        showTotalCount: false
+        showChildOrganizations: false
+        onlyTrueDenies: false
+        simulateDeny: false
+      id_field: actionLogId
+    - name: system_audit
+      url: SystemAudit/SystemAuditGetByParameters
+      window: 5m
+      parameters:
+        viewChildOrganizations: false
+      id_field: systemAuditId
+    - name: approval_request_denied
+      url: ApprovalRequest/ApprovalRequestGetByParameters
+      parameters:
+        statusId: 3            # denied
+        showChildOrganizations: false
+      id_field: approvalRequestId
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_THREATLOCKER"
+    platform: "json"
+    sensor_seed_key: "threatlocker-sensor"
+```
+
+## Configuring a ThreatLocker Adapter in the Web UI
+
+Within the LimaCharlie web application, select `+ Add Sensor`, then choose **ThreatLocker**.
+
+Pick or create an Installation Key for this adapter, then fill in:
+
+| Field | Value |
+| --- | --- |
+| API Key | ThreatLocker Portal API token (from *Administration → API Users*). |
+| Instance | Single instance letter from *Help → ThreatLocker Access (X)*, e.g. `g`. |
+| Managed Organization ID | *(optional)* Child-tenant UUID for MSP parent tokens. |
+| Feeds | *(optional)* JSON / YAML array of custom feeds. Leave empty to use the three defaults. |
+
+Click `Complete Cloud Installation`. LimaCharlie will authenticate against the Portal and begin polling.
+
+## Sample Rule
+
+The adapter ships each record under an `EventType` matching the feed's `name`. For the default feed set, that gives `approval_request`, `unified_audit`, and `system_audit` — so D&R rules can route directly on the feed:
+
+```yaml
+# Detection — flag every new pending approval request so an AI agent
+# can pick it up and call the ext-threatlocker enrichment actions.
+event: approval_request
+
+# Response
+- action: report
+  name: ThreatLocker Approval Request
+```
+
+To chain enrichment + decision from a rule on this event, dispatch to a [Playbook](../../../5-integrations/extensions/limacharlie/playbook.md) or an AI agent — the [ThreatLocker extension](../../../5-integrations/extensions/third-party/threatlocker.md) page walks through the action surface.
+
+## API Docs
+
+- ThreatLocker Portal Swagger: `https://portalapi.<instance>.threatlocker.com/swagger` (replace `<instance>` with your tenant's instance letter).

--- a/docs/2-sensors-deployment/adapters/types/threatlocker.md
+++ b/docs/2-sensors-deployment/adapters/types/threatlocker.md
@@ -23,7 +23,7 @@ Adapter Type: `threatlocker`
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `api_key` | yes | ThreatLocker API token (see [Authentication](#authentication) below). Sent verbatim in the `Authorization` header — no `Bearer ` prefix. |
+| `api_key` | yes | ThreatLocker API token (see [Authentication](#authentication) below). Sent verbatim in the `Authorization` header — no `Bearer` prefix. |
 | `instance` | yes* | ThreatLocker instance letter (`b`, `c`, …, `g`, `h`, …). *Required unless `base_url` is set. |
 | `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. Use to point the adapter at a non-standard endpoint; otherwise prefer `instance`. |
 | `managed_organization_id` | no | UUID of the managed (child) organization. Sent as the `managedOrganizationId` header — used by MSP **parent** tokens to scope every request to a specific child tenant. |
@@ -64,7 +64,7 @@ With no `feeds` configured, the adapter polls three feeds that together cover Th
 
 ## Authentication
 
-Create an API token under **Portal → Administration → API Users** in the ThreatLocker Portal. The token is sent verbatim in the `Authorization` header — there is no `Bearer ` prefix and no OAuth handshake.
+Create an API token under **Portal → Administration → API Users** in the ThreatLocker Portal. The token is sent verbatim in the `Authorization` header — there is no `Bearer` prefix and no OAuth handshake.
 
 ### Finding your instance
 

--- a/docs/5-integrations/extensions/third-party/index.md
+++ b/docs/5-integrations/extensions/third-party/index.md
@@ -15,6 +15,7 @@ Extensions built by third-party developers that integrate external tools and ser
 - [Renigma](renigma.md) - Renigma integration
 - [SecureAnnex](secureannex.md) - SecureAnnex integration
 - [Strelka](strelka.md) - File analysis with Strelka
+- [ThreatLocker](threatlocker.md) - ThreatLocker Application Control approval workflow
 - [Twilio](twilio.md) - SMS and voice notifications
 - [Velociraptor](velociraptor.md) - DFIR artifact collection
 - [YARA](yara.md) - YARA rule scanning

--- a/docs/5-integrations/extensions/third-party/threatlocker.md
+++ b/docs/5-integrations/extensions/third-party/threatlocker.md
@@ -34,7 +34,7 @@ In **Extensions → ext-threatlocker → Configuration**, fill in:
 | `instance_letter` | yes | The single lowercase letter from step 2, e.g. `g`. |
 | `managed_organization_id` | no | UUID of the managed (child) organization. Sent as the `ManagedOrganizationId` header. Used by MSP **parent** tokens to scope every call to a specific child tenant. |
 
-The API token is sent **verbatim** in the `Authorization` header — there is no `Bearer ` prefix and no OAuth flow. The instance letter is validated at save time; everything else is rejected at request time by the Portal API.
+The API token is sent **verbatim** in the `Authorization` header — there is no `Bearer` prefix and no OAuth flow. The instance letter is validated at save time; everything else is rejected at request time by the Portal API.
 
 ## Actions
 
@@ -194,7 +194,7 @@ Example response action that enriches a ThreatLocker approval-request event deli
 
 ## Authentication and tenancy
 
-- The Portal API token is sent **verbatim** in the `Authorization` header — there is no `Bearer ` prefix. Do not paste the token with a prefix; the API will reject it.
+- The Portal API token is sent **verbatim** in the `Authorization` header — there is no `Bearer` prefix. Do not paste the token with a prefix; the API will reject it.
 - The token is scoped to the instance that minted it. `403 TOKEN_REVOKED` means either the token was revoked **or** the wrong `instance_letter` was configured. Verify the instance letter first.
 - For **MSPs**, a single parent-tenant token can be used to drive multiple child organizations by setting `managed_organization_id` to the child organization's UUID. The header `ManagedOrganizationId` is then attached to every request and the Portal scopes the response accordingly — one extension subscription per parent tenant, not per child.
 

--- a/docs/5-integrations/extensions/third-party/threatlocker.md
+++ b/docs/5-integrations/extensions/third-party/threatlocker.md
@@ -1,0 +1,205 @@
+# ThreatLocker
+
+[ThreatLocker](https://threatlocker.com) is an Application Control platform whose **approval-request queue** — end-users asking for an unknown binary to be allowed — is the single biggest source of operator toil in any rollout.
+
+The ThreatLocker LimaCharlie Extension is a thin proxy over the [ThreatLocker Portal API](https://portalapi.g.threatlocker.com/swagger). It pairs with the [ThreatLocker adapter](../../../2-sensors-deployment/adapters/types/threatlocker.md), which delivers approval-request events into LimaCharlie: an AI agent (or a Playbook) reads each event, calls this extension to enrich it against the Portal API (matching built-in app, computer/group context, existing policies), then calls this extension again with the decision — **permit**, **reject**, or **ignore**. The extension itself makes no decisions; it forwards the JSON body verbatim and returns the Portal response verbatim.
+
+## Setup
+
+### 1. Create a Portal API token
+
+In the ThreatLocker Portal, navigate to **Administration → API Users** and create a new API user. Copy the resulting **API token** — you will need it in the next step. ThreatLocker shows the token only once.
+
+### 2. Find your instance letter
+
+ThreatLocker hosts each tenant on a lettered instance (`b`, `c`, `d`, …, `g`, `h`, …) and API tokens are scoped to the instance that minted them. To find yours, click the **Help** button in the top-right corner of any Portal page and read the letter in parentheses next to **ThreatLocker Access** (e.g. `ThreatLocker Access (G)` → `instance_letter: g`).
+
+> ⚠️ **A token from one instance returns `403 TOKEN_REVOKED` on every other instance.** The API does not distinguish "wrong instance" from a genuinely revoked token. If you are confident the token is active and still see `TOKEN_REVOKED`, double-check the instance letter before assuming the token was revoked.
+
+### 3. Subscribe to the extension
+
+Subscribe to `ext-threatlocker` from the LimaCharlie **Marketplace** (Extensions → Add-Ons).
+
+### 4. Store the API token
+
+In **Secrets Manager**, create a new secret (for example `threatlocker-api-token`) and paste the Portal API token as its value.
+
+### 5. Configure the extension
+
+In **Extensions → ext-threatlocker → Configuration**, fill in:
+
+| Field | Required | Value |
+| --- | --- | --- |
+| `api_token` | yes | Reference to the secret created in step 4, e.g. `hive://secret/threatlocker-api-token`. |
+| `instance_letter` | yes | The single lowercase letter from step 2, e.g. `g`. |
+| `managed_organization_id` | no | UUID of the managed (child) organization. Sent as the `ManagedOrganizationId` header. Used by MSP **parent** tokens to scope every call to a specific child tenant. |
+
+The API token is sent **verbatim** in the `Authorization` header — there is no `Bearer ` prefix and no OAuth flow. The instance letter is validated at save time; everything else is rejected at request time by the Portal API.
+
+## Actions
+
+The extension exposes thirteen actions. All `POST` actions take a single `body` parameter — the JSON object forwarded verbatim as the Portal API request body. `GET` actions take typed parameters: an `id` for single-id endpoints, or named flags for the computer-group inspector.
+
+The body field set per endpoint is **not shadowed** by the extension — the Portal API surface is large and changes over time, so the extension stays out of the way. Refer to the ThreatLocker Portal Swagger spec (visit `https://portalapi.<instance>.threatlocker.com/swagger`) for the exact field set per endpoint.
+
+### Approval-request reads
+
+#### `approval_request_search`
+
+`POST ApprovalRequest/ApprovalRequestGetByParameters` — list approval requests matching a filter.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Forwarded as the JSON request body. Common fields: `statusId` (1=pending, 4=approved, …), `searchText`, `requestTypeId`, `actionType` (array), `pageNumber`, `pageSize`, `orderBy`, `isAscending`. |
+
+#### `approval_request_get`
+
+`GET ApprovalRequest/ApprovalRequestGetById` — fetch a single approval request.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | **Required.** `approvalRequestId` (UUID). |
+
+### Application reads
+
+#### `application_get_matching`
+
+`POST Application/ApplicationGetMatchingList` — the **primary enrichment call**. Given a file (`sha256`, path, certificates, …) returns the ThreatLocker built-in (or custom) applications it matches. An empty result is the "no built-in match" answer — meaning the file is unknown to ThreatLocker's curated catalog and an AI policy decision should weigh that accordingly.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Common fields: `sha256`, `hash`, `path`, `certs`, `organizationIds`, `osType`, `approvalRequestId`. |
+
+#### `application_get`
+
+`GET Application/ApplicationGetById` — full details for a single application.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | **Required.** `applicationId` (UUID). |
+
+#### `application_get_research`
+
+`GET Application/ApplicationGetResearchDetailsById` — ThreatLocker's curated threat-research info for an application (Living-Off-The-Land flags, common abuse, reputation notes). Useful when deciding whether the matching app is sensitive enough to warrant a denial.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | **Required.** `applicationId` (UUID). |
+
+### Computer reads
+
+#### `computer_get`
+
+`GET Computer/ComputerGetForEditById` — fetch a single computer's full record (group, OS, tags, last check-in). The fastest path from an approval-request event's `computerId` to the device context.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | **Required.** `computerId` (UUID). |
+
+#### `computer_search`
+
+`POST Computer/ComputerGetByAllParameters` — free-text or group/mode-scoped computer search.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Common fields: `searchText`, `computerGroup`, `computerId`, `action`, `kindOfAction`, `showLastCheckIn`, `showDeleted`, `childOrganizations`, `pageNumber`, `pageSize`, `orderBy`, `isAscending`, `searchBy`. |
+
+### Computer-group reads
+
+#### `computer_group_list_for_permit`
+
+`GET ComputerGroup/ComputerGroupGetForPermitApplication` — list the computer groups eligible to receive an approval/permit decision. Start here when picking the scope to attach a new permit policy to.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `os_type` | int | `0` = All (default), `1` = Windows, `2` = Mac, `3` = Linux. |
+
+#### `computer_group_get_full`
+
+`GET ComputerGroup/ComputerGroupGetGroupAndComputer` — rich one-shot inspector: a group plus (optionally) every policy attached to it and every computer in it, in a single round trip.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `computer_group_id` | string | **Required.** `ComputerGroupId` (UUID). |
+| `os_type` | int | `0` = All, `1` = Windows, `2` = Mac, `3` = Linux. |
+| `include_all_policies` | bool | Include policies attached to the group. **Recommended** — defaults to `true`. |
+| `include_all_computers` | bool | Include computers in the group. **Recommended** — defaults to `true`. |
+| `include_global` | bool | Include the global "All Computers" group. |
+| `include_organizations` | bool | Include parent/child orgs. |
+| `include_parent_groups` | bool | Include parent groups. |
+| `include_logged_in_objects` | bool | Include logged-in objects. |
+| `include_access_devices` | bool | Include access devices. |
+| `include_removed_computers` | bool | Include removed computers. |
+| `portal_module_type_id` | int | Optional `PortalModuleTypeId`. |
+
+With `include_all_policies=true` and `include_all_computers=true` this endpoint answers, in a single call, *"who else is in this group, what policies are already attached, and would this new permit policy collide with any of them?"*
+
+### Policy reads
+
+#### `policy_get`
+
+`GET Policy/PolicyGetById` — fetch one policy's full record by id. The Portal API has no list-policies-by-parameters endpoint; iterate via `computer_group_get_full` with `include_all_policies=true` and resolve each policy by id with `policy_get`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | **Required.** `policyId` (UUID). |
+
+### Decisions
+
+The three write actions close the loop on an approval request — they are the only actions in this extension that mutate ThreatLocker state.
+
+#### `approval_request_permit`
+
+`POST ApprovalRequest/ApprovalRequestPermitApplication` — **approve**. Creates (or updates) a permit policy and lets the requestor's blocked application through.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Full `PermitApplicationDto` body. Set `body.adminNotes` to the AI's reasoning — it lands in the Portal audit trail so a human can later reconstruct *why* an automated decision was made. |
+
+#### `approval_request_reject`
+
+`POST ApprovalRequest/ApprovalRequestUpdateForReject` — **deny**. Notifies the requestor with a reason.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Set `body.rejectReason` (the requestor-visible message) and `body.responseReason` (the internal audit-trail note). |
+
+#### `approval_request_ignore`
+
+`POST ApprovalRequest/ApprovalRequestUpdateForIgnore` — **soft-dismiss**. Leaves the request in the queue for human review without notifying the requestor. Use this when the AI cannot confidently permit or reject.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `body` | object | **Required.** Forwarded as the JSON request body. |
+
+## Detection & Response
+
+Example response action that enriches a ThreatLocker approval-request event delivered by the [adapter](../../../2-sensors-deployment/adapters/types/threatlocker.md) by calling `application_get_matching` on the file's SHA-256:
+
+```yaml
+- action: extension request
+  extension action: application_get_matching
+  extension name: ext-threatlocker
+  extension request:
+    body:
+      sha256: '{{ .event/hash }}'
+      osType: 1
+      approvalRequestId: '{{ .event/approvalRequestId }}'
+```
+
+> **Wrap literal strings in `{{ "..." }}`.**
+> Values under `extension request` are evaluated as templates. A bare string without `{{ }}` is interpreted as a [gjson](https://github.com/tidwall/gjson) path against the event and, if it doesn't resolve, the key is silently dropped from the payload.
+
+`extension request` actions are fire-and-forget — the rule engine does not surface the response back into the rule's evaluation context, so the enrichment result is not available to a subsequent action in the same rule. Workflows that chain (enrich → decide → write back) belong in a [Playbook](../limacharlie/playbook.md) or an AI agent, which can hold the intermediate results between calls.
+
+## Authentication and tenancy
+
+- The Portal API token is sent **verbatim** in the `Authorization` header — there is no `Bearer ` prefix. Do not paste the token with a prefix; the API will reject it.
+- The token is scoped to the instance that minted it. `403 TOKEN_REVOKED` means either the token was revoked **or** the wrong `instance_letter` was configured. Verify the instance letter first.
+- For **MSPs**, a single parent-tenant token can be used to drive multiple child organizations by setting `managed_organization_id` to the child organization's UUID. The header `ManagedOrganizationId` is then attached to every request and the Portal scopes the response accordingly — one extension subscription per parent tenant, not per child.
+
+## Notes
+
+- The extension caches the underlying HTTP client per `(org, instance_letter, token, managed_organization_id)`. Rotating the secret in Secrets Manager evicts the cached client on the next surfaced `403 TOKEN_REVOKED`.
+- No request or response transformation is performed — what ThreatLocker returns is what the caller sees. New Portal fields don't require a code change.
+- Read actions are safe to retry. Write actions (`approval_request_permit` / `_reject` / `_ignore`) are not idempotent on the Portal side — re-firing them on the same `approvalRequestId` after the first success will surface a Portal error.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ plugins:
         'docs/ext-secureannex.md': '5-integrations/extensions/third-party/secureannex.md'
         'docs/ext-sensor-cull.md': '5-integrations/extensions/limacharlie/sensor-cull.md'
         'docs/ext-strelka.md': '5-integrations/extensions/third-party/strelka.md'
+        'docs/ext-threatlocker.md': '5-integrations/extensions/third-party/threatlocker.md'
         'docs/ext-twilio.md': '5-integrations/extensions/third-party/twilio.md'
         'docs/ext-usage-alerts.md': '5-integrations/extensions/limacharlie/usage-alerts.md'
         'docs/ext-velociraptor.md': '5-integrations/extensions/third-party/velociraptor.md'
@@ -279,6 +280,7 @@ nav:
               - Sophos: 2-sensors-deployment/adapters/types/sophos.md
               - Carbon Black: 2-sensors-deployment/adapters/types/carbon-black.md
               - Sublime Security: 2-sensors-deployment/adapters/types/sublime-security.md
+              - ThreatLocker: 2-sensors-deployment/adapters/types/threatlocker.md
           - Collaboration:
               - Microsoft 365: 2-sensors-deployment/adapters/types/microsoft-365.md
               - Slack Audit: 2-sensors-deployment/adapters/types/slack-audit-logs.md
@@ -428,6 +430,7 @@ nav:
               - Renigma: 5-integrations/extensions/third-party/renigma.md
               - SecureAnnex: 5-integrations/extensions/third-party/secureannex.md
               - Strelka: 5-integrations/extensions/third-party/strelka.md
+              - ThreatLocker: 5-integrations/extensions/third-party/threatlocker.md
               - Twilio: 5-integrations/extensions/third-party/twilio.md
               - Velociraptor: 5-integrations/extensions/third-party/velociraptor.md
               - YARA: 5-integrations/extensions/third-party/yara.md


### PR DESCRIPTION
## Summary

Documents both halves of the LimaCharlie + ThreatLocker integration:

- **`threatlocker` USP adapter** (Sensors → Adapters → Security Tools): delivers Application Control approval-request events plus the unified and system audit streams. Covers the instance-letter quirk, the three default feeds, the generic `*GetByParameters` feed schema, polling semantics, and a custom-feed example.
- **`ext-threatlocker` extension** (Integrations → Extensions → Third-Party): thin proxy to the ThreatLocker Portal API. Covers per-org config, all thirteen actions (approval-request reads, application / computer / group / policy enrichment, and the three permit / reject / ignore decisions), and MSP parent-token scoping via `managed_organization_id`.

The two pages cross-link so the "adapter delivers events, extension enriches and writes back the decision" workflow is discoverable from either side. Adds the `ext-threatlocker` readme.io redirect for the legacy slug, and lists ThreatLocker under Security Tools on the adapters index.

## Test plan

- [x] `mkdocs build --strict` is clean — no new pages-not-in-nav warnings and no broken cross-references.
- [ ] Reviewer eyes on the per-action field tables and the per-feed schema table — pulled from the ext-threatlocker and usp-adapters/threatlocker READMEs respectively. Worth a sanity-check that the body field hints under each POST action match the current Portal API.
- [ ] Reviewer eyes on the `instance_letter` / `instance` wording — both pages call out that a wrong instance letter masquerades as `TOKEN_REVOKED`, which is the single most common config mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)