### PR TITLE
docs(smtp): document multi-recipient, cc and bcc fields

### DIFF
--- a/docs/5-integrations/outputs/destinations/smtp.md
+++ b/docs/5-integrations/outputs/destinations/smtp.md
@@ -15,7 +15,9 @@ To utilize SMTP output, you will need:
 Output individually each event, detection, audit, deployment or log through an email.
 
 - `dest_host`: the IP or DNS (and optionally port) of the SMTP server to use to send the email.
-- `dest_email`: the email address to send the email to.
+- `dest_email`: one or more email addresses to send the email to. Multiple addresses can be provided comma-separated (for example `soc@corp.com, oncall@corp.com`), and display names are supported (for example `SOC <soc@corp.com>`). Every address receives a copy and appears in the `To:` header.
+- `cc_email`: (optional) one or more comma-separated email addresses to add to the `Cc:` header. Each receives a copy.
+- `bcc_email`: (optional) one or more comma-separated email addresses to copy without exposing them in the message headers (blind copy).
 - `from_email`: the email address set in the From field.
 - `username`: the username (if any) used to authenticate to the SMTP server.
 - `password`: the password (if any) used to authenticate to the SMTP server.
@@ -39,6 +41,20 @@ is_starttls: false
 is_authlogin: false
 subject: LC Detection- <Name>
 ```
+
+Example sending to multiple recipients with `Cc` and `Bcc`:
+
+```text
+dest_host: smtp.gmail.com
+dest_email: soc@corp.com, oncall@corp.com
+cc_email: manager@corp.com
+bcc_email: audit@corp.com
+from_email: lc@corp.com
+secret_key: this-is-my-secret-shared-key
+is_readable: true
+```
+
+> Note: recipients in `dest_email` and `cc_email` appear in the message headers, so they can see each other. Use `bcc_email` for recipients who should receive a copy without being visible to the others. A malformed address in any of these fields will cause the output to fail validation when it is saved.
 
 ## Related articles
 


### PR DESCRIPTION
## Summary

Documents the new SMTP output recipient capabilities:
- `dest_email` now accepts a comma-separated list (and display names).
- New optional `cc_email` and `bcc_email` fields.
- A multi-recipient example.
- A note that `To:`/`Cc:` recipients are visible to each other while `Bcc` is not, and that malformed addresses fail validation at save time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)