### PR TITLE
docs: document ThreatLocker extension response shape + add AI topic index

### DIFF
--- a/docs/5-integrations/extensions/third-party/threatlocker.md
+++ b/docs/5-integrations/extensions/third-party/threatlocker.md
@@ -60,6 +60,66 @@ The body field set per endpoint is **not shadowed** by the extension — the Por
 | --- | --- | --- |
 | `id` | string | **Required.** `approvalRequestId` (UUID). |
 
+#### Response shape
+
+No request or response transformation is performed, so an automation reads the Portal response as-is. The extension returns the Portal payload under a top-level `data` key. For the **search/list** read (`approval_request_search`) `data` is an **array** of approval-request records; for the single-id read (`approval_request_get`) `data` is a single record object. An empty array (`"data": []`) on a search means **no matching requests** — it is a successful, empty result, **not** an error.
+
+```json
+{
+  "data": [
+    {
+      "approvalRequestId": "<uuid>",
+      "statusId": 1,
+      "hostname": "<hostname>",
+      "username": "<domain\\user>",
+      "requestorEmailAddress": "<email>",
+      "requestorReason": "<base64-encoded reason>",
+      "computerId": "<uuid>",
+      "organizationId": "<uuid>",
+      "path": "<full path on the endpoint>",
+      "dateTime": "<ISO-8601 timestamp>",
+      "threatLockerActionDto": {
+        "actionType": "<action type>",
+        "sha256": "<hex sha-256>",
+        "fullPath": "<full path>",
+        "certs": ["<certificate>"],
+        "osType": 1,
+        "processName": "<process name>"
+      }
+    }
+  ]
+}
+```
+
+Salient fields an automation typically needs:
+
+| Field | Notes |
+| --- | --- |
+| `approvalRequestId` | Request UUID — pass to `approval_request_get` and the decision actions. |
+| `statusId` | Request state. `1` = pending. |
+| `hostname` | Endpoint that raised the request. |
+| `username` | The requesting user. |
+| `requestorEmailAddress` | Email of the requestor. |
+| `requestorReason` | The requestor's justification, **base64-encoded** — decode before display. |
+| `computerId` | Computer UUID — resolve device context via `computer_get`. |
+| `organizationId` | ThreatLocker organization UUID the request belongs to. |
+| `path` | Full path of the binary on the endpoint. |
+| `dateTime` | When the request was raised. |
+| `threatLockerActionDto` | Nested object describing the blocked action (see below). |
+
+The nested `threatLockerActionDto` object carries the file/action detail an enrichment call needs:
+
+| Field | Notes |
+| --- | --- |
+| `actionType` | The action that was blocked. |
+| `sha256` | SHA-256 of the file — the primary key for `application_get_matching`. |
+| `fullPath` | Full path of the file. |
+| `certs` | Array of code-signing certificate identities. |
+| `osType` | OS type (`1` = Windows, `2` = Mac, `3` = Linux). |
+| `processName` | Name of the process. |
+
+> Field names and the exact set returned per endpoint are defined by ThreatLocker and may change over time. The authoritative reference is the ThreatLocker Portal Swagger spec (visit `https://portalapi.<instance>.threatlocker.com/swagger`). The fields above are the well-known ones an approval-request automation depends on; the response may carry additional fields not listed here.
+
 ### Application reads
 
 #### `application_get_matching`

--- a/docs/index-for-ai.md
+++ b/docs/index-for-ai.md
@@ -1,0 +1,49 @@
+# Topic Index for Automation & AI Consumers
+
+> **Curated and may lag the tree.** This page is a hand-maintained map of major
+> topics and integrations to their canonical doc paths, meant to help tooling
+> and AI consumers route quickly. It is not exhaustive and can fall behind the
+> actual documentation tree — when in doubt, the live docs are authoritative.
+>
+> A complementary, fully auto-generated flat index of every navigation page is
+> published at [`/llms.txt`](https://docs.limacharlie.io/llms.txt) (built from
+> the navigation on every build). This page adds the cross-references that the
+> flat index cannot express — most importantly the adapter-vs-extension layout.
+
+## Top-level sections
+
+- [Getting Started](1-getting-started/index.md)
+- [Sensors & Deployment](2-sensors-deployment/index.md)
+- [Detection & Response](3-detection-response/index.md)
+- [Data & Queries](4-data-queries/index.md)
+- [Integrations](5-integrations/index.md)
+- [Developer Guide](6-developer-guide/index.md)
+- [Administration](7-administration/index.md)
+- [Reference](8-reference/index.md)
+- [AI Sessions](9-ai-sessions/index.md)
+- [Release Notes](10-release-notes/index.md)
+
+## Adapter vs. extension dual layout
+
+Some third-party products are documented in **two** complementary places:
+
+- An **adapter** under `2-sensors-deployment/adapters/types/` — ingests that
+  product's events into LimaCharlie (the **input** side: what events you
+  receive and their shape).
+- An **extension** under `5-integrations/extensions/third-party/` — exposes the
+  actions an AI agent or Playbook calls to enrich those events and act back
+  (the **action** side: requests you can send and the responses you get).
+
+When automating such a product you usually need **both** pages: the adapter to
+understand the incoming events, and the extension to understand the actions and
+their response shapes. One line per integration that has both, pointing to each:
+
+| Integration | Adapter (input) | Extension (actions) |
+| --- | --- | --- |
+| ThreatLocker | [adapter](2-sensors-deployment/adapters/types/threatlocker.md) | [extension](5-integrations/extensions/third-party/threatlocker.md) |
+
+## Full integration catalogs
+
+- All adapter types: [`2-sensors-deployment/adapters/types/`](2-sensors-deployment/adapters/index.md)
+- All third-party extensions: [`5-integrations/extensions/third-party/`](5-integrations/extensions/third-party/index.md)
+- First-party (LimaCharlie) extensions: [`5-integrations/extensions/limacharlie/`](5-integrations/extensions/limacharlie/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -504,6 +504,7 @@ nav:
 
   - Reference:
       - Overview: 8-reference/index.md
+      - Topic Index for Automation & AI: index-for-ai.md
       - Endpoint Commands: 8-reference/endpoint-commands.md
       - Detection Operators: 8-reference/detection-logic-operators.md
       - Response Actions: 8-reference/response-actions.md


### PR DESCRIPTION
## What

Two discoverability improvements found during routine review of the docs, aimed at automation and AI consumers:

1. **ThreatLocker extension — Response shape.** The extension page documented each action's *request* body but not the *response* envelope a consumer receives. Added a concise "Response shape" subsection to the approval-request reads:
   - The Portal payload is returned under a top-level `data` key — an **array** for the search/list read (`approval_request_search`), a single **object** for the single-id read (`approval_request_get`).
   - Documented the salient approval-request record fields an automation depends on (`approvalRequestId`, `statusId` with `1=pending`, `hostname`, `username`, `requestorEmailAddress`, `requestorReason` (base64), `computerId`, `organizationId`, `path`, `dateTime`) plus the nested `threatLockerActionDto` (`actionType`, `sha256`, `fullPath`, `certs`, `osType`, `processName`).
   - Clarified that an empty `data` array is a successful empty result, **not** an error.
   - Used placeholders only (no tenant-specific values), and pointed at the already-cited public ThreatLocker Portal Swagger as the authoritative field-set reference.

2. **AI topic index.** Added `docs/index-for-ai.md`: a short, curated map of the top-level sections and — importantly — the **adapter-vs-extension dual layout**, with one line per integration that has both, pointing to BOTH its adapter path and its extension path (currently ThreatLocker). It carries a header note that it is curated and may lag the tree, and complements the existing auto-generated `/llms.txt` (a flat nav dump that cannot express these cross-references). Wired into the Reference nav.

## Notes

- The brief mentioned a possible dangling internal `REFERENCES.md` pointer in the ThreatLocker docs. None exists — both pages already point readers to the public Portal Swagger for field-set details, and the new Response shape section reinforces that public pointer.
- Followed the repo's existing `llms.txt` convention (generated by `hooks/llms_txt.py`, never committed) by adding the curated companion as `index-for-ai.md` rather than a static `llms.txt` that would collide with the generated one.

## Validation

- `npx markdownlint-cli2 docs/**/*.md` — 0 errors.
- `mkdocs build` — clean (only the generic Material/MkDocs advisory banner); new page builds, no broken relative links introduced, `index-for-ai.md` present in nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)