### PR TITLE
docs: document api-key --store-secret and adapter discovery commands

### DIFF
--- a/docs/2-sensors-deployment/adapters/usage.md
+++ b/docs/2-sensors-deployment/adapters/usage.md
@@ -405,6 +405,33 @@ USP Clients generate LimaCharlie Sensors at runtime. The ID of those sensors (SI
 
 This implies that if want to re-key an IID (perhaps it was leaked), you may replace the IID with a new valid one. As long as you use the same OID and Sensor Seed Key, the generated SIDs will be stable despite the IID change.
 
+### Discovering adapter types and finding an adapter's sensor
+
+The CLI can enumerate the supported adapter types, describe their configuration schema, and locate the sensor an adapter produced. These commands work for both `cloud-adapter` (the hosted set) and `external-adapter` (the on-prem set); the examples below use `cloud-adapter`.
+
+List the supported adapter/sensor type names:
+
+```bash
+limacharlie cloud-adapter list-types
+```
+
+Note that `external-adapter list-types` lists the on-prem set, which differs from the cloud set.
+
+Show the configuration field listing for one adapter type. This indicates where each field lives (for example, `hostname` under `client_options`). Add `--output json` for the raw schema:
+
+```bash
+limacharlie cloud-adapter schema --type <t>
+limacharlie cloud-adapter schema --type <t> --output json
+```
+
+Find the live sensor(s) an adapter produced, matched by installation-key IID:
+
+```bash
+limacharlie cloud-adapter sensors --key <adapter-record>
+```
+
+An empty result means the adapter has not delivered any events yet; the sensor materializes on the first event.
+
 ## Validating Configurations
 
 Before deploying an adapter to production, you can validate your configuration and test parsing rules to ensure data will be correctly ingested.

--- a/docs/7-administration/access/api-keys.md
+++ b/docs/7-administration/access/api-keys.md
@@ -215,7 +215,7 @@ Similar to agents, Sensors send telemetry to the LimaCharlie platform in the for
     limacharlie api-key create --name <name> --permissions "..." --store-secret <secret-name> [--store-secret-tag <tag>]
     ```
 
-    This creates the key and writes its value to `hive://secret/<secret-name>`. The value is shown only once at creation, so storing it directly avoids having to capture and re-pipe it. If a secret with that name already exists, it is updated in place via its etag.
+    This creates the key and writes its value to `hive://secret/<secret-name>`. The value is shown only once at creation, so storing it directly avoids having to capture and re-pipe it. If a secret with that name already exists, it is updated in place via its etag. The identity running this command needs the `secret.set` permission (to write the secret) in addition to the permission to create API keys.
 
 ### Delete an API Key
 

--- a/docs/7-administration/access/api-keys.md
+++ b/docs/7-administration/access/api-keys.md
@@ -209,6 +209,14 @@ Similar to agents, Sensors send telemetry to the LimaCharlie platform in the for
     limacharlie api-key create --name ci-key --permissions "dr.list,dr.set"
     ```
 
+    To mint the key and store its value in the [secret hive](../config-hive/secrets.md) in a single step, add `--store-secret`:
+
+    ```bash
+    limacharlie api-key create --name <name> --permissions "..." --store-secret <secret-name> [--store-secret-tag <tag>]
+    ```
+
+    This creates the key and writes its value to `hive://secret/<secret-name>`. The value is shown only once at creation, so storing it directly avoids having to capture and re-pipe it. If a secret with that name already exists, it is updated in place via its etag.
+
 ### Delete an API Key
 
 === "REST API"


### PR DESCRIPTION
Documents newly-shipped LimaCharlie CLI capabilities (docs-only, Markdown).

## Changes

- **`docs/7-administration/access/api-keys.md`** — Adds a note and example for the new `--store-secret` flag on `limacharlie api-key create`. The flag mints the key and writes its value into the secret hive at `hive://secret/<secret-name>` in one step (with optional `--store-secret-tag`), so the once-shown value never needs to be captured/re-piped. Existing secrets are updated in place via their etag.
- **`docs/2-sensors-deployment/adapters/usage.md`** — Adds a "Discovering adapter types and finding an adapter's sensor" subsection documenting three commands (for both `cloud-adapter` and `external-adapter`): `list-types`, `schema --type <t>` (with `--output json`), and `sensors --key <adapter-record>`.

## Testing

- `npx markdownlint-cli2 "docs/**/*.md"` → 0 errors.
- Examples use generic `<oid>` / `<adapter-record>` placeholders; no real org or customer data.
- Verified the relative link to the secrets page resolves (`../config-hive/secrets.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)