### PR TITLE
docs(vuln): inventory filtering and Linux distro-aware matching

### DIFF
--- a/docs/2-sensors-deployment/asset-tags.md
+++ b/docs/2-sensors-deployment/asset-tags.md
@@ -1,6 +1,6 @@
 # Asset Tag Namespace (`lc:asset:*`)
 
-`lc:asset:*` is a reserved sensor-tag namespace for marking endpoints with structured asset metadata — criticality, network exposure, environment, owner, and compliance regimes. It is a convention layered on top of [Sensor Tags](sensor-tags.md): there is no separate field on the sensor model, no migration to run, and no per-surface schema to extend. Any LimaCharlie surface that needs asset context (Vulnerabilities, D&R, Cases, Search, Query Console, Outputs, etc.) reads the same tags and gets a consistent view.
+`lc:asset:*` is a reserved sensor-tag namespace for marking endpoints with structured asset metadata — criticality, network exposure, environment, owner, compliance regimes, and OS. It is a convention layered on top of [Sensor Tags](sensor-tags.md): there is no separate field on the sensor model, no migration to run, and no per-surface schema to extend. Any LimaCharlie surface that needs asset context (Vulnerabilities, D&R, Cases, Search, Query Console, Outputs, etc.) reads the same tags and gets a consistent view.
 
 The first consumer of the namespace is the [Vulnerability Reporting extension](../5-integrations/extensions/limacharlie/vulnerability-reporting.md), which uses `lc:asset:criticality:*` to drive risk scoring and SLA windows. Other surfaces will adopt the same parser as they need asset context.
 
@@ -16,7 +16,7 @@ Adding a new sensor-model field for asset metadata would require schema changes,
 
 ## Schema
 
-The namespace defines five tag prefixes. The value follows the prefix as a third colon-separated segment.
+The namespace defines six tag prefixes. The value follows the prefix as a third colon-separated segment.
 
 | Tag | Values | Cardinality | Purpose |
 |---|---|---|---|
@@ -25,6 +25,7 @@ The namespace defines five tag prefixes. The value follows the prefix as a third
 | `lc:asset:env:<v>` | `prod`, `staging`, `dev`, `test` | Singleton | Environment for filtering and suppression scoping. |
 | `lc:asset:owner:<v>` | Free text | Singleton | Routing target for assignment / paging (e.g. a team name, an email, a Slack handle). |
 | `lc:asset:compliance:<v>` | Free text (e.g. `pci`, `hipaa`, `sox`, `gdpr`) | Multi-value | Compliance regimes the asset is subject to. A sensor can carry several at once. |
+| `lc:asset:os:<distro>-<release>` | Free text (e.g. `debian-11`, `redhat-enterprise-9`) | Singleton | Linux distribution and release. Lets the [Vulnerability Reporting extension](../5-integrations/extensions/limacharlie/vulnerability-reporting.md#linux-distro-aware-matching) apply distro backport data so backported security fixes aren't flagged as vulnerable. Split on the **last** `-`. |
 
 ### Validation rules
 
@@ -48,6 +49,7 @@ limacharlie tag add --sid SENSOR_ID --tag lc:asset:exposure:internet-facing
 limacharlie tag add --sid SENSOR_ID --tag lc:asset:env:prod
 limacharlie tag add --sid SENSOR_ID --tag lc:asset:owner:platform-team
 limacharlie tag add --sid SENSOR_ID --tag lc:asset:compliance:pci
+limacharlie tag add --sid SENSOR_ID --tag lc:asset:os:debian-11
 ```
 
 ### Tag a fleet by selector

--- a/docs/5-integrations/extensions/limacharlie/vulnerability-reporting.md
+++ b/docs/5-integrations/extensions/limacharlie/vulnerability-reporting.md
@@ -6,7 +6,7 @@ It is the first consumer of the canonical [`lc:asset:*` tag namespace](../../../
 
 ## What it does
 
-1. **Inventory collection.** A scheduled per-sensor `os_packages` task runs once a day and reports the installed software set. The default `scheduled` mode installs both the schedule and an ingest D&R rule that forwards only the tracked responses for analysis.
+1. **Inventory collection.** A scheduled per-sensor `os_packages` task runs once a day on each Windows, macOS, and Linux EDR sensor and reports the installed software set. The default `scheduled` mode installs both the schedule and an ingest D&R rule that forwards only the tracked responses for analysis. Before each package is looked up, the extension drops inventory entries that can never resolve to a CVE so they don't add noise — see [Inventory collection](#inventory-collection).
 2. **CVE resolution.** Inventories are sent to `cve.limacharlie.io`, which maps each `(package_name, package_version)` pair to the set of CVEs that affect it.
 3. **Enrichment.** Each CVE is joined against CISA KEV and FIRST EPSS via `cve.limacharlie.io/enrich`. KEV / EPSS / criticality multiplier are folded into a 0-100 [LC Risk](#lc-risk) score that is persisted on every finding row.
 4. **Resolutions.** Every finding is implicitly **open** unless an operator records a resolution: `mitigated`, `accepted`, or `false_positive`. Resolutions are keyed by a deterministic [fingerprint](#finding-fingerprint) so they survive rescans.
@@ -82,6 +82,36 @@ When `include_tags=true` is passed to `query_endpoints` or `query_cve_vuln_hosts
 ```
 
 Tags with malformed values for the closed-set fields (`criticality`, `exposure`, `env`) are dropped by the parser. See [Asset Tag Namespace](../../../2-sensors-deployment/asset-tags.md) for the full schema.
+
+## Inventory collection
+
+Each daily `os_packages` scan returns the full installed-software set for a sensor, but not every entry is a meaningful vulnerability target. The extension applies two passes between the raw inventory and the CVE database: it **filters** entries that can't yield a useful CVE, and for Linux it makes matching **distro-aware**.
+
+### Package filtering
+
+Some inventory entries can never resolve to a CVE — they have no public product identifier, or their reported "version" isn't an upstream version that can be range-compared against a CVE's affected ranges. Querying them only adds noise and slows scans, so the extension skips them before the lookup. This is why the number of findings on a host is usually lower than its raw installed-package count.
+
+The skip classes are:
+
+| Class | Examples | Rationale |
+|-------|----------|-----------|
+| **macOS Apple installer receipts** | `com.apple.pkg.CLTools_SDK_macOS13`, `com.apple.pkg.XProtectPlistConfigData…` (any `pkgutil` entry named `com.apple.*`) | Reverse-DNS bundle IDs for Apple system components. Not real installable products; their version slot is a build timestamp. Third-party `pkgutil` receipts (e.g. `org.wireshark.*`, `com.microsoft.*`) are deliberately **kept**. |
+| **Linux distro-internal packages** | `base-files`, `lsb-base`, `ca-certificates`, `apt-utils`, `init-system-helpers`, `filesystem`, `setup`, `redhat-release`, … | Distro "essential/required" configuration packages that have no upstream product entry and never will. |
+| **Windows inventory noise** | Tanium software-catalog rows (`tvcappstor-…`, `tvcfixedde-…`), hardware driver INF receipts (`Windows Driver Package - …`), .NET build toolchain / SDK / templates / targeting packs (`Microsoft .NET Toolset …`, `Microsoft.NET.Sdk.…`), Nuance TTS voice packs (`Vocalizer Expressive …`) | Either the name has no product identifier, or the version slot is an installer counter rather than the upstream version, so no CVE range comparison can succeed. |
+
+Runtime components that *do* ship vulnerable code — e.g. `Microsoft .NET Runtime` and `Microsoft Windows Desktop Runtime` — are deliberately **not** skipped; only build-time artifacts and pure configuration entries are. The per-scan skipped count is logged once per batch (no per-package spam).
+
+### Linux distro-aware matching
+
+Linux distributions routinely **backport** security fixes: a vendor patches a CVE in their packaged build while keeping the upstream version number unchanged. Matching such a package against upstream CVE ranges alone would flag it as vulnerable even though the distro already shipped the fix. To avoid these false positives, the extension identifies the endpoint's distribution and release and forwards them with each Linux package lookup, so distro-specific backport data can correct the verdict.
+
+The distro and release are detected in priority order:
+
+1. **`lc:asset:os:<distro>-<release>` sensor tag** (authoritative). For example `lc:asset:os:debian-11` or `lc:asset:os:redhat-enterprise-9`. The value is split on the **last** `-`, so distro names containing a dash survive intact. Setting this tag explicitly gives the most reliable results.
+2. **Marker-package version.** When no tag is present, the release is inferred from a distribution marker package — Debian's `base-files` major version (10 = buster, 11 = bullseye, 12 = bookworm, 13 = trixie), or the RHEL/CentOS/Rocky/AlmaLinux `*-release` / `fedora-release` package version.
+3. **Package source, no release.** As a last resort the package source pins the distro family only (`dpkg` → Debian, `rpm` → RHEL). With no release, matching falls back to upstream-only verdicts (fail-open) rather than guessing.
+
+Endpoints the extension can't pin to a release still get upstream CVE matching; they just don't benefit from backport correction. Tagging Linux fleets with `lc:asset:os:*` (for example via `limacharlie tag mass-add` keyed off an installation key or hostname pattern) is the simplest way to get accurate, backport-aware Linux results.
 
 ## Concepts
 
@@ -787,6 +817,8 @@ Suggested tag combos for common environments:
 
 Drive these via `limacharlie tag mass-add` keyed off existing infrastructure tags or installation keys, so newly-enrolled sensors land already classified. See [Asset Tag Namespace](../../../2-sensors-deployment/asset-tags.md#sample-real-world-tagging) for a fuller pattern.
 
+For **Linux** sensors, also set `lc:asset:os:<distro>-<release>` (e.g. `lc:asset:os:debian-11`). It is the most reliable input for [distro-aware matching](#linux-distro-aware-matching), which suppresses CVEs that the distribution has already fixed via a backport. Without it the extension still infers the distro from a marker package or package source, but an explicit tag is authoritative.
+
 ### LC Risk vs raw CVSS
 
 CVSS severity is environment-blind: a CVSS 9.8 critical scores the same on a dev laptop and on the customer-facing API gateway. LC Risk corrects for that by multiplying in the asset-criticality bucket — a `low` host caps roughly half the score, and a `critical` host inflates it by 60%. Always sort by LC Risk first; fall back to CVSS only when explaining the score externally.
@@ -829,6 +861,8 @@ Route the `vuln_finding.*` events to your existing alerting pipeline. A typical 
 | **Criticality** | Asset importance bucket (`critical`/`high`/`medium`/`low`). Source: `lc:asset:criticality:*` or the configured override map. |
 | **Exposure** | Network reachability bucket (`internet-facing`/`dmz`/`internal`). Source: `lc:asset:exposure:*`. |
 | **Env** | Environment bucket (`prod`/`staging`/`dev`/`test`). Source: `lc:asset:env:*`. |
+| **Distro / release** | The Linux distribution and version of an endpoint, used for backport-aware CVE matching. Source: `lc:asset:os:*` tag, a marker package, or the package source. See [Linux distro-aware matching](#linux-distro-aware-matching). |
+| **Backport** | A distribution shipping a security fix into a packaged build without changing its upstream version number. Distro-aware matching prevents these from being flagged as still-vulnerable. |
 | **Fingerprint** | SHA-256 hex of the canonical inputs that identify a finding across rescans. See [Finding fingerprint](#finding-fingerprint). |
 | **Scope** | `org` (per-package, applies to every host) or `host` (per-package-per-sensor). Resolution precedence: host beats org. |
 | **Resolution** | Replaces the older `state` term. A finding is either implicitly **open** (no row) or **resolved** with `resolution ∈ { mitigated, accepted, false_positive }`. See [Lifecycle states](#lifecycle-states). |


### PR DESCRIPTION
## What

Updates the public Vulnerability Reporting documentation to match the current behavior of `ext-vulnerability-reporting`. Two customer-relevant behaviors shipped in the extension but were never documented:

1. **Inventory filtering** — before each daily `os_packages` scan is looked up, the extension drops entries that can never resolve to a CVE (macOS `com.apple.*` `pkgutil` receipts, Linux distro-internal config packages, Windows build-toolchain/driver/catalog noise). This is why finding counts are lower than raw installed-package counts; runtime components that do ship vulnerable code are deliberately kept.
2. **Linux distro-aware matching** — the extension detects an endpoint's distribution + release and forwards it so distro **backport** data corrects the verdict (a CVE fixed via a backport, keeping the upstream version, isn't flagged). Detection order: `lc:asset:os:<distro>-<release>` tag → marker package version → package source.

## Changes

- `docs/5-integrations/.../vulnerability-reporting.md`: new **Inventory collection** section (package filtering table + distro/release detection order); glossary entries for *distro/release* and *backport*; Linux tagging guidance.
- `docs/2-sensors-deployment/asset-tags.md`: register `lc:asset:os:<distro>-<release>` in the namespace registry, with a cross-link to the extension's distro-aware matching section.

## Scope

Public-facing only. The `vulnerability-db` internals (resolver tiers, LLM disambiguation, suspect bits, Redis layout, eval harness) are intentionally **not** documented — that service is LimaCharlie-internal and only the extension's externally observable behavior is described here.

`markdownlint-cli2` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)