### PR TITLE
docs: add Cylance adapter page

### DIFF
--- a/docs/2-sensors-deployment/adapters/types/cylance.md
+++ b/docs/2-sensors-deployment/adapters/types/cylance.md
@@ -1,0 +1,59 @@
+# Cylance
+
+## Overview
+
+This Adapter allows you to connect to the Cylance (BlackBerry Protect) [ProtectAPI](https://developer.blackberry.com/) to fetch detections, threats, and memory-protection events.
+
+## Deployment Configurations
+
+All adapters support the same `client_options`, which you should always specify if using the binary adapter or creating a webhook adapter. If you use any of the Adapter helpers in the web app, you will not need to specify these values.
+
+- `client_options.identity.oid`: the LimaCharlie Organization ID (OID) this adapter is used with.
+- `client_options.identity.installation_key`: the LimaCharlie Installation Key this adapter should use to identify with LimaCharlie.
+- `client_options.platform`: the type of data ingested through this adapter, like `text`, `json`, `gcp`, `carbon_black`, etc.
+- `client_options.sensor_seed_key`: an arbitrary name for this adapter which Sensor IDs (SID) are generated from, see below.
+
+### Adapter-specific Options
+
+Adapter Type: `cylance`
+
+- `tenant_id`: your Cylance Tenant API key (the tenant the application belongs to).
+- `app_id`: your Cylance Application ID.
+- `app_secret`: your Cylance Application Secret.
+- `logging_base_url`: ProtectAPI base URL for your region. Defaults to `https://protectapi.cylance.com` (US). Set it to your shard, e.g. `https://protectapi-euc1.cylance.com` (EU), `https://protectapi-apne1.cylance.com` (APAC-NE), `https://protectapi-au.cylance.com` (AU), or `https://protectapi-sae1.cylance.com` (SAE).
+
+The adapter mints a short-lived JWT from `tenant_id` / `app_id` / `app_secret`, exchanges it at `<logging_base_url>/auth/v2/token`, and polls the `/detections/v2`, `/threats/v2`, and `/memoryprotection/v2` endpoints.
+
+### Getting Your Credentials
+
+1. In the Cylance console, go to **Settings → Integrations** and add a new application.
+2. Grant it read access to **Detections**, **Threats**, and **Memory Protection**.
+3. On creation, copy the **Application ID** (`app_id`), **Application Secret** (`app_secret`), and your **Tenant API key** (`tenant_id`).
+
+### Infrastructure as Code Deployment
+
+```python
+# For cloud sensor deployment, store credentials as hive secrets:
+
+#   tenant_id: "hive://secret/cylance-tenant-id"
+#   app_id: "hive://secret/cylance-app-id"
+#   app_secret: "hive://secret/cylance-app-secret"
+
+sensor_type: "cylance"
+cylance:
+  tenant_id: "hive://secret/cylance-tenant-id"
+  app_id: "hive://secret/cylance-app-id"
+  app_secret: "hive://secret/cylance-app-secret"
+  logging_base_url: "https://protectapi.cylance.com"
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_CYLANCE"
+    hostname: "cylance-adapter"
+    platform: "cylance"
+    sensor_seed_key: "cylance-sensor"
+```
+
+## API Doc
+
+See the official [BlackBerry / Cylance developer documentation](https://developer.blackberry.com/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -275,6 +275,7 @@ nav:
           - Security Tools:
               - Check Point Harmony: 2-sensors-deployment/adapters/types/checkpoint-harmony.md
               - CrowdStrike: 2-sensors-deployment/adapters/types/crowdstrike.md
+              - Cylance: 2-sensors-deployment/adapters/types/cylance.md
               - Microsoft Defender: 2-sensors-deployment/adapters/types/microsoft-defender.md
               - SentinelOne: 2-sensors-deployment/adapters/types/sentinelone.md
               - Sophos: 2-sensors-deployment/adapters/types/sophos.md


### PR DESCRIPTION
Documents the `cylance` USP adapter under **Sensors → Adapters → Security Tools**, following the existing adapter page pattern.

## What's covered

- Adapter Type `cylance`, fetching Cylance (BlackBerry Protect) detections, threats, and memory-protection events via the ProtectAPI (`/detections/v2`, `/threats/v2`, `/memoryprotection/v2`).
- The JWT-from-app-credentials auth flow (`tenant_id` / `app_id` / `app_secret` → `/auth/v2/token`).
- The regional `logging_base_url` shards (default US `protectapi.cylance.com`).
- Console integration setup for obtaining the credentials.
- IaC example with `hive://` secret references; recommends the dedicated `cylance` platform.

Config fields and endpoints verified against `usp-adapters/cylance/client.go`.

Draft — markdownlint-cli2 passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)