### PR TITLE
Fix reg_list/reg_get command docs to match implementation

### DIFF
--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -1037,14 +1037,14 @@ List Windows registry keys and values.
 
 **Parameters:**
 
-- `reg_path` (required): Registry path to list (e.g., "HKEY_LOCAL_MACHINE\\SOFTWARE")
+- `reg` (required, positional): Registry path to list. Must start with one of `hkcr`, `hkcc`, `hkcu`, `hklm`, `hku` (e.g., `hklm\software`). Backslashes must be escaped.
 
-**Response Event:** REG_LIST_REP
+**Response Event:** REGISTRY_LIST_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> reg_list --reg_path "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
+limacharlie sensor task <SID> reg_list "hklm\\software\\microsoft\\windows\\currentversion\\run"
 ```
 
 ---
@@ -1059,15 +1059,15 @@ Fetch a single named value from a Windows registry key. Complements `reg_list`, 
 
 **Parameters:**
 
-- `reg_path` (required): Registry path to read from (e.g., "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run")
-- `value_name` (optional): Name of the value to fetch; omit for the key's default (unnamed) value
+- `reg` (required, positional): Registry key to read from. Must start with one of `hkcr`, `hkcc`, `hkcu`, `hklm`, `hku` (e.g., `hklm\software`). Backslashes must be escaped.
+- `name` (optional, positional): Name of the value to fetch; omit for the key's default (unnamed) value
 
 **Response Event:** REGISTRY_GET_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> reg_get --reg_path "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" --value_name "OneDrive"
+limacharlie sensor task <SID> reg_get "hklm\\software\\microsoft\\windows\\currentversion\\run" "OneDrive"
 ```
 
 ---


### PR DESCRIPTION
Corrects the `reg_list` and `reg_get` entries in `docs/8-reference/endpoint-commands.md` to match the actual parser in `legion_tasking-go/service/command_parser/command/{reg_list,reg_get}.go`.

### Fixes
- **Positional, not a flag** — both commands take the registry path as a required *positional* argument (`arg:"required,positional"`), not a `--reg_path` flag. `reg_get`'s value name is likewise a positional `name`, not `--value_name`.
- **Short hive prefixes** — paths must start with `hkcr`, `hkcc`, `hkcu`, `hklm`, or `hku` (e.g. `hklm\software`). A long form like `HKEY_LOCAL_MACHINE` fails the `registryHives.Exists` check with `INVALID_REGISTRY_PREFIX`.
- **Response event name** — `reg_list`'s response event is `REGISTRY_LIST_REP`, not `REG_LIST_REP` (confirmed in `edr-events.md`).

> Stacked on #260 (which adds the `reg_get` docs). Base will auto-retarget to `master` when #260 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)