### PR TITLE
docs: Microsoft Response, SentinelOne, ServiceNow extensions + Gmail adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Sensor selectors use [bexpr](https://github.com/hashicorp/go-bexpr) syntax to fi
 
 **EDR Platforms:** `windows`, `linux`, `macos`, `ios`, `android`, `chrome`, `vpn`
 
-**Adapter/USP Platforms:** `text`, `json`, `gcp`, `aws`, `carbon_black`, `1password`, `office365`, `sophos`, `crowdstrike`, `msdefender`, `sentinel_one`, `okta`, `duo`, `github`, `slack`, `azure_ad`, `azure_monitor`, `entraid`, `zeek`, `cef`, `wel`, `xml`, `guard_duty`, `k8s_pods`, `wiz`, `proofpoint`, `box`, `cylance`, `fortigate`, `netscaler`, `paloalto_fw`, `iis`, `trend_micro`, `trend_worryfree`, `bitwarden`, `mimecast`, `hubspot`, `zendesk`, `pandadoc`, `falconcloud`, `sublime`, `itglue`, `canary_token`, `lc_event`, `email`, `mac_unified_logging`, `azure_event_hub_namespace`, `azure_key_vault`, `azure_kubernetes_service`, `azure_network_security_group`, `azure_sql_audit`, `otel`, `cortex_xdr`, `harmony`, `threatlocker`, `halopsa`
+**Adapter/USP Platforms:** `text`, `json`, `gcp`, `aws`, `carbon_black`, `1password`, `office365`, `sophos`, `crowdstrike`, `msdefender`, `sentinel_one`, `okta`, `duo`, `github`, `slack`, `azure_ad`, `azure_monitor`, `entraid`, `zeek`, `cef`, `wel`, `xml`, `guard_duty`, `k8s_pods`, `wiz`, `proofpoint`, `box`, `cylance`, `fortigate`, `netscaler`, `paloalto_fw`, `iis`, `trend_micro`, `trend_worryfree`, `bitwarden`, `mimecast`, `hubspot`, `zendesk`, `pandadoc`, `falconcloud`, `sublime`, `itglue`, `canary_token`, `lc_event`, `email`, `mac_unified_logging`, `azure_event_hub_namespace`, `azure_key_vault`, `azure_kubernetes_service`, `azure_network_security_group`, `azure_sql_audit`, `otel`, `cortex_xdr`, `harmony`, `threatlocker`, `halopsa`, `cato`, `gmail`
 
 ### Architecture Values (`arch`)
 

--- a/docs/2-sensors-deployment/adapters/types/gmail.md
+++ b/docs/2-sensors-deployment/adapters/types/gmail.md
@@ -117,7 +117,7 @@ Adapter Type: `gmail`
 - **Messages**: each poll lists message ids matching `query` over a rolling time window, fetches each message at the configured `format`, and forwards the full message resource verbatim. A deduper keyed on the immutable Gmail message id guarantees each message ships exactly once despite overlapping windows. The event timestamp is the message's `internalDate`.
 - **Configuration state**: polled on `settings_poll_interval`; only appearances and changes are shipped.
 - **History**: the first run records a baseline `historyId` and ships nothing; later polls list forward from the cursor, filtered to deletions and label changes. Gmail retains history for roughly a week — if the cursor ages out, the adapter re-baselines and resumes rather than stopping.
-- **Errors**: `401` triggers one transparent token refresh; `429`/`5xx` are retried with backoff; persistently rejected credentials stop that mailbox's collector (other mailboxes are unaffected); a failing BEC capability is logged and skipped without affecting the others.
+- **Errors**: `401` triggers one transparent token refresh; `429`/`5xx`/`403` rate-limit errors are retried with backoff; persistently rejected credentials stop that mailbox's collector (other mailboxes are unaffected); a failing BEC capability is logged and skipped without affecting the others.
 
 ## CLI Deployment
 

--- a/docs/2-sensors-deployment/adapters/types/gmail.md
+++ b/docs/2-sensors-deployment/adapters/types/gmail.md
@@ -1,0 +1,214 @@
+# Gmail
+
+## Overview
+
+This Adapter collects telemetry from one or many Gmail mailboxes using the [Gmail REST API](https://developers.google.com/workspace/gmail/api/reference/rest). Beyond incoming-email telemetry, it can collect the mailbox configuration and change signals most relevant to **Business Email Compromise (BEC)** — the mail rules, forwarding, aliases, delegates, protocol access, and deletions an intruder uses to persist, exfiltrate mail, and cover their tracks.
+
+Each signal is an independent, opt-in **capability** that ships its own event type. They are all readable with the default `gmail.readonly` scope.
+
+With the service-account flow the adapter can watch **many mailboxes at once** — an explicit list, or every mailbox in a Google Workspace domain via auto-discovery — and ships each mailbox to its own LimaCharlie sensor.
+
+## Capabilities
+
+Enable any combination with the `collect_*` flags. If you set none, the adapter defaults to message telemetry only (`collect_messages`).
+
+| Flag | Event type(s) | What it gives you |
+| --- | --- | --- |
+| `collect_messages` | `gmail_message` | Incoming email as telemetry — the raw signal for phishing/lure detection. |
+| `collect_filters` | `gmail_filter` | Mail rules. Attackers create rules that auto-delete, auto-forward, or hide replies about invoices/wires. |
+| `collect_forwarding` | `gmail_forwarding_address`, `gmail_auto_forwarding` | Forwarding destinations and the account-wide auto-forward toggle — a classic mail-exfiltration vector. |
+| `collect_send_as` | `gmail_send_as` | Send-as / "from" identities. An added identity is an impersonation/persistence signal. |
+| `collect_delegates` | `gmail_delegate` | Mailbox delegates — granting a delegate is persistence. **Workspace only** (see note below). |
+| `collect_imap_pop` | `gmail_imap`, `gmail_pop` | IMAP/POP access settings. Enabling these allows bulk mailbox download via a desktop client. |
+| `collect_vacation` | `gmail_vacation` | The vacation responder, occasionally abused for harvesting/social engineering. |
+| `collect_history` | `gmail_history` | Mailbox changes: message **deletions** and **label changes** (marking a security alert read, trashing the fraud thread). |
+
+> **Delegates are Workspace-only.** Google exposes the delegates listing only to service-account clients with domain-wide delegation. On a consumer account (or without delegation) the call returns an error, which the adapter logs and skips — it does not stop the adapter or affect the other capabilities.
+
+The configuration-state capabilities (filters, forwarding, send-as, delegates, IMAP/POP, vacation) are **change-only**: an item is shipped when it first appears or its content changes, and suppressed otherwise. On adapter restart the in-memory dedupe state is empty, so the current state is re-emitted once as a fresh baseline — write detections against the *state* in these events rather than treating every event as a brand-new change.
+
+## Authentication
+
+Choose one of two modes.
+
+### OAuth 2.0 refresh token (a single mailbox)
+
+For collecting one user's mailbox. Create an OAuth client (Desktop or Web) in the Google Cloud console, enable the Gmail API, and complete the authorization-code flow once to obtain a refresh token for the `gmail.readonly` scope.
+
+| Field | Description |
+| --- | --- |
+| `client_id` | OAuth client id |
+| `client_secret` | OAuth client secret |
+| `refresh_token` | Long-lived refresh token for the mailbox owner |
+
+### Service account with domain-wide delegation (Google Workspace)
+
+For monitoring Workspace mailboxes without per-user consent. Create a service account, enable domain-wide delegation, and in the Workspace Admin console authorize its client id for the `https://www.googleapis.com/auth/gmail.readonly` scope.
+
+| Field | Description |
+| --- | --- |
+| `service_account_credentials` | The service account JSON key, inline |
+| `service_account_file` | Path to the service account JSON key file (alternative to the inline form) |
+| `subject` | A single mailbox owner to impersonate, e.g. `user@yourdomain.com` |
+
+Provide the mailbox(es) with `subject` (one), `subjects` (a list), and/or `discover_mailboxes` (the whole domain). At least one of these is required.
+
+## Multiple mailboxes
+
+With the service-account flow, each mailbox is impersonated independently and **shipped to its own sensor**: when more than one mailbox is collected, the sensor seed key is derived as `<sensor_seed_key>/<mailbox-address>` and the sensor hostname is set to the mailbox address.
+
+There are two ways to enumerate mailboxes, and they can be combined (the union is collected):
+
+- **Static list** (`subjects`): list the mailboxes explicitly — good for a fixed set of high-value mailboxes (executives, finance, AP).
+- **Auto-discovery** (`discover_mailboxes`): enumerate the Workspace domain's mailboxes via the Admin SDK Directory API, re-run on `discovery_interval` (default 1h) so newly-provisioned mailboxes are picked up and deprovisioned ones dropped automatically. Suspended accounts are skipped unless `include_suspended` is set.
+
+Auto-discovery has two extra requirements beyond the Gmail collection itself:
+
+1. `admin_subject` — a Workspace admin user the service account impersonates for the Directory call.
+2. An extra delegated scope — authorize the service account's client id for `https://www.googleapis.com/auth/admin.directory.user.readonly` in the Workspace Admin console.
+
+If a discovery pass fails or comes back empty while mailboxes are already being collected, the current set keeps collecting (with a warning logged) — discovery never tears down working mailboxes on a transient blip.
+
+## Deployment Configurations
+
+All adapters support the same `client_options`, which you should always specify if using the binary adapter:
+
+- `client_options.identity.oid`: the LimaCharlie Organization ID (OID) this adapter is used with.
+- `client_options.identity.installation_key`: the LimaCharlie Installation Key this adapter should use to identify with LimaCharlie.
+- `client_options.platform`: `gmail`.
+- `client_options.sensor_seed_key`: an arbitrary name for this adapter which Sensor IDs (SID) are generated from.
+
+### Adapter-specific Options
+
+Adapter Type: `gmail`
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `client_id` / `client_secret` / `refresh_token` | — | OAuth refresh-token flow credentials (single mailbox). |
+| `service_account_credentials` / `service_account_file` | — | Service-account flow credentials (Workspace). |
+| `subject` | — | Single mailbox to impersonate (service-account flow). |
+| `subjects` | — | Static list of mailboxes to impersonate. |
+| `discover_mailboxes` | `false` | Enumerate the domain's mailboxes via the Directory API. |
+| `admin_subject` | — | Admin user impersonated for the Directory API (required with `discover_mailboxes`). |
+| `customer` | `my_customer` | Directory API customer id (mutually exclusive with `domain`). |
+| `domain` | — | Restrict discovery to one domain of a multi-domain Workspace. |
+| `discovery_query` | — | Optional Directory API user search filter, e.g. `orgUnitPath='/Finance'`. |
+| `discovery_interval` | `1h` | How often discovery re-enumerates. |
+| `include_suspended` | `false` | Also collect suspended mailboxes. |
+| `max_concurrent_polls` | `10` | Cap on how many mailboxes poll the Gmail API at once. |
+| `collect_messages` … `collect_history` | see [Capabilities](#capabilities) | Capability toggles. |
+| `settings_poll_interval` | `15m` | Cadence for the configuration-state capabilities. |
+| `user_id` | `me` | Mailbox path segment for the refresh-token flow. Ignored by the service-account flow. |
+| `query` | `in:inbox` | Gmail [search query](https://support.google.com/mail/answer/7190) selecting messages. A time bound is appended automatically — do not add one. |
+| `scopes` | `gmail.readonly` | OAuth scopes to request. |
+| `format` | `full` | Message detail: `minimal`, `full`, `raw`, or `metadata`. |
+| `metadata_headers` | — | Headers to keep when `format` is `metadata`. |
+| `label_ids` | — | Only list messages carrying all of these label ids. |
+| `include_spam_trash` | `false` | Include SPAM and TRASH messages. |
+| `max_results` | `100` | Page size for the message listing (max 500). |
+| `poll_interval` | `5m` | Wait between message/history polls. |
+| `overlap` | `2m` | Window backdating to avoid gaps from late-indexed mail; re-listed messages are deduped. |
+| `initial_lookback` | `0` | On startup, reach back this far to backfill recent mail. |
+| `dedupe_ttl` | `168h` (7d) | How long a message id is remembered to suppress re-shipping. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | `5s` / `30s` / `3` | Transient-failure retry tuning. |
+
+## How collection works
+
+- **Messages**: each poll lists message ids matching `query` over a rolling time window, fetches each message at the configured `format`, and forwards the full message resource verbatim. A deduper keyed on the immutable Gmail message id guarantees each message ships exactly once despite overlapping windows. The event timestamp is the message's `internalDate`.
+- **Configuration state**: polled on `settings_poll_interval`; only appearances and changes are shipped.
+- **History**: the first run records a baseline `historyId` and ships nothing; later polls list forward from the cursor, filtered to deletions and label changes. Gmail retains history for roughly a week — if the cursor ages out, the adapter re-baselines and resumes rather than stopping.
+- **Errors**: `401` triggers one transparent token refresh; `429`/`5xx` are retried with backoff; persistently rejected credentials stop that mailbox's collector (other mailboxes are unaffected); a failing BEC capability is logged and skipped without affecting the others.
+
+## CLI Deployment
+
+[Adapter downloads](../deployment.md) are available on the deployment page.
+
+```bash
+chmod +x /path/to/lc_adapter
+
+/path/to/lc_adapter gmail \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=gmail \
+  client_options.sensor_seed_key=gmail \
+  client_id=$GMAIL_CLIENT_ID \
+  client_secret=$GMAIL_CLIENT_SECRET \
+  refresh_token=$GMAIL_REFRESH_TOKEN \
+  query="in:inbox" \
+  poll_interval=5m
+```
+
+## Infrastructure as Code Deployment
+
+Full BEC monitoring of a Workspace mailbox — message telemetry plus the persistence, exfiltration, and tamper signals:
+
+```yaml
+# For cloud sensor deployment, store credentials as hive secrets:
+#
+#   service_account_credentials: "hive://secret/gmail-service-account"
+
+sensor_type: "gmail"
+gmail:
+  service_account_credentials: "hive://secret/gmail-service-account"
+  subject: "soc-mailbox@yourdomain.com"
+  collect_messages: true
+  collect_filters: true
+  collect_forwarding: true
+  collect_send_as: true
+  collect_delegates: true
+  collect_imap_pop: true
+  collect_vacation: true
+  collect_history: true
+  poll_interval: 5m
+  settings_poll_interval: 15m
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_GMAIL"
+    platform: "gmail"
+    sensor_seed_key: "gmail-sensor"
+```
+
+Domain-wide auto-discovery — every mailbox in the Workspace, each on its own sensor:
+
+```yaml
+sensor_type: "gmail"
+gmail:
+  service_account_credentials: "hive://secret/gmail-service-account"
+  discover_mailboxes: true
+  admin_subject: "admin@yourdomain.com"
+  discovery_interval: 1h
+  collect_messages: true
+  collect_filters: true
+  collect_forwarding: true
+  collect_history: true
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_GMAIL"
+    platform: "gmail"
+    sensor_seed_key: "gmail-sensor"
+```
+
+## Sample Rule
+
+The BEC capabilities ship each signal under its own event type, so D&R rules can route directly on the signal. For example, flag every change to the account-wide auto-forwarding setting:
+
+```yaml
+# Detection
+event: gmail_auto_forwarding
+op: is
+path: event/enabled
+value: true
+
+# Response
+- action: report
+  name: Gmail auto-forwarding enabled
+```
+
+> **Note:** the `gmail.metadata` scope does not allow the `q` search parameter. If you restrict the adapter to that scope, leave `query` empty and rely on `label_ids` / `include_spam_trash` instead. The default `gmail.readonly` scope covers every capability; the narrower `gmail.metadata` scope cannot read the settings sub-resources, so a capability using them will be logged and skipped.
+
+## API Docs
+
+- Gmail API reference: [https://developers.google.com/workspace/gmail/api/reference/rest](https://developers.google.com/workspace/gmail/api/reference/rest)
+- Admin SDK Directory API (`users.list`, used by auto-discovery): [https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list)

--- a/docs/5-integrations/extensions/third-party/index.md
+++ b/docs/5-integrations/extensions/third-party/index.md
@@ -8,12 +8,15 @@ Extensions built by third-party developers that integrate external tools and ser
 - [Govee](govee.md) - Govee device integration
 - [HaloPSA](halopsa.md) - PSA ticketing and asset management
 - [Hayabusa](hayabusa.md) - Windows event log analysis
+- [Microsoft Response](microsoft-response.md) - Entra ID, Intune, and Defender for Endpoint response actions
 - [NIMS](nims.md) - NIMS integration
 - [OTX](otx.md) - AlienVault OTX threat intelligence
 - [PagerDuty](pagerduty.md) - Incident management notifications
 - [Plaso](plaso.md) - Timeline analysis with Plaso
 - [Renigma](renigma.md) - Renigma integration
 - [SecureAnnex](secureannex.md) - SecureAnnex integration
+- [SentinelOne](sentinelone.md) - SentinelOne EDR response and triage actions
+- [ServiceNow](servicenow.md) - Incident management and bidirectional Case mirroring
 - [Strelka](strelka.md) - File analysis with Strelka
 - [ThreatLocker](threatlocker.md) - ThreatLocker Application Control approval workflow
 - [Twilio](twilio.md) - SMS and voice notifications

--- a/docs/5-integrations/extensions/third-party/microsoft-response.md
+++ b/docs/5-integrations/extensions/third-party/microsoft-response.md
@@ -1,0 +1,216 @@
+# Microsoft Response
+
+The Microsoft Response LimaCharlie Extension exposes the incident-response surface of Microsoft's cloud security platforms — **Microsoft Graph** (Entra ID identities, Identity Protection, groups, Intune devices, audit logs) and **Microsoft Defender for Endpoint** (machine isolation, scans, forensics, file quarantine, custom indicators) — to D&R rules and AI agents. It enables automated containment of account and endpoint compromise directly from detections.
+
+The extension provides two layers:
+
+- **Typed actions** for the common containment and triage workflows, with friendly parameter names and built-in safety rails.
+- A generic **`api_call`** passthrough for any Graph or Defender endpoint not covered by a typed action.
+
+Authentication is OAuth2 **client credentials** against an Entra app registration — no user interaction, no delegated tokens.
+
+## Setup
+
+### 1. Create an Entra app registration
+
+In the Azure portal (**Entra ID → App registrations → New registration**), create an app registration and note its **Application (client) ID** and your **Directory (tenant) ID**. Create a **client secret** under *Certificates & secrets*.
+
+### 2. Grant application permissions
+
+Under *API permissions*, add **application** permissions (not delegated) and grant **admin consent**. The least-privilege set per capability:
+
+| Capability | Permission | API |
+| --- | --- | --- |
+| List/read users | `User.Read.All` | Microsoft Graph |
+| Disable / enable account | `User.EnableDisableAccount.All` | Microsoft Graph |
+| Revoke sign-in sessions | `User.RevokeSessions.All` | Microsoft Graph |
+| Reset password | `User-PasswordProfile.ReadWrite.All` | Microsoft Graph |
+| List authentication methods | `UserAuthenticationMethod.Read.All` | Microsoft Graph |
+| Risky users (read / confirm / dismiss) | `IdentityRiskyUser.ReadWrite.All` | Microsoft Graph |
+| Groups read / membership change | `GroupMember.ReadWrite.All` | Microsoft Graph |
+| Sign-in & directory audit logs | `AuditLog.Read.All` | Microsoft Graph |
+| Intune device actions | `DeviceManagementManagedDevices.PrivilegedOperations.All` (+ `DeviceManagementManagedDevices.Read.All` to list) | Microsoft Graph |
+| Machine isolation | `Machine.Isolate` | WindowsDefenderATP |
+| Antivirus scan | `Machine.Scan` | WindowsDefenderATP |
+| Restrict app execution | `Machine.RestrictExecution` | WindowsDefenderATP |
+| Collect investigation package | `Machine.CollectForensics` | WindowsDefenderATP |
+| Stop & quarantine file | `Machine.StopAndQuarantine` | WindowsDefenderATP |
+| List machines / machine actions | `Machine.ReadWrite.All` | WindowsDefenderATP |
+| Custom indicators (IoCs) | `Ti.ReadWrite.All` | WindowsDefenderATP |
+
+Only add what you will use — every action degrades independently with a `403` if its permission is missing.
+
+> **Privileged user writes need a directory role too.** For `disable_user`, `enable_user`, and `reset_user_password`, Graph permissions alone are not sufficient: the app's service principal must also hold an Entra **directory role** (e.g. *User Administrator*) covering the target user. A `403` on these actions is a consent/role problem, not a bug.
+>
+> **Identity Protection requires Entra ID P2.** `list_risky_users`, `confirm_user_compromised`, and `dismiss_user_risk` return `403` on tenants without a P2 license.
+
+### 3. Subscribe to the extension
+
+Subscribe to `ext-microsoft-response` from the LimaCharlie **Marketplace** (Extensions → Add-Ons).
+
+### 4. Store the client secret
+
+In **Secrets Manager**, create a new secret (for example `msft-response-client-secret`) and paste the client secret as its value.
+
+### 5. Configure the extension
+
+In **Extensions → ext-microsoft-response → Configuration**, fill in:
+
+| Field | Required | Value |
+| --- | --- | --- |
+| `tenant_id` | yes | Entra (Azure AD) tenant ID (GUID) or a verified domain name. |
+| `client_id` | yes | App registration Application (client) ID. |
+| `client_secret` | yes | Reference to the secret created in step 4, e.g. `hive://secret/msft-response-client-secret`. |
+| `login_base_url` | no | OAuth endpoint override for sovereign clouds. Default `https://login.microsoftonline.com`. |
+| `graph_base_url` | no | Microsoft Graph base override. Default `https://graph.microsoft.com/v1.0`. |
+| `defender_base_url` | no | Defender for Endpoint base override. Default `https://api.securitycenter.microsoft.com/api`. |
+
+The three base-URL overrides support sovereign clouds (US Government GCC High / DoD, China 21Vianet); leave them empty for the public cloud.
+
+## Actions
+
+Every action that targets an entity requires an explicit selector (`user_id`, `device_id`, `machine_id`, …) — the extension refuses to run without one, preventing accidental fleet-wide containment.
+
+### Common list parameters
+
+The `list_*` actions share an OData query schema and return `{data: [...], pagination: {next_link}}`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `filter` | string | OData `$filter`, e.g. `accountEnabled eq false`. |
+| `select` | string | OData `$select` — comma-separated fields. |
+| `search` | string | Free-text `$search`, e.g. `displayName:alex` (Graph sets `ConsistencyLevel: eventual` automatically). |
+| `order_by` | string | OData `$orderby`, e.g. `createdDateTime desc`. |
+| `top` | int | Page size, default `100`, clamped to `999`. |
+| `count` | bool | Request a `$count`. |
+| `next_link` | string | Opaque `@odata.nextLink` from a previous response — pass it back to fetch the next page. |
+| `extra_query` | object | Raw query params merged into the request (escape hatch). |
+
+### Generic
+
+#### `api_call`
+
+Generic passthrough to Graph or Defender for Endpoint.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `service` | enum | `graph` (default) or `defender`. Token audience is handled automatically. |
+| `method` | enum | **Required.** `GET`, `POST`, `PATCH`, `PUT`, `DELETE`. |
+| `path` | string | **Required.** Path relative to the service base (e.g. `users/{id}/revokeSignInSessions`) or a full `@odata.nextLink` URL. |
+| `query` | object | Query-string parameters (`$filter`, `$select`, `$top`, …). |
+| `headers` | object | Extra request headers, e.g. `{"ConsistencyLevel": "eventual"}`. |
+| `body` | object | JSON body for `POST`/`PATCH`/`PUT`. Note Defender bodies use PascalCase keys (`IsolationType`, `Comment`, …). |
+
+### Entra ID identities
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `list_users` | common list params | List/search users. Add `accountEnabled` to `select` to read it (not returned by default). |
+| `disable_user` | `user_id` | Set `accountEnabled=false` — blocks new sign-ins immediately. Reverse with `enable_user`. |
+| `enable_user` | `user_id` | Re-enable a disabled user. |
+| `revoke_sign_in_sessions` | `user_id` | Invalidate all refresh tokens / sessions, forcing re-authentication everywhere. Takes a few minutes to fully propagate. |
+| `reset_user_password` | `user_id`, `password`, `force_change_password_next_sign_in` (default `true`) | Set a new password via `passwordProfile`. Requires a directory role (see Setup). |
+| `list_auth_methods` | `user_id` | List registered authentication methods — spot attacker-registered MFA. |
+
+`user_id` accepts either the user object ID (GUID) or the userPrincipalName (UPN).
+
+For full account containment, combine `disable_user` with `revoke_sign_in_sessions`: disabling blocks new sign-ins, revoking kills existing sessions.
+
+### Identity Protection (Entra ID P2)
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `list_risky_users` | common list params | Users flagged by Identity Protection (`riskLevel`, `riskState`, `riskDetail`). |
+| `confirm_user_compromised` | `user_ids` (list of GUIDs) | Mark users confirmed-compromised, raising risk to high (drives risk-based Conditional Access). |
+| `dismiss_user_risk` | `user_ids` (list of GUIDs) | Clear the risk on users. Max 60 per call. |
+
+### Directory & audit reads
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `list_groups` | common list params | List groups (e.g. find a quarantine or privileged group). |
+| `list_sign_ins` | common list params | Entra sign-in events. Always scope with a `createdDateTime` filter. |
+| `list_directory_audits` | common list params | Directory audit log — who changed what. |
+
+### Group containment
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `add_group_member` | `group_id`, `user_id` | Add a user to a group — e.g. drop a compromised user into a Conditional-Access block/quarantine group. |
+| `remove_group_member` | `group_id`, `user_id` | Remove a user from a group — e.g. strip a compromised user out of a privileged group. |
+
+### Intune devices
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `list_managed_devices` | common list params | List Intune-managed devices (`deviceName`, `complianceState`, `userPrincipalName`, …). |
+| `wipe_device` | `device_id`, `keep_enrollment_data`, `keep_user_data`, `data` | Factory-reset a device. **Destructive.** |
+| `retire_device` | `device_id` | Remove company data and MDM policies, leave personal data. |
+| `remote_lock_device` | `device_id` | Remote-lock the device. |
+| `reset_device_passcode` | `device_id` | Reset the device passcode. |
+| `reboot_device` | `device_id` | Immediate reboot. |
+
+`device_id` is the Intune `managedDevice` id from `list_managed_devices`.
+
+### Defender for Endpoint machines
+
+Machine actions are **asynchronous**: they return a `machineAction` object with `status: Pending`, and the work completes in the background. Poll with `get_machine_action` until `Succeeded` / `Failed`. All take an optional `comment` recorded in the Defender action audit (default `Automated response via LimaCharlie`) and an optional `data` object merged into the payload.
+
+| Action | Parameters | What it does |
+| --- | --- | --- |
+| `list_machines` | common list params | List Defender machines (`computerDnsName`, `riskScore`, `exposureLevel`, …). |
+| `isolate_machine` | `machine_id`, `isolation_type` (`Full` default, or `Selective`) | Network-isolate a machine. `Selective` keeps Teams/Outlook working. |
+| `unisolate_machine` | `machine_id` | Release from isolation. |
+| `run_antivirus_scan` | `machine_id`, `scan_type` (`Quick` default, or `Full`) | Trigger a Defender AV scan. |
+| `restrict_app_execution` | `machine_id` | Only Microsoft-signed binaries may run. |
+| `unrestrict_app_execution` | `machine_id` | Remove the execution restriction. |
+| `collect_investigation_package` | `machine_id` | Collect a forensics package; fetch the download URL via `get_machine_action` once complete. |
+| `stop_and_quarantine_file` | `machine_id`, `sha1` | Stop running instances of a file (by SHA-1) and quarantine it. |
+| `list_machine_actions` | common list params | The response-action audit/queue. |
+| `get_machine_action` | `action_id` | Poll one machine action's status (`Pending` / `InProgress` / `Succeeded` / `Failed`). |
+
+### Custom indicators
+
+#### `create_indicator`
+
+Create a Defender custom threat indicator to block or alert on an IoC across the tenant.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `indicator_value` | string | **Required.** The IoC value. |
+| `indicator_type` | enum | **Required.** `FileSha1`, `FileSha256`, `FileMd5`, `IpAddress`, `DomainName`, `Url`, `CertificateThumbprint`. |
+| `action` | enum | **Required.** `Alert`, `Warn`, `Block`, `Audit`, `BlockAndRemediate`, `AlertAndBlock`, `Allowed`. |
+| `title` | string | **Required.** Indicator title. |
+| `description` | string | **Required.** Indicator description. |
+| `severity` | enum | `Informational`, `Low`, `Medium` (default), `High`. |
+| `expiration_time` | string | ISO-8601 UTC expiry; omit for no expiry. |
+| `recommended_actions` | string | Recommended-actions text shown with the alert. |
+| `generate_alert` | bool | Generate an alert on match. **Required `true` when `action` is `Audit`.** |
+| `data` | object | Extra fields merged into the payload (e.g. `rbacGroupNames`). |
+
+## Detection & Response
+
+Example response action that isolates the Defender machine named in a detection:
+
+```yaml
+- action: extension request
+  extension action: isolate_machine
+  extension name: ext-microsoft-response
+  extension request:
+    machine_id: '{{ .event/machine_id }}'
+    isolation_type: '{{ "Full" }}'
+    comment: '{{ "Isolated by LimaCharlie D&R rule" }}'
+```
+
+> **Wrap literal strings in `{{ "..." }}`.**
+> Values under `extension request` are evaluated as templates. A bare string without `{{ }}` is interpreted as a [gjson](https://github.com/tidwall/gjson) path against the event and, if it doesn't resolve, the key is silently dropped from the payload.
+
+`extension request` actions are fire-and-forget — the rule engine does not surface the response back into the rule's evaluation context, so a `machineAction` id is not available to a subsequent action in the same rule. Workflows that chain (look up the machine, isolate it, poll the action, collect forensics) belong in a [Playbook](../limacharlie/playbook.md) or an AI agent, which can hold ids between calls.
+
+## Notes
+
+- Graph and Defender use **separate token audiences**; the extension caches one token per service and renews it before expiry. A token rejected by the other service surfaces as `403`, not `401`.
+- A single `401` is treated as a token-expiry race: the cached token is dropped and the request retried once with a fresh token. Rotating `client_secret` in Secrets Manager recovers the same way — the next auth failure evicts the cached client and re-reads the secret.
+- Microsoft Graph throttling (`429`) is **not** retried by the extension; throttled requests surface to the caller.
+- Error messages are formatted `microsoft <service> api <status> on <path>: <code>: <message>`, with query strings redacted.
+- Unsubscribing from the extension preserves its saved configuration; re-subscribing restores it without reconfiguration.

--- a/docs/5-integrations/extensions/third-party/microsoft-response.md
+++ b/docs/5-integrations/extensions/third-party/microsoft-response.md
@@ -95,7 +95,7 @@ Generic passthrough to Graph or Defender for Endpoint.
 | Field | Type | Notes |
 | --- | --- | --- |
 | `service` | enum | `graph` (default) or `defender`. Token audience is handled automatically. |
-| `method` | enum | **Required.** `GET`, `POST`, `PATCH`, `PUT`, `DELETE`. |
+| `method` | enum | `GET` (default), `POST`, `PATCH`, `PUT`, `DELETE`. |
 | `path` | string | **Required.** Path relative to the service base (e.g. `users/{id}/revokeSignInSessions`) or a full `@odata.nextLink` URL. |
 | `query` | object | Query-string parameters (`$filter`, `$select`, `$top`, …). |
 | `headers` | object | Extra request headers, e.g. `{"ConsistencyLevel": "eventual"}`. |

--- a/docs/5-integrations/extensions/third-party/sentinelone.md
+++ b/docs/5-integrations/extensions/third-party/sentinelone.md
@@ -1,0 +1,209 @@
+# SentinelOne
+
+[SentinelOne](https://www.sentinelone.com/) is an endpoint protection platform. The SentinelOne LimaCharlie Extension exposes the SentinelOne Management API to D&R rules and AI agents: list and act on agents (isolate, scan), triage threats (mitigate, verdict, incident status, notes), blocklist file hashes, and read the tenant's org hierarchy and activity log.
+
+The extension provides two layers:
+
+- **Typed actions** for the common EDR/SecOps workflows, with friendly parameter names and built-in safety rails.
+- A generic **`api_call`** passthrough for any SentinelOne endpoint not covered by a typed action.
+
+## Setup
+
+### 1. Create a SentinelOne API token
+
+In the SentinelOne management console, create an API token. A **Service User** token (Settings → Users → Service Users) is recommended: it is an API-only credential with a configurable expiry, unlike regular user tokens which expire after 30 days. Scope it to the sites/accounts the extension should manage.
+
+### 2. Subscribe to the extension
+
+Subscribe to `ext-sentinelone` from the LimaCharlie **Marketplace** (Extensions → Add-Ons).
+
+### 3. Store the API token
+
+In **Secrets Manager**, create a new secret (for example `sentinelone-api-token`) and paste the API token as its value.
+
+### 4. Configure the extension
+
+In **Extensions → ext-sentinelone → Configuration**, fill in:
+
+| Field | Required | Value |
+| --- | --- | --- |
+| `console_url` | yes | Your SentinelOne management console URL, e.g. `https://usea1-partners.sentinelone.net` |
+| `api_token` | yes | Reference to the secret created in step 3, e.g. `hive://secret/sentinelone-api-token` |
+| `api_version` | no | API version path segment. Defaults to `v2.1`. |
+
+The token is sent as `Authorization: ApiToken <token>` on every request. Rotating the secret in Secrets Manager takes effect on the next request after a surfaced `401`.
+
+## Actions
+
+Every action that mutates state (isolate, scan, mitigate, verdict, incident, note) selects its targets with either an explicit id list (`agent_ids` / `threat_ids`) or a raw SentinelOne `filter` object. **An empty selector is refused** — the extension will not run an action that would target every entity in the tenant.
+
+List actions return one page plus a cursor: `{data: [...], pagination: {nextCursor, totalItems}}`. Pass `cursor` back (together with the same filters) to fetch the next page. `limit` defaults to `100` (max `1000`).
+
+### Generic
+
+#### `api_call`
+
+Call any SentinelOne Management API endpoint — the escape hatch for endpoints without a typed action.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `method` | enum | `GET` (default), `POST`, `PUT`, `DELETE`. |
+| `path` | string | **Required.** Endpoint path relative to `/web/api/<version>`, e.g. `agents`, `threats/mitigate/kill`, `system/info`. |
+| `query` | object | Query-string parameters as a flat object. |
+| `body` | object | JSON request body for `POST`/`PUT`. Action endpoints expect `{filter: {...}, data: {...}}`. |
+
+Returns the full SentinelOne response envelope.
+
+### Agents
+
+#### `list_agents`
+
+List/search agents (endpoints).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Free-text search (computer name, IP, …). |
+| `computer_name` | string | Substring match on computer name. |
+| `uuid` | string | Filter by agent UUID. |
+| `is_active` | bool | Only active (`true`) / inactive (`false`) agents. |
+| `network_status` | enum | `connected`, `connecting`, `disconnected`, `disconnecting`. |
+| `infected` | bool | Only agents with (`true`) / without (`false`) active threats. |
+| `os_types` | list of enum | `windows`, `linux`, `macos`, `windows_legacy`. |
+| `site_ids` / `group_ids` / `account_ids` | list of string | Restrict to sites / groups / accounts. |
+| `limit` / `cursor` | int / string | Pagination. |
+| `extra_query` | object | Raw query params merged into the request (escape hatch). |
+
+#### `isolate_agent` / `deisolate_agent` / `scan_agent`
+
+Network-isolate (disconnect), reconnect, or start a full-disk scan on selected agents.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `agent_ids` | list of string | Agent ids to act on (the common case). |
+| `filter` | object | Raw SentinelOne agent filter (advanced alternative to `agent_ids`). |
+| `data` | object | Extra fields merged into the action's data payload. |
+
+At least one of `agent_ids` or `filter` is required. Returns `{data: {affected: N}}`.
+
+### Threats
+
+#### `list_threats`
+
+List/search threats.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Free-text search (file path, hash, computer name, …). |
+| `content_hashes` | list of string | Filter by file SHA-1 hashes. |
+| `mitigation_statuses` | list of string | e.g. `mitigated`, `active`, `blocked`, `suspicious`. |
+| `incident_statuses` | list of string | `unresolved`, `in_progress`, `resolved`. |
+| `analyst_verdicts` | list of string | `true_positive`, `false_positive`, `suspicious`, `undefined`. |
+| `classifications` | list of string | e.g. `Malware`, `PUA`, `Ransomware`. |
+| `resolved` | bool | Only resolved (`true`) / unresolved (`false`) threats. |
+| `created_at__gte` / `created_at__lte` | string | ISO-8601 UTC bounds, e.g. `2026-06-01T00:00:00.000000Z`. |
+| `site_ids` / `account_ids` | list of string | Restrict to sites / accounts. |
+| `limit` / `cursor` / `extra_query` | — | Pagination and raw-params escape hatch. |
+
+#### `mitigate_threat`
+
+Apply a mitigation action to selected threats.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `action` | enum | **Required.** `kill`, `quarantine`, `remediate`, `rollback-remediation`, `un-quarantine`, `network-quarantine`. |
+| `threat_ids` | list of string | Threat ids to mitigate. |
+| `filter` | object | Raw SentinelOne threat filter (advanced alternative). |
+| `data` | object | Extra fields merged into the action's data payload. |
+
+#### `set_threat_verdict`
+
+Set the analyst verdict on selected threats.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `verdict` | enum | **Required.** `true_positive`, `false_positive`, `suspicious`, `undefined`. |
+| `threat_ids` / `filter` | — | Target selection, at least one required. |
+
+#### `set_threat_incident`
+
+Set the incident status on selected threats.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `status` | enum | **Required.** `unresolved`, `in_progress`, `resolved`. |
+| `threat_ids` / `filter` | — | Target selection, at least one required. |
+
+#### `add_threat_note`
+
+Append a note to selected threats — useful for AI agents to record triage findings in the SentinelOne console.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `text` | string | **Required.** Note text. |
+| `threat_ids` / `filter` | — | Target selection, at least one required. |
+
+### Blocklist
+
+#### `blocklist_hash`
+
+Add a SHA-1 file hash to the SentinelOne blocklist.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `hash` | string | **Required.** SHA-1 hash to block. |
+| `os_type` | enum | **Required.** `windows`, `windows_legacy`, `macos`, `linux`. |
+| `description` | string | Reason for the blocklist entry. |
+| `tenant` | bool | Apply tenant-wide. Default `false`. |
+| `site_ids` / `group_ids` / `account_ids` | list of string | Scope the entry when `tenant` is not set. |
+| `data` | object | Extra fields merged into the restriction's data payload. |
+
+A scope is required: set `tenant: true` or at least one of `site_ids` / `group_ids` / `account_ids`.
+
+### Tenant reads
+
+#### `list_sites` / `list_accounts` / `list_groups`
+
+List the org hierarchy — useful to resolve the ids used by the scoping parameters above.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Free-text name match. |
+| `site_ids` / `account_ids` | list of string | Restrict by id. |
+| `limit` / `cursor` / `extra_query` | — | Pagination and raw-params escape hatch. |
+
+#### `list_activities`
+
+List the activity / audit log.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `activity_types` | list of string | Numeric activity type codes (see the SentinelOne `/activities/types` endpoint). |
+| `agent_ids` / `site_ids` | list of string | Restrict by agent / site. |
+| `created_at__gte` / `created_at__lte` | string | ISO-8601 UTC bounds. |
+| `limit` / `cursor` / `extra_query` | — | Pagination and raw-params escape hatch. |
+
+## Detection & Response
+
+Example response action that network-isolates the SentinelOne agent named in a detection:
+
+```yaml
+- action: extension request
+  extension action: isolate_agent
+  extension name: ext-sentinelone
+  extension request:
+    agent_ids:
+      - '{{ .event/agent_id }}'
+```
+
+> **Wrap literal strings in `{{ "..." }}`.**
+> Values under `extension request` are evaluated as templates. A bare string without `{{ }}` is interpreted as a [gjson](https://github.com/tidwall/gjson) path against the event and, if it doesn't resolve, the key is silently dropped from the payload.
+
+`extension request` actions are fire-and-forget — the rule engine does not surface the response back into the rule's evaluation context. Workflows that need to chain (find the agent, isolate it, annotate the threat) belong in a [Playbook](../limacharlie/playbook.md) or an AI agent, which can hold ids between calls.
+
+## Notes
+
+- The token is sent as `Authorization: ApiToken <token>` — SentinelOne API tokens are static, not OAuth, and are not refreshable. A `401` is surfaced as a real auth failure; the extension then evicts its cached client so the next request re-reads the (possibly rotated) secret.
+- SentinelOne cursors are not self-contained: re-send the same filters along with `cursor` on every page.
+- `console_url` may be pasted with or without a trailing `/web/api[/version]` suffix — the extension normalizes it either way.
+- Errors are surfaced as `sentinelone api <status> on <path>: <message>`, with SentinelOne's error envelope flattened into the message.
+- Unsubscribing from the extension preserves its saved configuration; re-subscribing restores it without reconfiguration.

--- a/docs/5-integrations/extensions/third-party/servicenow.md
+++ b/docs/5-integrations/extensions/third-party/servicenow.md
@@ -1,0 +1,216 @@
+# ServiceNow
+
+[ServiceNow](https://www.servicenow.com/) is an IT service management platform. The ServiceNow LimaCharlie Extension provides **bidirectional mirroring between LimaCharlie Cases and ServiceNow incidents**, plus a set of outbound incident-management actions for D&R rules and AI agents: incident lifecycle (create/update/get/search), work notes and comments, attachments, CMDB lookups, and a read-only Table API escape hatch.
+
+The sync model is stateless on the LimaCharlie side:
+
+- **LC → ServiceNow**: `mirror_case` idempotently upserts a ServiceNow incident from a LimaCharlie Case, anchored on the incident's standard `correlation_id` / `correlation_display` fields. Repeated calls update the same incident.
+- **ServiceNow → LC**: `pull_incident_changes` returns incidents updated since a watermark, normalized for feeding back into Cases. Changes made by the integration's own user are excluded, breaking echo loops.
+
+## Setup
+
+### 1. Create a ServiceNow integration user
+
+Create a dedicated ServiceNow user (for example `lc.integration`) with permissions to read/create/update records on the `incident` table (including `work_notes`, `comments`, `correlation_id`, and `correlation_display`), attach files, and read whatever other tables you intend to query (`cmdb_ci` for `lookup_ci`, etc.). Using a dedicated user matters: its username is how the extension recognizes — and filters out — its own writes.
+
+### 2. Choose an authentication mode
+
+| Mode | `auth_mode` | Credentials needed | Notes |
+| --- | --- | --- | --- |
+| HTTP Basic | `basic` | `username`, `password` | Simplest; credentials sent on every request. |
+| OAuth password grant | `oauth_password` | `client_id`, `client_secret`, `username`, `password` | Token obtained then auto-refreshed. |
+| OAuth client credentials | `oauth_client_credentials` | `client_id`, `client_secret` | True server-to-server. Requires the instance property `glide.oauth.inbound.client.credential.grant_type.enabled` to be `true`. |
+
+For the OAuth modes, create an OAuth API endpoint client in ServiceNow (**System OAuth → Application Registry**).
+
+### 3. Subscribe to the extension
+
+Subscribe to `ext-servicenow` from the LimaCharlie **Marketplace** (Extensions → Add-Ons).
+
+### 4. Store the secrets
+
+In **Secrets Manager**, store the password and/or client secret (for example `servicenow-password`, `servicenow-client-secret`).
+
+### 5. Configure the extension
+
+In **Extensions → ext-servicenow → Configuration**, fill in:
+
+| Field | Required | Value |
+| --- | --- | --- |
+| `instance_url` | yes | ServiceNow instance base URL, e.g. `https://acme.service-now.com`. |
+| `auth_mode` | no | `basic` (default), `oauth_password`, or `oauth_client_credentials`. |
+| `username` | for `basic` / `oauth_password` | The integration user's username. |
+| `password` | for `basic` / `oauth_password` | Reference to the stored secret, e.g. `hive://secret/servicenow-password`. |
+| `client_id` | for OAuth modes | OAuth client ID. |
+| `client_secret` | for OAuth modes | Reference to the stored secret, e.g. `hive://secret/servicenow-client-secret`. |
+| `correlation_display` | no | Label stamped on mirrored incidents' `correlation_display`. Default `LimaCharlie`. Scopes both upserts and polling, so multiple integrations can coexist. |
+| `integration_user` | no | The ServiceNow username the extension authenticates as. `pull_incident_changes` excludes changes by this user to break echo loops. |
+| `close_code` | no | Incident `close_code` applied when mirroring a case into Resolved/Closed (data policies usually require one). Default `Solved (Permanently)`. |
+
+## Actions
+
+### Incident lifecycle
+
+#### `create_incident`
+
+Create a new incident. Only `short_description` is required.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `short_description` | string | **Required.** Incident subject line. |
+| `description` | string | Incident body. |
+| `state` | int | `1` New, `2` In Progress, `3` On Hold, `6` Resolved, `7` Closed, `8` Canceled. |
+| `urgency` / `impact` | int | `1` High … `3` Low. |
+| `priority` | int | Usually derived from urgency × impact; set to override. |
+| `category` | string | Category. |
+| `assignment_group` | string | Assignment group **sys_id** (display names are not resolved). |
+| `assigned_to` | string | Assignee user **sys_id**. |
+| `caller_id` | string | Caller user **sys_id**. |
+| `correlation_id` | string | External correlation id (e.g. an LC case id). |
+| `correlation_display` | string | External system label. |
+| `extra` | object | Raw ServiceNow incident fields to merge — escape hatch for fields not modeled above. |
+
+Returns the created record, including `sys_id` and `number`.
+
+#### `update_incident`
+
+Update an incident by `sys_id`. Accepts the same fields as `create_incident` (minus `short_description` being required), plus:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sys_id` | string | **Required.** Incident to update. |
+| `work_note` | string | Internal (IT-only) work note to append. |
+| `comment` | string | Customer-visible comment to append. |
+
+#### `get_incident`
+
+Fetch a single incident by `sys_id` or human-readable `number` (e.g. `INC0010023`). Optional `fields` (comma-separated `sysparm_fields`) and `display_value` (`false` / `true` / `all`).
+
+#### `search_incidents`
+
+Search incidents with a ServiceNow encoded query.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Encoded query (`sysparm_query`), e.g. `active=true^state=2^ORDERBYDESCsys_updated_on`. |
+| `fields` | string | Comma-separated fields to return. |
+| `limit` | int | Default `50`. |
+| `offset` | int | Pagination offset. |
+| `display_value` | enum | `false` / `true` / `all`. |
+
+Returns `{ "count": N, "incidents": [...] }`.
+
+### Notes & attachments
+
+#### `add_note`
+
+Append an internal work note and/or a customer-visible comment to a record. Journal fields append — they never overwrite.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sys_id` | string | **Required.** Record sys_id. |
+| `table` | string | Table name. Default `incident`. |
+| `note` | string | Internal (IT-only) work note. |
+| `comment` | string | Customer-visible comment. |
+
+#### `add_attachment`
+
+Upload a file onto a record.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `sys_id` | string | **Required.** Record sys_id. |
+| `file_name` | string | **Required.** Attachment file name. |
+| `table` | string | Default `incident`. |
+| `content_type` | string | MIME type. Default `application/octet-stream`. |
+| `content` | string | File content — text, or base64 when `content_base64` is `true`. |
+| `content_base64` | bool | Set for binary content. |
+
+### Reads
+
+#### `query_table`
+
+Read-only Table API query against any table (`incident`, `problem`, `change_request`, `cmdb_ci`, `sys_user`, …) — the escape hatch for data the typed actions don't cover, and the way to resolve display names to the sys_ids the write actions expect. Takes `table` (required), `query`, `fields`, `limit` (default `50`), `offset`, `display_value`. Returns `{ "count": N, "records": [...] }`.
+
+#### `lookup_ci`
+
+Resolve a CMDB configuration item — bridges LC sensor hostnames to the ServiceNow CMDB. Takes `name` (LIKE match), or a custom `query`; optional `class` (default `cmdb_ci`) and `limit` (default `50`). Returns `{ "count": N, "cis": [...] }`.
+
+### Case mirroring
+
+#### `mirror_case`
+
+Idempotently upsert a ServiceNow incident from a LimaCharlie Case. The incident is matched on `correlation_id = case_id` (scoped to this integration's `correlation_display`), so repeated calls update the same incident.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `case_id` | string | **Required.** LimaCharlie case id — stored as `correlation_id`. |
+| `case_number` | int | LC case number, used in the incident subject (`LimaCharlie Case #N: …`). |
+| `status` | enum | `new`, `in_progress`, `resolved`, `closed`. |
+| `severity` | enum | `critical`, `high`, `medium`, `low`, `info`. |
+| `classification` | string | Case classification (appended to the description). |
+| `summary` | string | Case summary — becomes the incident subject (first line, truncated to 160 chars) and description. |
+| `conclusion` | string | Case conclusion — appended to the description; used as `close_notes` on terminal states. |
+| `assignees` / `tags` | list of string | Appended to the description. |
+| `correlation_display` | string | Override the configured label for this mirror. |
+| `sync_note` | string | Optional work note recording the sync on the incident. |
+
+Mappings applied:
+
+- Status → incident `state`: `new` → 1, `in_progress` → 2, `resolved` → 6, `closed` → 7. Terminal states also set `close_code` (from config) and `close_notes`.
+- Severity → `urgency`/`impact`: `critical` → 1/1, `high` → 1/2, `medium` → 2/2, `low` and `info` → 3/3.
+
+Returns `{ "created": bool, "sys_id": "...", "number": "...", "incident": {...} }`.
+
+#### `pull_incident_changes`
+
+Return incidents belonging to this integration (matched on `correlation_display`) updated at or after a watermark, normalized for feeding back into LC Cases.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `since` | string | ServiceNow datetime watermark (`YYYY-MM-DD HH:MM:SS`, UTC). Empty bootstraps from the most recent changes; pass the returned watermark back on the next call. |
+| `limit` | int | Default `100`. Keep it above the largest expected same-second burst of updates. |
+| `include_own_changes` | bool | Disable the echo-loop guard (changes by `integration_user` are excluded by default). |
+
+Returns `{ "count": N, "changes": [...], "watermark": "YYYY-MM-DD HH:MM:SS" }`. Each change carries `sys_id`, `number`, `case_id` (from `correlation_id`), `state`, a normalized `case_status` (`new` / `in_progress` / `resolved` / `closed` — On Hold maps to `in_progress`, Canceled to `closed`), `short_description`, `sys_updated_on`, and `sys_updated_by`.
+
+The watermark boundary is **inclusive** (≥ `since`) so records sharing the watermark's second are never missed; de-duplicate by `sys_id` when applying changes.
+
+## Wiring up the bidirectional sync
+
+Both directions are driven from D&R rules — the extension holds no schedule of its own:
+
+- **LC → ServiceNow**: a D&R rule on Case events calls `mirror_case` with the case fields, pushing changes as they happen.
+- **ServiceNow → LC**: a scheduled D&R rule periodically calls `pull_incident_changes`, passing back the watermark from the previous run, and applies the returned changes to Cases.
+
+Because `pull_incident_changes` excludes the integration user's own writes, the LC → SN → LC round trip does not re-import what the extension itself mirrored.
+
+## Detection & Response
+
+Example response action that opens a ServiceNow incident for a detection:
+
+```yaml
+- action: extension request
+  extension action: create_incident
+  extension name: ext-servicenow
+  extension request:
+    short_description: '{{ .cat }} - {{ .routing.hostname }}'
+    description: '{{ .event }}'
+    urgency: 2
+    impact: 2
+    correlation_display: '{{ "LimaCharlie" }}'
+```
+
+> **Wrap literal strings in `{{ "..." }}`.**
+> Values under `extension request` are evaluated as templates. A bare string without `{{ }}` is interpreted as a [gjson](https://github.com/tidwall/gjson) path against the event and, if it doesn't resolve, the key is silently dropped from the payload.
+
+`extension request` actions are fire-and-forget — the rule engine does not surface the response back into the rule's evaluation context, so the freshly-created incident `sys_id` is not available to a subsequent action in the same rule. Workflows that need to chain (create an incident, attach a file, add notes) belong in a [Playbook](../limacharlie/playbook.md) or an AI agent, which can hold the `sys_id` between calls.
+
+## Notes
+
+- Reference fields (`assignment_group`, `assigned_to`, `caller_id`) take **sys_ids**, not display names — resolve names first with `query_table`.
+- ServiceNow rate limiting (`429`) is honored once per request with a `Retry-After` cap of 5 seconds; a persistent `429` surfaces to the caller.
+- ServiceNow can return HTTP `200` with a `{"status": "failure"}` envelope when a business rule or data policy aborts the operation — the extension treats this as an error, not a success.
+- `correlation_id` and `correlation_display` values are sanitized (encoded-query delimiters stripped) on both the write and the lookup path, keeping upserts idempotent even for hostile values.
+- OAuth tokens are refreshed automatically; rotating a secret in Secrets Manager takes effect after the next surfaced `401` evicts the cached client.
+- Errors are surfaced as `servicenow api <status> on <path>: <message>`.

--- a/docs/5-integrations/extensions/third-party/servicenow.md
+++ b/docs/5-integrations/extensions/third-party/servicenow.md
@@ -151,7 +151,8 @@ Idempotently upsert a ServiceNow incident from a LimaCharlie Case. The incident 
 | `classification` | string | Case classification (appended to the description). |
 | `summary` | string | Case summary — becomes the incident subject (first line, truncated to 160 chars) and description. |
 | `conclusion` | string | Case conclusion — appended to the description; used as `close_notes` on terminal states. |
-| `assignees` / `tags` | list of string | Appended to the description. |
+| `tags` | list of string | Appended to the description. |
+| `assignees` | list of string | Accepted, but not currently reflected on the incident. |
 | `correlation_display` | string | Override the configured label for this mirror. |
 | `sync_note` | string | Optional work note recording the sync on the incident. |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ nav:
               - Microsoft 365: 2-sensors-deployment/adapters/types/microsoft-365.md
               - Slack Audit: 2-sensors-deployment/adapters/types/slack-audit-logs.md
               - Google Workspace: 2-sensors-deployment/adapters/types/google-workspace.md
+              - Gmail: 2-sensors-deployment/adapters/types/gmail.md
               - Atlassian: 2-sensors-deployment/adapters/types/atlassian.md
               - HubSpot: 2-sensors-deployment/adapters/types/hubspot.md
               - Zendesk: 2-sensors-deployment/adapters/types/zendesk.md
@@ -423,12 +424,15 @@ nav:
               - Govee: 5-integrations/extensions/third-party/govee.md
               - HaloPSA: 5-integrations/extensions/third-party/halopsa.md
               - Hayabusa: 5-integrations/extensions/third-party/hayabusa.md
+              - Microsoft Response: 5-integrations/extensions/third-party/microsoft-response.md
               - NIMS: 5-integrations/extensions/third-party/nims.md
               - OTX: 5-integrations/extensions/third-party/otx.md
               - PagerDuty: 5-integrations/extensions/third-party/pagerduty.md
               - Plaso: 5-integrations/extensions/third-party/plaso.md
               - Renigma: 5-integrations/extensions/third-party/renigma.md
               - SecureAnnex: 5-integrations/extensions/third-party/secureannex.md
+              - SentinelOne: 5-integrations/extensions/third-party/sentinelone.md
+              - ServiceNow: 5-integrations/extensions/third-party/servicenow.md
               - Strelka: 5-integrations/extensions/third-party/strelka.md
               - ThreatLocker: 5-integrations/extensions/third-party/threatlocker.md
               - Twilio: 5-integrations/extensions/third-party/twilio.md


### PR DESCRIPTION
## Summary

Documents the four recently added integrations:

**New extension pages** (`docs/5-integrations/extensions/third-party/`):
- **Microsoft Response** (`ext-microsoft-response`) — Entra ID identity containment, Identity Protection, group containment, Intune device actions, Defender for Endpoint machine response and custom indicators. Includes the least-privilege app-registration permission matrix and sovereign-cloud overrides.
- **SentinelOne** (`ext-sentinelone`) — agent isolation/scan, threat mitigation/verdict/incident/notes, hash blocklisting, tenant reads, plus the generic `api_call` passthrough.
- **ServiceNow** (`ext-servicenow`) — incident lifecycle, notes/attachments, CMDB lookup, Table API escape hatch, and the bidirectional Case mirroring model (`mirror_case` / `pull_incident_changes` with watermark + echo-loop guard).

**New adapter page** (`docs/2-sensors-deployment/adapters/types/`):
- **Gmail** — single/multi-mailbox collection (static list or Workspace auto-discovery), message telemetry plus the opt-in BEC capabilities (filters, forwarding, send-as, delegates, IMAP/POP, vacation, history), each shipping its own event type on the dedicated `gmail` platform.

ThreatLocker (extension + adapter) and Check Point Harmony already have current pages, so no changes there.

**Housekeeping:** nav entries in `mkdocs.yml`, third-party index entries, and the `cato` / `gmail` platform identifiers added to the sensor-selector reference in `CLAUDE.md`.

`markdownlint-cli2` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)