### PR TITLE
Document the `app` config hive

### DIFF
--- a/docs/7-administration/config-hive/apps.md
+++ b/docs/7-administration/config-hive/apps.md
@@ -57,13 +57,13 @@ Records use a strict unmarshal: unknown fields are rejected. The maximum record 
 
 ## Permissions
 
-Managing records in the `app` hive currently reuses the `playbook.*` permission set:
+Managing records in the `app` hive requires the `app.*` permission set:
 
-- `playbook.get`
-- `playbook.set`
-- `playbook.del`
-- `playbook.get.mtd`
-- `playbook.set.mtd`
+- `app.get`
+- `app.set`
+- `app.del`
+- `app.get.mtd`
+- `app.set.mtd`
 
 !!! note
     These permissions gate who can **manage app records**. They are entirely separate from an app's own `required_permissions`, which are minted into the per-viewer iframe JWT. Do not conflate the two.
@@ -346,5 +346,5 @@ Managing records in the `app` hive currently reuses the `playbook.*` permission 
 
 ## See Also
 
-- [Permissions Reference](../../8-reference/permissions.md) -- The `playbook.*` permissions that gate app record management.
+- [Permissions Reference](../../8-reference/permissions.md) -- The `app.*` permissions that gate app record management.
 - [AI Sessions](../../9-ai-sessions/index.md) -- AI-driven workflows that author and consume LimaCharlie configuration.

--- a/docs/7-administration/config-hive/apps.md
+++ b/docs/7-administration/config-hive/apps.md
@@ -1,0 +1,350 @@
+# Config Hive: Apps
+
+The `app` hive stores user-authored, AI-generated mini web applications. Each record holds a single, self-contained HTML document (HTML plus inline JavaScript and CSS) that the LimaCharlie web UI renders inside a sandboxed `<iframe>`. The result is a small custom "app" that users can build conversationally through AI and surface throughout the LimaCharlie console.
+
+Because each app is a single self-contained document, there are no external asset fetches to authorize and no build step: the whole app is content-addressed by the record's etag. The `schema_version` field exists so the format can evolve to a multi-asset layout later without breaking existing records.
+
+## Security Model
+
+An app frequently needs to call LimaCharlie APIs on behalf of the user viewing it. To make that possible, the host mints a **user JWT scoped down to a subset of permissions** and hands it to the iframe. The granted set is always the intersection of what the app declares and what the viewer actually holds:
+
+```text
+granted_to_iframe = required_permissions ∩ viewing_user_permissions
+```
+
+A viewer can therefore never gain authority they don't already have. To also close the classic "confused deputy" hole — where a low-privilege author crafts an app requesting powerful permissions that only become active when an admin opens it — the following invariants are enforced at **write time**:
+
+1. **Every declared permission must be a real, JWT-issuable permission.** Typos and invented strings are rejected.
+2. **No permission may be a root/backend-only permission.** Those are never minted into a user JWT.
+3. **The author must already hold every permission they declare.** You cannot author an app that requests authority you do not yourself possess. (Trusted root/backend writes are exempt, so the platform can provision apps on a user's behalf.)
+
+As defense in depth, the iframe's network egress is also allowlisted via the iframe's Content-Security-Policy `connect-src`, across two dimensions:
+
+- `allowed_origins` — arbitrary third-party `https` origins the app opts into. `https` is mandatory so the scoped JWT can never be exfiltrated over cleartext.
+- `required_services` — first-party LimaCharlie services beyond the always-available `api.limacharlie.io`. Authors name services from a curated allowlist rather than hardcoding internal hostnames (which differ per deployment); the host resolves each to the org's concrete, region-specific origin. The same scoped JWT is used against them, and each service independently enforces the declared permissions — so `required_services` brokers only *where* the token may go, never *what* it may do.
+
+## Format
+
+```json
+{
+    "schema_version": 1,
+    "display_name": "My App",
+    "description": "A short blurb describing what the app does.",
+    "icon": "🚀",
+    "html": "<!doctype html><html>…</html>",
+    "required_permissions": ["sensor.get", "sensor.task"],
+    "allowed_origins": ["https://example.com"],
+    "required_services": ["search", "cases"],
+    "locations": ["standalone", "within_a_sensor"],
+    "expected_context": ["sid", "atom"]
+}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `schema_version` | No | App content format version. `0`/omitted is treated as v1. A version newer than the platform supports is rejected. Current max: `1`. |
+| `display_name` | Yes | Human label shown in the launcher and embeds (max 256 chars). The record *name* is the stable slug/id; this is the pretty name. |
+| `description` | No | Optional blurb describing the app (max 4096 chars). |
+| `icon` | No | Optional emoji, icon id, or small data-URI for the launcher (max 256 chars). |
+| `html` | Yes | The single self-contained document rendered in the iframe. |
+| `required_permissions` | No | LimaCharlie permissions the app's JS needs. The iframe JWT is scoped to the intersection of this set and the viewer's own permissions. Each entry must be a real, non-root, JWT-issuable permission that the author already holds. May be empty for a purely static app (the safest kind). Max 64. |
+| `allowed_origins` | No | Allowlist of external `https` origins the app's JS may contact. Each must be scheme + host only (no path, query, fragment, or credentials). Empty means "LimaCharlie only". Max 32. |
+| `required_services` | No | First-party LimaCharlie services the app needs to reach beyond `api.limacharlie.io`. Valid values: `search`, `replay`, `cases`, `ai`. Max 16. |
+| `locations` | No | Where the app may be surfaced in the UI: `standalone`, `within_a_sensor`, `within_a_detection`, `within_a_case`, `within_a_dr_rule`. Max 8. |
+| `expected_context` | No | Context keys the app expects when embedded (e.g. `sid`, `atom`, `detection_id`), so the host passes the right identifiers from the surrounding object into the iframe. Max 32. |
+
+Records use a strict unmarshal: unknown fields are rejected. The maximum record size is 10 MB; larger documents are rejected.
+
+## Permissions
+
+Managing records in the `app` hive currently reuses the `playbook.*` permission set:
+
+- `playbook.get`
+- `playbook.set`
+- `playbook.del`
+- `playbook.get.mtd`
+- `playbook.set.mtd`
+
+!!! note
+    These permissions gate who can **manage app records**. They are entirely separate from an app's own `required_permissions`, which are minted into the per-viewer iframe JWT. Do not conflate the two.
+
+## Programmatic Management
+
+!!! info "Prerequisites"
+    All API and SDK examples require an API key with the appropriate permissions. See [API Keys](../access/api-keys.md) for setup instructions.
+
+### List Apps
+
+=== "REST API"
+
+    ```bash
+    curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/app/YOUR_OID" \
+      -H "Authorization: Bearer $LC_JWT"
+    ```
+
+=== "Python"
+
+    ```python
+    from limacharlie.client import Client
+    from limacharlie.sdk.organization import Organization
+    from limacharlie.sdk.hive import Hive
+
+    client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+    org = Organization(client)
+    hive = Hive(org, "app")
+    records = hive.list()
+    for name, record in records.items():
+        print(name, record.data)
+    ```
+
+=== "Go"
+
+    ```go
+    package main
+
+    import (
+        "fmt"
+        limacharlie "github.com/refractionPOINT/go-limacharlie/limacharlie"
+    )
+
+    func main() {
+        client, _ := limacharlie.NewClient(limacharlie.ClientOptions{
+            OID:    "YOUR_OID",
+            APIKey: "YOUR_API_KEY",
+        }, nil)
+        org, _ := limacharlie.NewOrganization(client)
+        hc := limacharlie.NewHiveClient(org)
+
+        records, _ := hc.List(limacharlie.HiveArgs{
+            HiveName:     "app",
+            PartitionKey: "YOUR_OID",
+        })
+        for name, record := range records {
+            fmt.Println(name, record.Data)
+        }
+    }
+    ```
+
+=== "CLI"
+
+    ```bash
+    limacharlie hive list --hive-name app
+    ```
+
+### Get an App
+
+=== "REST API"
+
+    ```bash
+    curl -s -X GET \
+      "https://api.limacharlie.io/v1/hive/app/YOUR_OID/my-app/data" \
+      -H "Authorization: Bearer $LC_JWT"
+    ```
+
+=== "Python"
+
+    ```python
+    from limacharlie.client import Client
+    from limacharlie.sdk.organization import Organization
+    from limacharlie.sdk.hive import Hive
+
+    client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+    org = Organization(client)
+    hive = Hive(org, "app")
+    record = hive.get("my-app")
+    print(record.data)
+    ```
+
+=== "Go"
+
+    ```go
+    package main
+
+    import (
+        "fmt"
+        limacharlie "github.com/refractionPOINT/go-limacharlie/limacharlie"
+    )
+
+    func main() {
+        client, _ := limacharlie.NewClient(limacharlie.ClientOptions{
+            OID:    "YOUR_OID",
+            APIKey: "YOUR_API_KEY",
+        }, nil)
+        org, _ := limacharlie.NewOrganization(client)
+        hc := limacharlie.NewHiveClient(org)
+
+        record, _ := hc.Get(limacharlie.HiveArgs{
+            HiveName:     "app",
+            PartitionKey: "YOUR_OID",
+            Key:          "my-app",
+        })
+        fmt.Println(record.Data)
+    }
+    ```
+
+=== "CLI"
+
+    ```bash
+    limacharlie hive get --hive-name app --key my-app
+    ```
+
+### Create / Update an App
+
+!!! warning
+    New hive records are created **disabled by default**. Each example below explicitly enables the app — drop the `enabled` portion if you want the app to start disabled and enable it later via `limacharlie hive enable --hive-name app --key …`.
+
+=== "REST API"
+
+    ```bash
+    curl -s -X POST \
+      "https://api.limacharlie.io/v1/hive/app/YOUR_OID/my-app/data" \
+      -H "Authorization: Bearer $LC_JWT" \
+      -d 'data={"display_name":"My App","html":"<!doctype html><html><body>Hello</body></html>","required_permissions":[]}' \
+      -d 'usr_mtd={"enabled":true}'
+    ```
+
+=== "Python"
+
+    ```python
+    from limacharlie.client import Client
+    from limacharlie.sdk.organization import Organization
+    from limacharlie.sdk.hive import Hive, HiveRecord
+
+    client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+    org = Organization(client)
+    hive = Hive(org, "app")
+    record = HiveRecord(
+        "my-app",
+        data={
+            "display_name": "My App",
+            "html": "<!doctype html><html><body>Hello</body></html>",
+            "required_permissions": [],
+        },
+        enabled=True,
+    )
+    hive.set(record)
+    ```
+
+=== "Go"
+
+    ```go
+    package main
+
+    import (
+        limacharlie "github.com/refractionPOINT/go-limacharlie/limacharlie"
+    )
+
+    func main() {
+        client, _ := limacharlie.NewClient(limacharlie.ClientOptions{
+            OID:    "YOUR_OID",
+            APIKey: "YOUR_API_KEY",
+        }, nil)
+        org, _ := limacharlie.NewOrganization(client)
+        hc := limacharlie.NewHiveClient(org)
+
+        enabled := true
+        hc.Add(limacharlie.HiveArgs{
+            HiveName:     "app",
+            PartitionKey: "YOUR_OID",
+            Key:          "my-app",
+            Data: limacharlie.Dict{
+                "display_name":         "My App",
+                "html":                 "<!doctype html><html><body>Hello</body></html>",
+                "required_permissions": []string{},
+            },
+            Enabled: &enabled,
+        })
+    }
+    ```
+
+=== "CLI"
+
+    ```bash
+    limacharlie hive set --hive-name app --key my-app \
+      --input-file app.json --enabled
+    ```
+
+    Where `app.json` contains:
+
+    ```json
+    {
+        "data": {
+            "display_name": "My App",
+            "html": "<!doctype html><html><body>Hello</body></html>",
+            "required_permissions": []
+        }
+    }
+    ```
+
+    The `--enabled` flag creates-and-enables the record in one shot. Omit it (and `usr_mtd.enabled` in the file) to leave the app disabled until you call `limacharlie hive enable --hive-name app --key my-app`.
+
+### Delete an App
+
+=== "REST API"
+
+    ```bash
+    curl -s -X DELETE \
+      "https://api.limacharlie.io/v1/hive/app/YOUR_OID/my-app" \
+      -H "Authorization: Bearer $LC_JWT"
+    ```
+
+=== "Python"
+
+    ```python
+    from limacharlie.client import Client
+    from limacharlie.sdk.organization import Organization
+    from limacharlie.sdk.hive import Hive
+
+    client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+    org = Organization(client)
+    hive = Hive(org, "app")
+    hive.delete("my-app")
+    ```
+
+=== "Go"
+
+    ```go
+    package main
+
+    import (
+        limacharlie "github.com/refractionPOINT/go-limacharlie/limacharlie"
+    )
+
+    func main() {
+        client, _ := limacharlie.NewClient(limacharlie.ClientOptions{
+            OID:    "YOUR_OID",
+            APIKey: "YOUR_API_KEY",
+        }, nil)
+        org, _ := limacharlie.NewOrganization(client)
+        hc := limacharlie.NewHiveClient(org)
+
+        hc.Remove(limacharlie.HiveArgs{
+            HiveName:     "app",
+            PartitionKey: "YOUR_OID",
+            Key:          "my-app",
+        })
+    }
+    ```
+
+=== "CLI"
+
+    ```bash
+    limacharlie hive delete --hive-name app --key my-app --confirm
+    ```
+
+### Enable / Disable an App
+
+=== "CLI"
+
+    ```bash
+    # Disable an app:
+    limacharlie hive disable --hive-name app --key my-app
+    # Re-enable:
+    limacharlie hive enable --hive-name app --key my-app
+    ```
+
+## See Also
+
+- [Permissions Reference](../../8-reference/permissions.md) -- The `playbook.*` permissions that gate app record management.
+- [AI Sessions](../../9-ai-sessions/index.md) -- AI-driven workflows that author and consume LimaCharlie configuration.

--- a/docs/7-administration/config-hive/index.md
+++ b/docs/7-administration/config-hive/index.md
@@ -9,6 +9,7 @@ The Config Hive is LimaCharlie's hierarchical configuration store. It provides a
 - [Secrets](secrets.md) - Secure credential management
 - [YARA](yara.md) - YARA rule storage and management
 - [Cloud Sensors](cloud-sensors.md) - Cloud sensor configurations
+- [Apps](apps.md) - User-authored, AI-generated mini web applications
 
 ## Usage
 

--- a/docs/8-reference/permissions.md
+++ b/docs/8-reference/permissions.md
@@ -163,6 +163,16 @@ LimaCharlie uses a granular permission system that controls access to all platfo
 | playbook.get.mtd | View playbook metadata only |
 | playbook.set.mtd | Modify playbook metadata only |
 
+### Apps
+
+| Permission | Description |
+| --- | --- |
+| app.get | Access app records |
+| app.set | Create and modify app records |
+| app.del | Delete app records |
+| app.get.mtd | View app metadata only |
+| app.set.mtd | Modify app metadata only |
+
 ### External Adapters
 
 | Permission | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -506,6 +506,7 @@ nav:
           - D&R Rules: 7-administration/config-hive/dr-rules.md
           - YARA: 7-administration/config-hive/yara.md
           - Cloud Sensors: 7-administration/config-hive/cloud-sensors.md
+          - Apps: 7-administration/config-hive/apps.md
 
   - Reference:
       - Overview: 8-reference/index.md


### PR DESCRIPTION
## Summary

Documents the new `app` config hive introduced in [legion_config_hive](https://github.com/refractionPOINT/legion_config_hive) (`Add \`app\` hive for AI-generated iframe web apps` and follow-ups). The `app` hive stores user-authored, AI-generated mini web applications — each record is a single self-contained HTML document rendered in a sandboxed `<iframe>` in the LimaCharlie web UI.

## What's added

- **New page** `docs/7-administration/config-hive/apps.md` covering:
  - What the hive is and the single-document rationale (`schema_version` forward-compat).
  - The **security model**: the per-viewer scoped iframe JWT (`granted = required_permissions ∩ viewer_permissions`) and the three write-time invariants that defeat the confused-deputy escalation (perm must be real/JWT-issuable, non-root, and already held by the author).
  - CSP egress allowlisting via `allowed_origins` (third-party https) and `required_services` (first-party `search`/`replay`/`cases`/`ai`).
  - Full record **format** table for every field, with size/count bounds and the 10 MB record cap.
  - The dedicated `app.*` permissions that gate app-record management (distinct from the app's own `required_permissions`).
  - REST / Python / Go / CLI management examples (list, get, create/update, delete, enable/disable).
- Added an **Apps** section to the [Permissions Reference](docs/8-reference/permissions.md) for the new `app.get/set/del/get.mtd/set.mtd` permissions (added in go-essentials).
- Linked the page from the **Config Hive index** and the **mkdocs nav**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)