### PR TITLE
docs(story-tags): add the `app` node type slug

### DIFF
--- a/docs/8-reference/story-tags.md
+++ b/docs/8-reference/story-tags.md
@@ -72,6 +72,7 @@ Used in `TARGET_TYPE` for `links:` and `edge-label:` tags, and as the `type` fie
 | AI          | `ai-agent`        | Hive `ai_agent`             |
 | AI          | `ai-skill`        | Hive `ai_skill`             |
 | AI          | `ai-memory`       | Hive `ai_memory`            |
+| Interface   | `app`             | Hive `app` (sandboxed iframe mini-app / dashboard) |
 
 ### Drop rules (assembler)
 


### PR DESCRIPTION
## Summary

Adds `app` to the canonical type-slug table in the Story Tag Namespace reference. Apps — sandboxed iframe mini-apps / custom dashboards stored in the `app` hive ([legion_config_hive](https://github.com/refractionPOINT/legion_config_hive/pull/297)) — can now be tagged `lc:story:*` and surface as nodes in an assembled story.

The assembler-side change (recognizing the `app` slug, the hive→type mapping, and the `app → ai-agent/dr-rule/lookup` "visualizes" declared edges) is in lc_api-go PR #797; this documents the slug so authors know `app` is a valid `TARGET_TYPE` / node type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)