### PR TITLE
docs(sensor): add CLI & environment reference, document undocumented agent knobs

### DIFF
--- a/docs/2-sensors-deployment/connectivity.md
+++ b/docs/2-sensors-deployment/connectivity.md
@@ -22,6 +22,12 @@ To enable this, set the same environment variable to the `-` value, like `LC_PRO
 
 Also on Windows, in some cases the environment variable changes do not propagate to all processes in the expected way. Usually a reboot of the machine will fix it, but for machines that cannot be rebooted you have the ability to set a special value to the environment variable (deletion is usually problematic but setting a var works) that will disable the proxy specifically: `!`. So if you set the `LC_PROXY` variable to `!` (exclamation mark), the proxy will be disabled.
 
+## Certificate Revocation Checks on Restricted Networks (Windows)
+
+On Windows, when the sensor verifies code signatures it performs certificate revocation checks, which can attempt to reach CRL/OCSP endpoints over the network. On air-gapped or tightly restricted networks those lookups may stall or fail.
+
+Setting the `LC_LOCAL_CACHE_ONLY_REVOCATION_CHECK` environment variable to `1` (or `true`) on the sensor process makes these revocation checks use only the local cache and never reach out to the network.
+
 Similar to agents, Sensors send telemetry to the LimaCharlie platform in the form of EDR telemetry or forwarded logs. Sensors are offered as a scalable, serverless solution for securely connecting endpoints of an organization to the cloud.
 
 In LimaCharlie, an Organization represents a tenant within the Agentic SecOps Workspace, providing a self-contained environment to manage security data, configurations, and assets independently. Each Organization has its own sensors, detection rules, data sources, and outputs, offering complete control over security operations. This structure enables flexible, multi-tenant setups, ideal for managed security providers or enterprises managing multiple departments or clients.

--- a/docs/2-sensors-deployment/endpoint-agent/cli-reference.md
+++ b/docs/2-sensors-deployment/endpoint-agent/cli-reference.md
@@ -1,0 +1,96 @@
+# Agent CLI & Environment Reference
+
+This page is the single reference for the command-line options, environment
+variables, and local files supported by the LimaCharlie endpoint agent (the
+on-disk sensor binary, named `rphcp` once installed). The platform-specific
+installation pages link here for the full list.
+
+All options below are available in the released sensor. Internal/debug-only
+flags are intentionally not documented.
+
+## Command-Line Options
+
+The same binary is used both to install/manage the service and to run it. When
+run from the command line you can pass the following options. Most management
+actions require **root** (Linux/macOS) or **Administrator** (Windows).
+
+| Option | Long form | Description |
+|--------|-----------|-------------|
+| `-i <KEY>` | `--install` | Install as a service using the specified installation key, then enroll. |
+| `-d <KEY>` | `--deployment` | Run with the installation key without performing a permanent installation (temporary/foreground enrollment). Pass `-d -` to read the key from the environment or a local file (see [Installation key sources](#installation-key-sources)). |
+| `-u` | `--upgrade` | Upgrade the installed service in place using this binary. Requires sensor **4.33.28+**. See [Service Upgrades](service-upgrades.md). |
+| `-r` | `--uninstall` | Uninstall the service, leaving the identity files on disk. |
+| `-c` | `--uninstall-clean` | Uninstall the service and delete the identity/config files (`hcp`, `hcp_hbs`, `hcp_conf`). |
+| `-t` | `--vdi` | Write the VDI delay file to postpone enrollment by 24 hours, for use when baking golden images. See [VDI Templates](vdi/templates.md). |
+| `-H` | `--health` | Run the sensor health check and write a diagnostic report. See [Sensor Troubleshooting Utility](../../8-reference/faq/troubleshooting.md#sensor-troubleshooting-utility). Requires sensor **4.33.6+**. |
+| `-v` | `--verbose` | Enable verbose logging output (equivalent to setting `LC_VERBOSE=1`). |
+| `-V` | `--version` | Print the sensor build version and exit. |
+| `-w` | `--service` | Run as a service. This is the form used by the OS service manager (SCM, launchd, systemd); you normally do not invoke it directly. |
+| `-h` | `--help` | Print the list of accepted options. |
+
+## Environment Variables
+
+These environment variables are read by the sensor process. For installed
+services, set them through your service manager (systemd unit, launchd plist,
+or the Windows service environment) so the running service inherits them.
+
+### Enrollment
+
+| Variable | Platforms | Description |
+|----------|-----------|-------------|
+| `LC_INSTALLATION_KEY` | All | Installation key used when enrolling with `-d -` (or via packaged installers). Takes priority over the local key file. |
+
+### Logging & Troubleshooting
+
+| Variable | Platforms | Description |
+|----------|-----------|-------------|
+| `LC_VERBOSE` | All | Set to `1`/`true` to enable verbose logging (same effect as the `-v` flag). |
+| `RPAL_LOG_LEVEL` | All | Sets the log verbosity. Accepted values: `off`, `error` (alias `critical`), `warning` (alias `warn`), `info`, `debug`. Defaults to `warning` in release builds. |
+| `RPAL_LOG_FILE` | All | Path to a file to write logs to. Setting this is the opt-in for logging on a release sensor — output is written to the file at `RPAL_LOG_LEVEL` (default `warning`). Without it, a release sensor stays silent unless `LC_VERBOSE` is set. |
+
+See [Enabling Verbose and File Logging](../../8-reference/faq/troubleshooting.md#enabling-verbose-and-file-logging)
+for usage examples.
+
+### Connectivity
+
+| Variable | Platforms | Description |
+|----------|-----------|-------------|
+| `LC_PROXY` | All | Route the cloud connection through an HTTP CONNECT proxy (e.g. `proxy.corp.com:8080`). Special values: `-` (Windows registry auto-detect) and `!` (disable). See [Sensor Connectivity](../connectivity.md#proxy-tunneling). |
+| `LC_LOCAL_CACHE_ONLY_REVOCATION_CHECK` | Windows | Set to `1`/`true` to make code-signature revocation checks (CRL/OCSP) use only the local cache and never reach out to the network. Useful on air-gapped or tightly restricted networks. |
+| `LC_DISABLE_REVERSE_DNS_HOSTNAME` | All | Set to `1`/`true` to skip reverse-DNS hostname resolution. See [Hostname Resolution](hostname-resolution.md). |
+
+### Data & Collection
+
+| Variable | Platforms | Description |
+|----------|-----------|-------------|
+| `LC_DATA_DIRECTORY` | All | Override the directory where the sensor stores its data and status files (default `/opt/limacharlie` on Linux, `/Library/Application Support/limacharlie` on macOS, `C:\ProgramData\limacharlie` on Windows). Useful on non-standard or hardened distributions where the default path is not writable. |
+| `LC_DNS_IFACE` | Linux | Restrict DNS tracking to a single named network interface (e.g. `eth0`). When unset, all interfaces are watched. |
+| `DISABLE_NETLINK` | Linux | Set to any value to skip the netlink (`CN_PROC`) process connector and fall back to `/proc` polling. No effect when eBPF is in use. See [Disabling Netlink](linux/installation.md#disabling-netlink). |
+| `LC_MOD_LOAD_LOC` | Linux/macOS | Alternate directory for the sensor's temporary module-loading files, for hosts where the default location is restricted (e.g. SELinux). |
+| `HOST_FS` | Linux/macOS | Path to the host root filesystem when the sensor runs inside a container. See [Docker installation](docker/installation.md). |
+| `NET_NS` | Linux/macOS | Directory containing network namespaces (default `/var/run/docker/netns`) for namespace-aware network collection in containerized hosts. |
+
+### Upgrades
+
+| Variable | Platforms | Description |
+|----------|-----------|-------------|
+| `LC_UPGRADE_SKIP_VERSION_CHECK` | All | **Advanced.** Set to `1`/`true` to skip the version comparison during an in-place upgrade (`-u`), forcing the binary to replace the installed service even when it is not newer. Use only when deliberately re-applying or downgrading a known-good build. |
+
+## Local Files
+
+| File | Default location | Purpose |
+|------|------------------|---------|
+| `lc_installation_key.txt` | Current working directory | Optional source of the installation key when using `-d -`. |
+| `hcp`, `hcp_hbs`, `hcp_conf` | `/etc` (Linux), `/usr/local` (macOS), `C:\Windows\System32` (Windows) | Identity and configuration files written at install time. Removed by `-c`; left in place by `-r`. |
+| `hcp_vdi` / `hcp_vdi.dat` | `/etc` or CWD (Linux), `/usr/local` (macOS), `C:\Windows\System32` (Windows) | VDI delay file holding the epoch timestamp until which enrollment is postponed. See [VDI Templates](vdi/templates.md). |
+| `hcp.log` | `./hcp.log` (Linux), `/usr/local/hcp.log` (macOS), `C:\Windows\System32\hcp.log` (Windows) | First-connection connectivity log. See [Sensor Not Connecting](../../8-reference/faq/troubleshooting.md#sensor-not-connecting). |
+| `hcp_hbs_status.json` | Sensor data directory (see `LC_DATA_DIRECTORY`) | Local status file with sensor ID, org ID, version, and uptime. |
+| `sensor_health_YYYY_MM_DD_HH_MM.json` | Sensor data directory (see `LC_DATA_DIRECTORY`) | Output of the `-H` health check. |
+
+## Installation Key Sources
+
+When `-i`/`-d` is given `-` instead of a literal key, the sensor looks for the
+installation key in this order:
+
+1. The `LC_INSTALLATION_KEY` environment variable.
+2. The `lc_installation_key.txt` file in the current working directory.

--- a/docs/2-sensors-deployment/endpoint-agent/cli-reference.md
+++ b/docs/2-sensors-deployment/endpoint-agent/cli-reference.md
@@ -45,8 +45,8 @@ or the Windows service environment) so the running service inherits them.
 | Variable | Platforms | Description |
 |----------|-----------|-------------|
 | `LC_VERBOSE` | All | Set to `1`/`true` to enable verbose logging (same effect as the `-v` flag). |
-| `RPAL_LOG_LEVEL` | All | Sets the log verbosity. Accepted values: `off`, `error` (alias `critical`), `warning` (alias `warn`), `info`, `debug`. Defaults to `warning` in release builds. |
-| `RPAL_LOG_FILE` | All | Path to a file to write logs to. Setting this is the opt-in for logging on a release sensor — output is written to the file at `RPAL_LOG_LEVEL` (default `warning`). Without it, a release sensor stays silent unless `LC_VERBOSE` is set. |
+| `RPAL_LOG_LEVEL` | All | Sets the log verbosity. Accepted values: `off`, `error` (alias `critical`), `warning` (alias `warn`), `info`, `debug`. Defaults to `warning` in release builds. **In released sensors `warning` is the most verbose level that produces output — `info` and `debug` log statements are compiled out, so those values have no additional effect.** |
+| `RPAL_LOG_FILE` | All | Path to a file to write logs to. Setting this is the opt-in for logging on a release sensor — output is written to the file at `RPAL_LOG_LEVEL` (`warning` and above). Without it, a release sensor stays silent unless `LC_VERBOSE` is set. The log can contain operational details about the host; treat it as potentially sensitive and remove it once you are done troubleshooting. |
 
 See [Enabling Verbose and File Logging](../../8-reference/faq/troubleshooting.md#enabling-verbose-and-file-logging)
 for usage examples.

--- a/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
@@ -171,6 +171,16 @@ You may also pass the value `-` instead of the `INSTALLATION_KEY` like: `-d -`. 
 
 By default, when running on a kernel where eBPF is unavailable, the Linux sensor uses the netlink proc connector (`CN_PROC`) to receive real-time process events. In some rare configurations this auto-detection may be unwanted — for example when another agent on the host already consumes the same connector — and netlink usage can be disabled by setting the environment variable `DISABLE_NETLINK` to any value on the sensor process. With netlink disabled and no eBPF available, the agent falls back to user-mode `/proc` polling. This setting has no effect when eBPF is the active acquisition path.
 
+### Custom Data Directory
+
+The sensor stores its data and status files under `/opt/limacharlie` by default. On non-standard or hardened distributions where that path is not writable, you can point the sensor at a different directory by setting the `LC_DATA_DIRECTORY` environment variable on the sensor process to an absolute path. The directory must exist and be writable by the sensor.
+
+### Restricting DNS Tracking to an Interface
+
+By default DNS tracking watches all network interfaces. To restrict it to a single interface, set the `LC_DNS_IFACE` environment variable to the interface name (for example `LC_DNS_IFACE=eth0`) on the sensor process.
+
+For the complete list of supported options, see the [Agent CLI & Environment Reference](../cli-reference.md).
+
 ## Uninstalling the Agent
 
 For additional agent uninstall options, see [Endpoint Agent Uninstallation](../uninstallation.md)

--- a/docs/2-sensors-deployment/endpoint-agent/macos/installation-older.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/installation-older.md
@@ -7,15 +7,18 @@ This document provides details of how to install, verify, and uninstall the Lima
 When running the installer from the command line, you can pass the following arguments:
 
 ```text
--v: display build version.
--q: quiet; do not display banner.
+-v: verbose logging output.
+-V: display the sensor build version.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
 -r: uninstall executable as a service.
 -c: uninstall executable as a service and delete identity files.
+-H: verify sensor health and write a diagnostic report.
 -w: executable is running as a macOS service.
 -h: displays the list of accepted arguments.
 ```
+
+For the complete list of options, environment variables, and local files, see the [Agent CLI & Environment Reference](../cli-reference.md).
 
 ## Installation Flow
 

--- a/docs/2-sensors-deployment/endpoint-agent/macos/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/installation.md
@@ -7,15 +7,18 @@ This document provides details of how to install, verify, and uninstall the Lima
 When running the installer from the command line, you can pass the following arguments:
 
 ```text
--v: display build version.
--q: quiet; do not display banner.
+-v: verbose logging output.
+-V: display the sensor build version.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
 -r: uninstall executable as a service.
 -c: uninstall executable as a service and delete identity files.
+-H: verify sensor health and write a diagnostic report.
 -w: executable is running as a macOS service.
 -h: displays the list of accepted arguments.
 ```
+
+For the complete list of options, environment variables, and local files, see the [Agent CLI & Environment Reference](../cli-reference.md).
 
 ## Installation Flow
 

--- a/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
+++ b/docs/2-sensors-deployment/endpoint-agent/macos/sequoia.md
@@ -7,15 +7,18 @@ This document provides details of how to install, verify, and uninstall the Lima
 When running the installer from the command line, you can pass the following arguments:
 
 ```text
--v: display build version.
--q: quiet; do not display banner.
+-v: verbose logging output.
+-V: display the sensor build version.
 -d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
 -r: uninstall executable as a service.
 -c: uninstall executable as a service and delete identity files.
+-H: verify sensor health and write a diagnostic report.
 -w: executable is running as a macOS service.
 -h: displays the list of accepted arguments.
 ```
+
+For the complete list of options, environment variables, and local files, see the [Agent CLI & Environment Reference](../cli-reference.md).
 
 ## Installation Flow
 

--- a/docs/2-sensors-deployment/endpoint-agent/service-upgrades.md
+++ b/docs/2-sensors-deployment/endpoint-agent/service-upgrades.md
@@ -62,3 +62,10 @@ The `-u` flag requires sensor version **4.33.28 or later**.
     ```bat
     hcp_win_x64_release_4.33.28.exe -u
     ```
+
+## Advanced: Forcing an Upgrade
+
+By default an in-place upgrade (`-u`) only replaces the installed service when the supplied binary is newer than what is installed. To re-apply or move to a build that is not strictly newer (for example to re-deploy a known-good version), set the `LC_UPGRADE_SKIP_VERSION_CHECK` environment variable to `1` (or `true`) on the upgrade process. This bypasses the version comparison and replaces the installed service unconditionally.
+
+!!! warning
+Use this only when you intend to override the version check. The automatic rollback on a failed start still applies, but skipping the check makes it possible to deliberately downgrade the on-disk agent.

--- a/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/windows/installation.md
@@ -85,6 +85,8 @@ When running the installer from the command line, you can use the following opti
 | `-H` | Verify sensor health and installation |
 | `-h` | Display help message |
 
+For the complete list of options, environment variables, and local files, see the [Agent CLI & Environment Reference](../cli-reference.md).
+
 ## Installation Methods
 
 ### Method 1: Executable (EXE) Installation

--- a/docs/8-reference/faq/troubleshooting.md
+++ b/docs/8-reference/faq/troubleshooting.md
@@ -339,6 +339,39 @@ The log data is formatted similarly to the example below:
 }
 ```
 
+## Enabling Verbose and File Logging
+
+By default a released sensor logs almost nothing, to keep it quiet on production
+hosts. When diagnosing an issue you can raise the verbosity and route the output
+to a file using environment variables on the sensor process (set them in your
+systemd unit, launchd plist, or the Windows service environment so the running
+service inherits them):
+
+| Variable | Effect |
+| --- | --- |
+| `LC_VERBOSE` | Set to `1`/`true` to enable verbose logging (same as the `-v` flag). |
+| `RPAL_LOG_LEVEL` | Sets the verbosity. Accepted values: `off`, `error` (alias `critical`), `warning` (alias `warn`), `info`, `debug`. Defaults to `warning` in release builds. |
+| `RPAL_LOG_FILE` | Path to a log file. Setting this is the opt-in that turns on logging for a release sensor: output is written to the file at `RPAL_LOG_LEVEL`. Without it (and without `LC_VERBOSE`), a release sensor stays silent. |
+
+For example, to capture detailed logs to a file while reproducing an issue:
+
+=== "Linux / macOS"
+
+    ```bash
+    sudo RPAL_LOG_FILE=/tmp/lc_sensor.log RPAL_LOG_LEVEL=info ./rphcp -d -
+    ```
+
+=== "Windows"
+
+    ```bat
+    set RPAL_LOG_FILE=C:\Temp\lc_sensor.log
+    set RPAL_LOG_LEVEL=info
+    rphcp.exe -d -
+    ```
+
+See the [Agent CLI & Environment Reference](../../2-sensors-deployment/endpoint-agent/cli-reference.md)
+for the full list of supported options.
+
 ## Additional Help
 
 If these steps do not help, get in touch with us, and we will help you figure out the issue. The best way of contacting us is via our [Community Site](https://community.limacharlie.com/), followed by `support@limacharlie.io`.

--- a/docs/8-reference/faq/troubleshooting.md
+++ b/docs/8-reference/faq/troubleshooting.md
@@ -353,21 +353,26 @@ service inherits them):
 | `RPAL_LOG_LEVEL` | Sets the verbosity. Accepted values: `off`, `error` (alias `critical`), `warning` (alias `warn`), `info`, `debug`. Defaults to `warning` in release builds. |
 | `RPAL_LOG_FILE` | Path to a log file. Setting this is the opt-in that turns on logging for a release sensor: output is written to the file at `RPAL_LOG_LEVEL`. Without it (and without `LC_VERBOSE`), a release sensor stays silent. |
 
-For example, to capture detailed logs to a file while reproducing an issue:
+!!! note
+In released sensors, `warning` is the most verbose level that produces output. The `info` and `debug` log statements are compiled out of release builds, so setting `RPAL_LOG_LEVEL` to `info` or `debug` has no additional effect over `warning`.
+
+For example, to capture logs to a file while reproducing an issue:
 
 === "Linux / macOS"
 
     ```bash
-    sudo RPAL_LOG_FILE=/tmp/lc_sensor.log RPAL_LOG_LEVEL=info ./rphcp -d -
+    sudo RPAL_LOG_FILE=/tmp/lc_sensor.log RPAL_LOG_LEVEL=warning ./rphcp -d -
     ```
 
 === "Windows"
 
     ```bat
     set RPAL_LOG_FILE=C:\Temp\lc_sensor.log
-    set RPAL_LOG_LEVEL=info
+    set RPAL_LOG_LEVEL=warning
     rphcp.exe -d -
     ```
+
+The log file can contain operational details about the host, so treat it as potentially sensitive and remove it once you are done troubleshooting.
 
 See the [Agent CLI & Environment Reference](../../2-sensors-deployment/endpoint-agent/cli-reference.md)
 for the full list of supported options.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ nav:
       - Log Collection Guide: 2-sensors-deployment/log-collection-guide.md
       - Telemetry Index: 2-sensors-deployment/telemetry-index.md
       - Endpoint Agents:
+          - CLI & Environment Reference: 2-sensors-deployment/endpoint-agent/cli-reference.md
           - Windows:
               - Installation: 2-sensors-deployment/endpoint-agent/windows/installation.md
               - Custom MSI: 2-sensors-deployment/endpoint-agent/windows/custom-msi.md


### PR DESCRIPTION
## Summary

The endpoint agent's supported command-line options, environment variables, and local files were scattered across per-OS install pages, and several user-supported knobs weren't documented anywhere. This adds a consolidated reference and fills the gaps. Everything documented here is available in the released sensor (no debug/internal-only knobs).

## What's added

- **New page: Agent CLI & Environment Reference** (`endpoint-agent/cli-reference.md`) — single source of truth with three tables: CLI options (long + short forms), environment variables (grouped by purpose), and local files/paths per platform. Added to the nav under Endpoint Agents; per-OS install pages link to it.
- **Logging / troubleshooting** — new "Enabling Verbose and File Logging" section in the sensor troubleshooting FAQ covering `LC_VERBOSE`, `RPAL_LOG_LEVEL`, and `RPAL_LOG_FILE` (how to turn on logging on an otherwise-silent release sensor), with examples.
- **Linux install page** — documents `LC_DATA_DIRECTORY` (override data directory on non-standard/hardened distros) and `LC_DNS_IFACE` (restrict DNS tracking to one interface).
- **Connectivity page** — documents `LC_LOCAL_CACHE_ONLY_REVOCATION_CHECK` for air-gapped / tightly restricted networks (Windows signature-revocation checks stay local).
- **Service Upgrades page** — documents the advanced `LC_UPGRADE_SKIP_VERSION_CHECK` override for re-applying / downgrading the on-disk agent.

## What's fixed

- The three macOS installer option blocks listed `-v` as "display build version" (it's verbose logging) and listed an unsupported `-q`. Corrected `-v`, added `-V` (version) and `-H` (health), and removed `-q`.

## Validation

- `mkdocs build --strict` passes (internal links validated).
- `markdownlint-cli2` reports 0 errors across the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)