### PR TITLE
docs(ai-sessions): architecture, rich cards, session lifecycle, fork API & profile memory

### DIFF
--- a/docs/9-ai-sessions/api-reference.md
+++ b/docs/9-ai-sessions/api-reference.md
@@ -208,6 +208,82 @@ Delete a terminated session from history. Only sessions in the `ended` state can
 }
 ```
 
+#### Fork Preflight Check
+
+```text
+GET /v1/sessions/{sessionId}/fork-preflight
+```
+
+Inspect a source session before forking. Reports whether the source can be forked, a suggested name, and any MCP servers the source uses that are missing from the forker's profile (these must be acknowledged when forking).
+
+Forking your own session needs no special permission. Forking a session owned by the organization (an API/D&R session) requires the `ai_agent.set` permission on the org.
+
+##### Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `profile_id` | The forker's profile ID. Defaults to the caller's default profile if omitted. |
+
+##### Response: 200 OK
+
+```json
+{
+  "source_session_id": "abc123",
+  "source_session_type": "user",
+  "source_status": "ended",
+  "source_name": "Investigation 2025-01-15",
+  "source_lifetime_days": 3,
+  "default_fork_name": "Fork of Investigation 2025-01-15",
+  "source_mcp_servers": ["virustotal"],
+  "missing_mcps": ["virustotal"],
+  "is_forkable": true,
+  "is_forkable_reason": "",
+  "history_available": true
+}
+```
+
+`source_session_type` is `user` or `api`. When `missing_mcps` is non-empty, pass those names in `acknowledge_missing_tools` on the fork request.
+
+#### Fork Session
+
+```text
+POST /v1/sessions/{sessionId}/fork
+```
+
+Create a new session forked from the given source. The fork inherits the source's conversation context but starts with the forker's profile. The source must be in a forkable state (dormant or ended, within its retention window).
+
+All fields are optional:
+
+```json
+{
+  "name": "Continued investigation",
+  "profile_id": "profile-xyz",
+  "initial_prompt": "Pick up where the previous session left off and check the new IOCs.",
+  "acknowledge_missing_tools": ["virustotal"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Name for the forked session (defaults to a derived name). |
+| `profile_id` | string | Profile to use for the fork (defaults to the caller's default profile). |
+| `initial_prompt` | string | Initial prompt for the forked session. |
+| `acknowledge_missing_tools` | array | MCP servers present in the source but missing from the fork profile, acknowledged by the caller. |
+
+##### Response: 201 Created
+
+Returns the new session object, the same shape as [Create Session](#create-session). The new session's `forked_from_session_id` field references the source.
+
+##### Errors
+
+| Status | Meaning |
+|--------|---------|
+| `403` | Forking an org-owned session without the `ai_agent.set` permission. |
+| `409` | Source is not in a forkable state, or a create/fork/resume is already in progress. |
+| `410` | Source workspace archive is no longer available. |
+| `412` | Source uses MCP servers missing from the fork profile; acknowledge them via `acknowledge_missing_tools`. |
+| `429` | Maximum concurrent sessions reached. |
+
 ---
 
 ### Profiles

--- a/docs/9-ai-sessions/architecture.md
+++ b/docs/9-ai-sessions/architecture.md
@@ -1,0 +1,82 @@
+# Architecture
+
+AI Sessions are fully-managed - you launch sessions and the platform handles provisioning,
+isolation, scaling, and teardown. This page gives a high-level view of how the
+platform is organized and the principles that keep your data and credentials safe.
+
+## How It's Organized
+
+At a high level there are three conceptual layers: a **control plane** that manages
+sessions and credentials, **isolated session environments** where the agents
+actually run, and a **real-time channel** that connects you to a live session.
+
+```mermaid
+flowchart TB
+    Client["You<br/>Web UI · CLI · API"]
+
+    subgraph PLATFORM["AI Sessions (managed platform)"]
+        direction TB
+        CP["Control Plane<br/>session lifecycle, profiles,<br/>credentials, authentication"]
+        RT["Real-time Channel<br/>streams a live session<br/>to and from you"]
+        subgraph SESSIONS["Isolated Session Environments"]
+            direction LR
+            S1["Agent session"]
+            S2["Agent session"]
+        end
+    end
+
+    Client --> CP
+    Client <--> RT
+    CP --> SESSIONS
+    RT <--> SESSIONS
+```
+
+## The Building Blocks
+
+| Building block | What it does |
+|----------------|--------------|
+| **Control plane** | The front door for everything you do: registering, creating and managing sessions, storing profiles, and holding your encrypted credentials. Also records usage for billing. |
+| **Session environment** | Where an agent actually runs — an isolated, ephemeral environment with the LimaCharlie CLI, security tooling, and your configured tools. One per session. See [Runner Environment](runner-environment.md). |
+| **Real-time channel** | Carries your prompts, the agent's responses, tool-approval requests, and file transfers between you and a running session. See the [API Reference](api-reference.md) for the WebSocket protocol. |
+| **Authentication service** | Lets you connect Claude Max credentials through a browser sign-in, with no local install. |
+
+## Isolation & Trust
+
+The most important design principle is **isolation**. An agent runs your prompts and
+can execute code, so its environment is treated as untrusted and is walled off from
+everything sensitive:
+
+- A session environment **cannot reach your stored credentials or encryption keys**.
+- A session environment **cannot see or interfere with any other session**.
+- It communicates only over a single authenticated channel scoped to that one
+  session.
+
+The managed control plane sits on the trusted side of that boundary — it holds the
+keys, verifies your identity, and hands each session only the narrow, scoped access
+it needs for its lifetime.
+
+```mermaid
+flowchart LR
+    subgraph TRUST["Trusted — managed platform"]
+        T["Control plane &<br/>credential storage"]
+    end
+    subgraph UNTRUST["Untrusted — your agent runs here"]
+        U["Isolated session<br/>environment"]
+    end
+    TRUST -->|"scoped, per-session access only"| UNTRUST
+```
+
+## Data Protection
+
+- **Bring Your Own Key** — you supply your own Anthropic credentials; LimaCharlie
+  never has access to your Claude conversations.
+- **Encrypted at rest** — credentials, MCP configurations, environment variables,
+  and profile memory are encrypted, and isolated per user.
+- **Encrypted in transit** — all traffic to and from the platform is encrypted.
+- **Scoped access** — to act against a LimaCharlie organization, the credentials you
+  provide must carry the `ai_agent.operate` permission on that org. The agent only
+  ever has the access those credentials grant.
+
+For how usage is billed and what it costs, see [Cost Tracking & Savings](cost-tracking.md)
+and the [billing summary](index.md#billing).
+

--- a/docs/9-ai-sessions/architecture.md
+++ b/docs/9-ai-sessions/architecture.md
@@ -79,4 +79,3 @@ flowchart LR
 
 For how usage is billed and what it costs, see [Cost Tracking & Savings](cost-tracking.md)
 and the [billing summary](index.md#billing).
-

--- a/docs/9-ai-sessions/index.md
+++ b/docs/9-ai-sessions/index.md
@@ -48,6 +48,8 @@ AI Sessions runs fully-managed Claude Code instances in isolated cloud environme
 3. **Connects to external data** via the LimaCharlie CLI, MCP servers, or other configured tools
 4. **Returns results** either as a final summary or streamed in real-time
 
+For the platform layers, the isolation model, and data residency, see [Architecture](architecture.md).
+
 ## Getting Started
 
 ### For D&R-Driven Sessions
@@ -83,10 +85,13 @@ respond:
 
 ## Documentation
 
+- [Grid: Your AI Field Engineer](grid.md) - The guided, outcome-first way to use AI Sessions
+- [Architecture](architecture.md) - How the platform is organized, the isolation model
 - [D&R-Driven Sessions](dr-sessions.md) - Automated sessions triggered by D&R rules
-- [User Sessions](user-sessions.md) - Interactive sessions via web UI or API
+- [User Sessions](user-sessions.md) - Interactive sessions via web UI or API, including the session lifecycle
 - [Tool Permissions & Profiles](tool-permissions.md) - How `allowed_tools`, `denied_tools`, and `permission_mode` work
 - [Runner Environment](runner-environment.md) - CLI tools, language runtimes, and reference data pre-installed in the session container
+- [Rich Cards & Slash Commands](rich-cards.md) - Interactive cards the agent renders inline, and the `/` commands that summon them
 - [AI Skills](skills.md) - Reusable Claude Code skill definitions stored in your org
 - [AI Memory](memory.md) - Per-agent persistent memory with partial-merge writes
 - [API Reference](api-reference.md) - REST API and WebSocket protocol

--- a/docs/9-ai-sessions/memory.md
+++ b/docs/9-ai-sessions/memory.md
@@ -127,6 +127,29 @@ am.delete("triage-bot", "progress/step-1")
 am.delete_record("triage-bot")
 ```
 
+## Profile memory bank
+
+AI Memory (above) is an **org-scoped, per-agent** store managed through the
+`ai_memory` Hive. There is a second, distinct kind of memory: the **profile memory
+bank**, which is **per-user and lifecycle-coupled to a [profile](user-sessions.md#session-profiles)**.
+
+When a session is launched from a profile, the bank's markdown files are mounted
+into the session workspace at `/workspace/.memory/<path>`, and edits the agent makes
+there during the session are synced back to the profile. It's useful for notes,
+runbooks, and reference material you want available in every session that uses a
+given profile, editable both by hand and by the agent.
+
+| | AI Memory (`ai_memory`) | Profile memory bank |
+|---|---|---|
+| Scope | Organization, per agent | A single user's profile |
+| Managed via | CLI / API / SDK (Hive) | Profile management, mounted into the session |
+| Mounted in session | No (the agent reads/writes via tools) | Yes, at `/workspace/.memory/` |
+| Limits | 1024 entries, 256-char names, 10 MB total | 100 entries, 64 KiB per entry, 5 MiB total |
+
+The bank is excluded from hibernation archives and re-mounted fresh on every start,
+so changes made through profile management while a session is dormant take effect on
+the next resume.
+
 ## Related
 
 - [AI Skills](skills.md) — companion store for reusable instruction sets.

--- a/docs/9-ai-sessions/rich-cards.md
+++ b/docs/9-ai-sessions/rich-cards.md
@@ -1,0 +1,54 @@
+# Rich Cards & Slash Commands
+
+In interactive sessions, the agent can render **rich cards** — interactive UI
+elements that appear inline in the chat instead of plain text. A card might be a
+clickable list of your organizations, a detail view of a D&R rule, a form that
+collects a secret, or a billing summary. Many of the same cards can also be summoned
+directly with **slash commands**, without waiting on the agent.
+
+!!! note "Where this applies"
+    Rich cards are a feature of the interactive chat experience (the web UI and the
+    "Chat with FDE" surface). Fire-and-forget [D&R-driven sessions](dr-sessions.md)
+    don't render cards.
+
+## How cards work
+
+When the agent wants to show structured information, it emits a small descriptor
+describing which card to render and the data to populate it with. The web app
+validates that data against the card's schema and renders the matching component.
+Cards that collect sensitive input (for example, a secret value) are schema-locked
+so the agent cannot pre-fill the fields it shouldn't see.
+
+There are roughly forty card types. They fall into a few groups:
+
+- **Resource cards** — detail and list views of LimaCharlie resources: organizations,
+  secrets, D&R rules, false-positive rules, YARA rules, lookups, sensors,
+  installation keys, cases, detections, users, roles, outputs, adapters, artifacts,
+  AI agents / skills / memories, playbooks, and SOPs.
+- **Interactive cards** — actions that go beyond display: a billing and usage view,
+  a secret-intake form, and a feedback form.
+- **Share card** — share what you built (an editable message that opens X, LinkedIn,
+  Reddit, the device share sheet, or copies a link — nothing posts automatically)
+  and, for org admins, invite teammates by email and role in one step.
+- **Onboarding cards** — a welcome/trust block shown to brand-new users.
+
+## Slash commands
+
+Typing `/` in the chat input opens a menu of commands. These render a card
+**client-side**, without an agent round-trip — handy when you already know exactly
+what you want. Common examples:
+
+| Command | Renders |
+|---------|---------|
+| `/orgs [search]` | Your organizations, clickable to set the working org |
+| `/help` | The list of available slash commands |
+| `/billing` | Billing and usage for the active org |
+| `/share` | The share / invite card |
+| `/secrets [filter]` | Your secrets |
+| `/dnr [filter]` | D&R rules |
+| `/fp [filter]` | False-positive rules |
+| `/yara [filter]` | YARA rules |
+| `/lookups [filter]` | Lookup tables |
+
+The agent can also emit any of these cards itself in the course of a conversation —
+for example, returning a clickable list of matching rules instead of a wall of text.

--- a/docs/9-ai-sessions/user-sessions.md
+++ b/docs/9-ai-sessions/user-sessions.md
@@ -169,15 +169,46 @@ curl -X POST https://ai-sessions.limacharlie.io/v1/sessions/{sessionId}/capture-
 
 ## Session Lifecycle
 
-### Session States
+### What you see: Running / Waiting / Ended
 
-| State | Description |
-|-------|-------------|
-| `starting` | Session is being created and provisioned |
-| `running` | Session is active and accepting prompts |
-| `ended` | Session has terminated (see `end_reason` for details) |
+Across the UI — the sidebar, session lists, the live grid, the chat header — a
+session shows one of three states, with an optional **needs-attention** flag:
 
-Idle sessions are automatically hibernated and resumed transparently — they continue to appear as `running` during hibernation and resume automatically when you send a new message.
+| State | Meaning |
+|-------|---------|
+| **Running** | The agent is actively working — thinking, running tools, or recovering. |
+| **Waiting** | The session is alive but idle — waiting for your next prompt, asleep but resumable, or blocked on an unanswered tool approval or question. |
+| **Ended** | The session is finished. The `end_reason` says why — see [End Reasons](#end-reasons) below. |
+
+**Needs attention** — when a Running or Waiting session is blocked on a tool approval
+or a question you haven't answered, the badge gains a trailing alert marker. If you
+send a prompt while a session is blocked, the chat shows a "message queued" notice
+with a button that scrolls the pending request into view.
+
+### Hibernation
+
+Idle sessions are automatically **hibernated**: the workspace is archived and the
+session becomes **dormant**, incurring storage cost but **zero compute** until you
+send a new message, at which point it resumes transparently. To you it simply stays
+"Waiting" the whole time and picks up where it left off — the conversation and
+working files are restored on resume.
+
+### Forking
+
+A dormant or ended session can be **forked** into a new session within its retention
+window. The fork inherits the source's **conversation context** but starts with the
+**forking user's profile** (its tools and capabilities). A fork preflight reports
+whether the source is forkable and which of its MCP servers are missing from your
+profiles, so you can acknowledge them before forking.
+
+### Resource limits
+
+Several [Profile Options](#profile-options) act as automatic termination triggers:
+`max_turns` ends the session after a number of turns, `max_budget_usd` when
+cumulative Claude cost exceeds the cap, `one_shot` after the initial task, and
+`ttl_seconds` sets the session lifetime (capped at 24 hours). A platform maximum
+session duration, set by your organization's tier, also applies. When one of these is
+reached the session moves to `ended` with the matching `end_reason` below.
 
 ### End Reasons
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -542,11 +542,13 @@ nav:
   - AI Sessions:
       - Overview: 9-ai-sessions/index.md
       - Grid - Your AI Field Engineer: 9-ai-sessions/grid.md
+      - Architecture: 9-ai-sessions/architecture.md
       - D&R-Driven Sessions: 9-ai-sessions/dr-sessions.md
       - User Sessions: 9-ai-sessions/user-sessions.md
       - Cost Tracking & Savings: 9-ai-sessions/cost-tracking.md
       - Tool Permissions & Profiles: 9-ai-sessions/tool-permissions.md
       - Runner Environment: 9-ai-sessions/runner-environment.md
+      - Rich Cards & Slash Commands: 9-ai-sessions/rich-cards.md
       - AI Skills: 9-ai-sessions/skills.md
       - AI Memory: 9-ai-sessions/memory.md
       - Command Line Interface: 9-ai-sessions/cli.md


### PR DESCRIPTION
Expands the **AI Sessions** documentation section with several additions and consolidates Grid content into it (rather than a parallel top-level section).

## What's new
- **Architecture** (new page) — platform layers, the isolation/trust model, data protection, and availability / data residency by region, with diagrams.
- **Rich Cards & Slash Commands** (new page) — the interactive cards the agent renders inline and the `/` commands that summon them.
- **User Sessions → Session Lifecycle** — replaces the thin 3-state table with the current **Running / Waiting / Ended** model (+ needs-attention), and adds **hibernation**, **forking**, and **resource limits** subsections.
- **API Reference → fork endpoints** — documents `GET /v1/sessions/{id}/fork-preflight` and `POST /v1/sessions/{id}/fork` (request/response shapes and error codes), drawn from the backend `openapi.yaml`.
- **AI Memory → Profile memory bank** — a new section distinguishing the per-user, profile-mounted bank from the org-scoped `ai_memory` store.
- Nav + Overview documentation list updated to include the new pages.

