### PR TITLE
docs(adapters): fix mapping hostname field name in usage page

### DIFF
--- a/docs/2-sensors-deployment/adapters/usage.md
+++ b/docs/2-sensors-deployment/adapters/usage.md
@@ -141,7 +141,7 @@ The following configurations allow you to customize the way data is ingested by 
 - `client_options.mapping.parsing_re`: regular expression with [named capture groups](https://github.com/StefanSchroeder/Golang-Regex-Tutorial/blob/master/01-chapter2.markdown#named-matches). The name of each group will be used as the key in the converted JSON parsing.
 - `client_options.mapping.parsing_grok:`  grok pattern parsing for structured data extraction from unstructured log messages. Grok patterns combine regular expressions with predefined patterns to simplify log parsing and field extraction.
 - `client_options.mapping.sensor_key_path`: indicates which component of the events represent unique sensor identifiers.
-- `client_options.mapping.hostname`: indicates which component of the event represents the hostname of the resulting Sensor in LimaCharlie.
+- `client_options.mapping.sensor_hostname_path`: indicates which component of the event represents the hostname of the resulting Sensor in LimaCharlie.
 - `client_options.mapping.event_type_path`: indicates which component of the event represents the Event Type of the resulting event in LimaCharlie. It also supports template strings based on each event.
 - `client_options.mapping.event_time_path`: indicates which component of the event represents the Event Time of the resulting event in LimaCharlie.
 - `client_options.mapping.event_time_timezone`: specifies the timezone for parsing timestamps that don't include timezone information. Uses IANA timezone names (e.g., `America/New_York`, `Europe/London`, `UTC`). If not specified, timestamps without timezone info are treated as UTC.


### PR DESCRIPTION
## Summary
- The "Configurations" list on the adapter usage page documented `client_options.mapping.hostname`, which does not exist in the adapter code.
- Corrected to `client_options.mapping.sensor_hostname_path`, the actual field name.

## Verification
- Confirmed against the adapter source: `MappingDescriptor.SensorHostnamePath` carries the tag `sensor_hostname_path` in go-uspclient (`protocol/mapping.go`), and there is no `hostname` key under `mapping`.
- The "extractors" list later on the same page already used the correct name; the two listings are now consistent.
- Grepped the docs tree — this was the only occurrence of the incorrect form. Note that `client_options.hostname` (top-level, the adapter's own hostname) is a real field and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)