### PR TITLE
docs(outputs): document time-based file organization for S3 and GCS outputs

### DIFF
--- a/docs/5-integrations/outputs/destinations/amazon-s3.md
+++ b/docs/5-integrations/outputs/destinations/amazon-s3.md
@@ -7,9 +7,9 @@ If you have your own visualization stack, or you just need the data archived, yo
 - `bucket`: the path to the AWS S3 bucket.
 - `key_id`:  the id of the AWS auth key.
 - `secret_key`: the AWS secret key to auth with.
-- `sec_per_file`: the number of seconds after which a file is cut and uploaded.
+- `sec_per_file`: the number of seconds after which a file is cut and uploaded (default 120, maximum 3600).
 - `is_compression`: if set to "true", data will be gzipped before upload.
-- `is_indexing`: *DEPRECATED* if set to "true", data is uploaded in a way that makes it searchable.
+- `is_indexing`: if set to "true", files are written under a time-based directory structure (`year/month/day/hour/`) instead of flat files with random names. See [File organization](#file-organization) below.
 - `region_name`: the region name of the bucket, it is recommended to set it, though not always required.
 - `endpoint_url`: optionally specify a custom endpoint URL, usually used with region\_name to output to S3-compatible 3rd party services.
 - `dir`: the directory prefix
@@ -22,17 +22,31 @@ bucket: my-bucket-name
 key_id: AKIAABCDEHPUXHHHHSSQ
 secret_key: fonsjifnidn8anf4fh74y3yr34gf3hrhgh8er
 is_indexing: "true"
+is_no_sharding: "true"
 is_compression: "true"
 ```
 
 ![aws](../../../assets/images/aws.png)
 
-If the `is_indexing` option is enabled, data uploaded to S3 will be in a specific format enabling some indexed queries.
+## File Organization
 
-LC data files begin with a `d`, while special manifest files (indicating
- which data files contain which sensors' data) begin with an `m`. Otherwise (not `is_indexing`), data is uploaded as flat files with a UUID name.
+By default, each batch of data is uploaded as a flat file with a random (UUID) name at the root of the bucket (or under `dir` if set). File names carry no ordering, so this mode is best suited for pipelines that list and consume all new objects regardless of name.
 
-The `is_compression` flag, if on, will compress each file as a GZIP when uploaded. It is recommended you enable `is_compression`.
+To organize files by date and time, set `is_indexing` to `"true"`. Files are then written under a time-based directory structure:
+
+```text
+[dir/][shard/]year/month/day/hour/d{stream-id}_{counter}[.gz]
+```
+
+For example: `logs/1/2026/7/7/13/d1b2c3d4-e5f6-7890-abcd-ef1234567890_12.gz`
+
+- The timestamp components are in **UTC** and reflect when the batch was uploaded.
+- Data files begin with a `d` prefix.
+- `shard` is a single hexadecimal character used to spread write load across key prefixes. If you prefer paths to start directly at the year, set `is_no_sharding` to `"true"`.
+- Directory components are not zero-padded (July is `7`, not `07`), so a plain lexical sort of object keys will not be strictly chronological; parse the path components numerically if ordering matters.
+- The frequency at which new files are created is controlled by `sec_per_file`.
+
+The `is_compression` flag, if on, will compress each file as a GZIP when uploaded (adding a `.gz` extension). It is recommended you enable `is_compression`.
 
 ## AWS IAM Configuration
 

--- a/docs/5-integrations/outputs/destinations/google-cloud-storage.md
+++ b/docs/5-integrations/outputs/destinations/google-cloud-storage.md
@@ -8,10 +8,11 @@ If you already use Google Chronicle, we make it easy to send telemetry you've co
 
 - `bucket`: the path to the GCS bucket.
 - `secret_key`: the secret json key identifying a service account.
-- `sec_per_file`: the number of seconds after which a file is cut and uploaded.
+- `sec_per_file`: the number of seconds after which a file is cut and uploaded (default 120, maximum 3600).
 - `is_compression`: if set to "true", data will be gzipped before upload.
-- `is_indexing`: if set to "true", data is uploaded in a way that makes it searchable.
+- `is_indexing`: if set to "true", files are written under a time-based directory structure (`year/month/day/hour/`) instead of flat files with random names. See [File organization](#file-organization) below.
 - `dir`: the directory prefix where to output the files on the remote host.
+- `is_no_sharding`: do not add a shard directory at the root of the files generated.
 
 Example:
 
@@ -30,8 +31,27 @@ secret_key: {
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-service-writer%40my-lc-data.iam.gserviceaccount.com"
 }
 is_indexing: "true"
+is_no_sharding: "true"
 is_compression: "true"
 ```
+
+## File Organization
+
+By default, each batch of data is uploaded as a flat file with a random (UUID) name at the root of the bucket (or under `dir` if set). File names carry no ordering, so this mode is best suited for pipelines that list and consume all new objects regardless of name.
+
+To organize files by date and time, set `is_indexing` to `"true"`. Files are then written under a time-based directory structure:
+
+```text
+[dir/][shard/]year/month/day/hour/d{stream-id}_{counter}[.gz]
+```
+
+For example: `logs/1/2026/7/7/13/d1b2c3d4-e5f6-7890-abcd-ef1234567890_12.gz`
+
+- The timestamp components are in **UTC** and reflect when the batch was uploaded.
+- Data files begin with a `d` prefix.
+- `shard` is a single hexadecimal character used to spread write load across key prefixes. If you prefer paths to start directly at the year, set `is_no_sharding` to `"true"`.
+- Directory components are not zero-padded (July is `7`, not `07`), so a plain lexical sort of object keys will not be strictly chronological; parse the path components numerically if ordering matters.
+- The frequency at which new files are created is controlled by `sec_per_file`.
 
 ## Related articles
 


### PR DESCRIPTION
## Summary

Users testing bucket outputs (S3/GCS) have asked how to organize the uploaded files by date and time — by default files land as flat, randomly-named (UUID) objects, and the docs did not explain how to change that.

- Document the **File Organization** behavior on the Amazon S3 and Google Cloud Storage output pages: flat UUID files by default, and a `[shard/]year/month/day/hour/` directory structure when `is_indexing: "true"` is set.
- Document the shard prefix and how to remove it with `is_no_sharding`, UTC timestamps, the `d` data-file prefix, and the fact that path components are not zero-padded (lexical sort caveat).
- Remove the stale *DEPRECATED* label on `is_indexing` and the reference to manifest (`m`) files, which are no longer produced. `is_indexing` is the supported way to get time-organized output files.
- Add `is_no_sharding` to the GCS page (same batching behavior as S3) and note the `sec_per_file` default (120s) and maximum (3600s) on both pages.

Verified against the current output batching implementation. `markdownlint-cli2` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT9zzai4wYPjfib7BBTF4X