### PR TITLE
docs(cloud-security): add the Cloud Security (CNAPP) product section

### DIFF
--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -30,7 +30,7 @@ Shared behaviors:
 | `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors. |
 | `GET /findings/{finding_id}` | `{finding}` — one finding in full. |
 | `GET /attack-paths` | `{paths}` — marquee toxic-combination paths. Filters: `severity[]`, `account[]`, `status[]`, `q`. |
-| `GET /chokepoints` | `{chokepoints, total_paths}` — shared attack-path hops ranked by paths broken. |
+| `GET /chokepoints` | `{chokepoints, total_paths}` — shared attack-path hops ranked by paths broken, including the principal-exposure metrics. |
 | `GET /ciem/public-access` | `{access}` — public/external access to sensitive resources. |
 | `GET /ciem/facets` | `{facets}` — identity facet counts. |
 | `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `account`, `region`, `q`, paging. |
@@ -43,12 +43,12 @@ Shared behaviors:
 | `GET /compliance` | `{report}` — per-control assessment. Params: `framework` (default `cis-gcp`) or `assignment` (overrides `framework`). |
 | `GET /compliance/frameworks` | `{frameworks}` — id, name, version, control counts. |
 | `GET /compliance/assignments` | `{assignments}` — scoped assignments with per-assignment scores. |
-| `GET /overview` | Composed risk overview (`score`, distributions, top paths, coverage, trend, changes). Param: `trend_days` (default 30). |
+| `GET /overview` | Composed risk overview (`score`, distributions, top paths, coverage, trend, changes, and the per-tenant `usage` metering block). Param: `trend_days` (default 30). |
 | `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50). |
 | `GET /risk-trend` | `{trend}` — score history, oldest first. Param: `trend_days`. |
 | `GET /scan-status` | `{status}` — collection run state. Param: `provider` (default `gcp`). |
-| `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (max 500). |
-| `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (max 500). |
+| `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (server cap 500/request; keep URLs under ~8KB — the CLI/SDK chunks automatically). |
+| `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (same caps and chunking). |
 | `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, paging. |
 | `GET /caasm/coverage` | `{findings, next_cursor}` — coverage-gap findings. Params: `status[]`, `severity[]`, `q`, `sort`, `order`, paging. |
 | `GET /caasm/policy` | Resource-list shape: zero rows (no policy) or one row whose `props` is the policy. |

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -46,7 +46,7 @@ Shared behaviors:
 | `GET /overview` | Composed risk overview (`score`, distributions, top paths, coverage, trend, changes, and the per-tenant `usage` metering block). Param: `trend_days` (default 30). |
 | `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50). |
 | `GET /risk-trend` | `{trend}` — score history, oldest first. Param: `trend_days`. |
-| `GET /scan-status` | `{status}` — collection run state. Param: `provider` (default `gcp`). |
+| `GET /scan-status` | `{status}` — collection run state. Param: `provider` (default `gcp`; ids are lowercase — the lookup is case-sensitive and an unknown/miscased id reads as never-scanned). |
 | `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (server cap 500/request; keep URLs under ~8KB — the CLI/SDK chunks automatically). |
 | `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (same caps and chunking). |
 | `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, paging. |
@@ -60,7 +60,7 @@ All writes are `POST` with a JSON body and require `cloudsec.set`.
 | Route | Body | Returns |
 |---|---|---|
 | `/findings/{finding_id}/status` | `{resolution: {kind, reason, expires_at}}` — `kind` is `mitigated` \| `accepted` \| `false_positive`, or `open` to clear the disposition and reopen. `expires_at` is unix seconds (meaningful with `accepted`). | `{ok}` |
-| `/findings/bulk/status` | `{finding_ids: [...], resolution: {...}}` — one resolution applied to many findings. | `{updated}` |
+| `/findings/bulk/status` | `{finding_ids: [...], resolution: {...}}` — one resolution applied to many findings. Unlike the single-finding route, `kind` must be `mitigated` \| `accepted` \| `false_positive` — the bulk route does **not** accept `open` (reopen findings one at a time). | `{updated}` |
 | `/findings/{finding_id}/owner` | `{owner}` — empty string clears. | `{ok}` |
 | `/findings/{finding_id}/ticket` | `{ticket}` — empty string clears. | `{ok}` |
 | `/chokepoints/dismiss` | `{urn, reason?}` | `{ok}` |

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -1,0 +1,112 @@
+# API Reference
+
+All Cloud Security routes live under
+`https://api.limacharlie.io/v1/cloudsec/{oid}/…` and appear in the public
+OpenAPI spec at [`/openapi`](https://api.limacharlie.io/openapi).
+Authentication is the standard `Authorization: Bearer <JWT>` header.
+
+!!! info "Permissions & enable gate"
+    Reads require `cloudsec.get`; writes require `cloudsec.set`. Every route
+    requires the organization to be subscribed to `ext-cloud-inventory` — a
+    `403` on any route means subscribe first. The `oid` is always taken from
+    the authorized path.
+
+Shared behaviors:
+
+- **Repeatable filters** (`severity`, `finding_class`, `status`, `account`,
+  `sid`, `urn`) are passed as repeated query keys: `?severity=CRITICAL&severity=HIGH`.
+  OR within a key, AND across keys. At most 100 values per filter key.
+- **Keyset pagination**: pages carry `next_cursor`; pass it back as
+  `?cursor=`. `limit` is clamped to 1000.
+- **CSV export**: `findings`, `inventory`, `compliance`, and `query` accept
+  `?format=csv` to stream the full filtered set as a CSV attachment
+  (server-side walk, capped at 100,000 rows, in-band `#` truncation notice).
+
+## Reads
+
+| Route | Returns |
+|---|---|
+| `GET /findings` | `{findings, next_cursor}` — the risk-ranked worklist. Filters: `severity[]`, `finding_class[]`, `status[]`, `account[]`, `reachable`, `kev`, `q`, `sort`, `order`, `cursor`, `limit`. |
+| `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors. |
+| `GET /findings/{finding_id}` | `{finding}` — one finding in full. |
+| `GET /attack-paths` | `{paths}` — marquee toxic-combination paths. Filters: `severity[]`, `account[]`, `status[]`, `q`. |
+| `GET /chokepoints` | `{chokepoints, total_paths}` — shared attack-path hops ranked by paths broken. |
+| `GET /ciem/public-access` | `{access}` — public/external access to sensitive resources. |
+| `GET /ciem/facets` | `{facets}` — identity facet counts. |
+| `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `account`, `region`, `q`, paging. |
+| `GET /inventory/facets` | Inventory facet counts by type/account/region. |
+| `GET /data-security/facets` | `{facets}` — DSPM data-store rollup. |
+| `GET /resource?urn=` | `{resource}` — the canonical record for any URN (null when unknown). |
+| `GET /graph/neighbors?urn=` | `{graph: {nodes, edges}}` — 1-hop expansion; `limit` default 200, cap 500; `truncated` flag. |
+| `GET /queries` | `{queries}` — the named query pack (name, title, description, query). |
+| `POST /query` | `{rows}` — run a graph query. Body: exactly one of `named` / `text` / `query` (DSL object), optional `project`. |
+| `GET /compliance` | `{report}` — per-control assessment. Params: `framework` (default `cis-gcp`) or `assignment` (overrides `framework`). |
+| `GET /compliance/frameworks` | `{frameworks}` — id, name, version, control counts. |
+| `GET /compliance/assignments` | `{assignments}` — scoped assignments with per-assignment scores. |
+| `GET /overview` | Composed risk overview (`score`, distributions, top paths, coverage, trend, changes). Param: `trend_days` (default 30). |
+| `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50). |
+| `GET /risk-trend` | `{trend}` — score history, oldest first. Param: `trend_days`. |
+| `GET /scan-status` | `{status}` — collection run state. Param: `provider` (default `gcp`). |
+| `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (max 500). |
+| `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (max 500). |
+| `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, paging. |
+| `GET /caasm/coverage` | `{findings, next_cursor}` — coverage-gap findings. Params: `status[]`, `severity[]`, `q`, `sort`, `order`, paging. |
+| `GET /caasm/policy` | Resource-list shape: zero rows (no policy) or one row whose `props` is the policy. |
+
+## Writes
+
+All writes are `POST` with a JSON body and require `cloudsec.set`.
+
+| Route | Body | Returns |
+|---|---|---|
+| `/findings/{finding_id}/status` | `{resolution: {kind, reason, expires_at}}` — `kind` is `mitigated` \| `accepted` \| `false_positive`, or `open` to clear the disposition and reopen. `expires_at` is unix seconds (meaningful with `accepted`). | `{ok}` |
+| `/findings/bulk/status` | `{finding_ids: [...], resolution: {...}}` — one resolution applied to many findings. | `{updated}` |
+| `/findings/{finding_id}/owner` | `{owner}` — empty string clears. | `{ok}` |
+| `/findings/{finding_id}/ticket` | `{ticket}` — empty string clears. | `{ok}` |
+| `/chokepoints/dismiss` | `{urn, reason?}` | `{ok}` |
+| `/chokepoints/restore` | `{urn}` | `{ok}` |
+| `/caasm/policy` | `{policy: {expect: [{label, capability, kinds}]}}` — validated before storing. | `{ok}` |
+| `/caasm/ingest` | `{source, records?: [...], record?: {...}, policy?: {...}}` — `source` required; a single `record` is treated as a one-element batch. Body capped at 1 MiB; ingestion is idempotent. | `{result: {received, normalized, skipped, assets, created, updated, deleted}}` |
+| `/providers/test` | `{provider: <cloudsec_provider record>}` — credential inline (ephemeral, never stored) or a `hive://secret/<name>` reference. | `{supported, report: {provider, ok, checks: [{id, name, required, ok, detail}]}}` |
+
+Example — disposition a finding:
+
+```bash
+curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  "https://api.limacharlie.io/v1/cloudsec/$OID/findings/fnd_0a1b.../status" \
+  -d '{"resolution": {"kind": "accepted", "reason": "SEC-123", "expires_at": 1767225600}}'
+```
+
+## Finding shape
+
+The finding object (list, get, and the `cloud_finding.created` event all
+carry the same shape) — key fields:
+
+| Field | Meaning |
+|---|---|
+| `finding_id`, `fingerprint` | Stable identity of the condition (`fnd_` + fingerprint prefix). |
+| `rule_id`, `finding_class`, `classification` | What detected it and its class (`toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`). |
+| `severity`, `lc_risk`, `risk_breakdown` | `CRITICAL`–`INFO`, the 0–1000 composite, and its explanation. |
+| `title`, `resource_urn`, `resource_name`, `resource_type`, `account`, `region` | The affected resource. |
+| `related_urns`, `path` | Related resources; the hop list for path findings. |
+| `reachable`, `in_kev`, `vulns`, `epss`, `epss_percentile` | Exposure and exploit intelligence; `vulns` entries carry `cve`, `package`, `package_version`, `fix_version`, `cvss_score`. |
+| `evidence`, `remediation` | The offending configuration and the fix. |
+| `ciem_access` | For identity findings: role, identity kind, public/external/privileged flags, grant path. |
+| `runtime_sids` | Sensors resolved onto the affected asset. |
+| `status`, `resolution`, `resolved_by`, `resolution_expires_at`, `owner`, `ticket` | The triage overlay. |
+| `first_seen`, `last_seen` | Lifecycle timestamps. |
+
+## Events
+
+With finding/resource emission enabled (see the
+[`emission` policy](configuration.md#emission-the-event-feed)), the
+platform emits into the organization's event stream:
+
+- `cloud_finding.created` — full finding under `event/finding`.
+- `cloud_finding.closed` — `{finding_id, fingerprint, finding_class}`.
+- `cloud_finding.still_open` — re-asserted at most daily for open findings
+  with a linked ticket.
+- `cloud_resource.*` — inventory change events.
+
+See [Automation & IaC](automation.md#findings-cases-automation) for D&R
+rules that consume them.

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -1,0 +1,197 @@
+# Automation & Infrastructure-as-Code
+
+Everything Cloud Security does is scriptable: configuration is Hive records,
+the query/triage surface is the [REST API](api-reference.md) and
+[CLI](cli.md), and findings flow through the standard event pipeline. This
+page collects the operator recipes.
+
+## Onboarding a tenant
+
+```bash
+# 1. Subscribe the org to the extension (billing/enable gate).
+limacharlie extension subscribe --name ext-cloud-inventory --oid $OID
+
+# 2. Store the collector credential as a secret.
+limacharlie hive set --hive-name secret --key gcp-collector-sa \
+  --oid $OID --data '{"secret": "<service-account-key-json>"}'
+
+# 3. Connect the provider.
+cat > provider.json <<EOF
+{
+  "provider_type": "gcp",
+  "gcp_scope": "organizations/123456789",
+  "credentials": "hive://secret/gcp-collector-sa",
+  "internal_domains": ["acme.com"]
+}
+EOF
+limacharlie hive set --hive-name cloudsec_provider --key acme-gcp \
+  --oid $OID --input-file provider.json --enabled
+
+# 4. Declare the crown jewels (nothing is sensitive without a policy).
+cat > classification.json <<EOF
+{
+  "policy_type": "classification",
+  "classification": {
+    "data_stores": [
+      {"name_contains": ["customer", "pii"], "classes": ["pii"]}
+    ]
+  }
+}
+EOF
+limacharlie hive set --hive-name cloudsec_policy --key classification \
+  --oid $OID --input-file classification.json --enabled
+```
+
+## Multi-tenant policy push
+
+The same records applied to N organizations is the MSSP fleet-policy story:
+
+```bash
+for OID in $(cat tenant-oids.txt); do
+  limacharlie hive set --hive-name cloudsec_policy --key classification \
+    --oid "$OID" --input-file classification.json --enabled
+done
+```
+
+## Suppression rules (finding disposition policy)
+
+A `suppression`-typed `cloudsec_policy` record dispositions matching
+findings automatically — the "accept this known risk in the sandbox for 90
+days" mechanic. An operator's own disposition always wins; deleting a rule
+releases exactly its own findings on the next cycle; criticals are never
+auto-suppressed unless a rule's `max_severity` says `critical` explicitly.
+
+```json
+{
+  "policy_type": "suppression",
+  "suppression": {
+    "rules": [{
+      "name": "sandbox-key-age",
+      "match": {
+        "rule": ["stale-user-managed-sa-key"],
+        "account": ["proj-sandbox-*"],
+        "max_severity": "high"
+      },
+      "effect": {
+        "kind": "accepted",
+        "reason": "sandbox accepted risk (SEC-123)",
+        "ttl_days": 90
+      }
+    }]
+  }
+}
+```
+
+## Saved queries
+
+Save a graph query as a `cloudsec_query` record and it appears in every
+teammate's query console:
+
+```json
+{
+  "version": 1,
+  "name": "Exposed VMs reaching sensitive data",
+  "query": {"text": "..."},
+  "tags": ["weekly"]
+}
+```
+
+See [Configuration](configuration.md#cloudsec_query) for the full record
+shape.
+
+## CSV export
+
+Add `?format=csv` to `findings`, `inventory`, `compliance`, or `query` to
+stream the result as a CSV attachment instead of JSON. The server walks the
+full filtered set itself (filter parameters apply; paging parameters are
+ignored), capped at 100,000 rows with a trailing `#`-comment row as the
+truncation notice:
+
+```bash
+curl -H "Authorization: Bearer $JWT" \
+  "https://api.limacharlie.io/v1/cloudsec/$OID/findings?severity=CRITICAL&severity=HIGH&format=csv" \
+  -o findings.csv
+```
+
+The compliance CSV carries one row per control including the proving finding
+ids — the auditor-facing evidence export.
+
+!!! note "CLI `--output csv` is per-page"
+    The CLI's global `--output csv` formats the rows the command returned —
+    one page. For a full-estate export use the `?format=csv` server-side
+    walk above.
+
+## Findings ↔ Cases automation
+
+Cloud findings emit lifecycle events into the organization's own event
+stream (see the [`emission` policy](configuration.md#emission-the-event-feed)):
+`cloud_finding.created` (carries the full finding under `finding`),
+`cloud_finding.closed` (`{finding_id, fingerprint, finding_class}`), and
+`cloud_finding.still_open` (re-asserted at most once per day for open
+findings with a linked ticket). D&R rules match these like any event; the
+Cases extension actions close the loop.
+
+**Auto-case on high/critical findings** (async, grouped, storm-safe — one
+case per rule category per window, and first-sync floods are summarized
+upstream):
+
+```yaml
+detect:
+  event: cloud_finding.created
+  op: in
+  path: event/finding/severity
+  values: [CRITICAL, HIGH]
+respond:
+  - action: extension request
+    extension name: ext-cases
+    extension action: ingest_detection
+    extension request:
+      detect_id: "{{ .event.finding.fingerprint }}"
+      cat: "cloudsec:{{ .event.finding.rule_id }}"
+      source: cloudsec
+      detect: "{{ .event.finding }}"
+```
+
+**Resolve the case when the sweep confirms the fix:**
+
+```yaml
+detect:
+  event: cloud_finding.closed
+  op: exists
+  path: event/fingerprint
+respond:
+  - action: extension request
+    extension name: ext-cases
+    extension action: update_case
+    extension request:
+      detect_id: "{{ .event.fingerprint }}"
+      status: resolved
+      note: "Finding closed: condition no longer detected by sweep"
+```
+
+**Reopen a case that was closed while the cloud wasn't actually fixed:**
+
+```yaml
+detect:
+  event: cloud_finding.still_open
+  op: exists
+  path: event/fingerprint
+respond:
+  - action: extension request
+    extension name: ext-cases
+    extension action: update_case
+    extension request:
+      detect_id: "{{ .event.fingerprint }}"
+      reopen_if_closed: true
+      note: "Linked cloud finding is still open — verified by latest sweep"
+```
+
+`update_case` resolves the case through the detection index (`detect_id` =
+the finding fingerprint), so the rules never need a case number; a finding
+with no linked case is a no-op. Cases never close findings — findings are
+detection truth and close when the sweep confirms the fix (or via
+operator/policy disposition).
+
+**Non-Cases shops:** route the same `cloud_finding.*` events to
+Jira/ServiceNow via an Output and key your tickets on `fingerprint` the same
+way.

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -11,9 +11,11 @@ page collects the operator recipes.
 # 1. Subscribe the org to the extension (billing/enable gate).
 limacharlie extension subscribe --name ext-cloud-inventory --oid $OID
 
-# 2. Store the collector credential as a secret.
-limacharlie hive set --hive-name secret --key gcp-collector-sa \
-  --oid $OID --data '{"secret": "<service-account-key-json>"}'
+# 2. Store the collector credential as a secret (hive set reads
+#    record data from --input-file or piped stdin).
+echo '{"secret": "<service-account-key-json>"}' | \
+  limacharlie hive set --hive-name secret --key gcp-collector-sa \
+    --oid $OID --enabled
 
 # 3. Connect the provider.
 cat > provider.json <<EOF

--- a/docs/cloud-security/caasm.md
+++ b/docs/cloud-security/caasm.md
@@ -1,0 +1,77 @@
+# CAASM — Cyber Asset Attack Surface Management
+
+Your tools already know what you own: the EDR sees devices, the identity
+provider sees users and their devices, MDM and scanners see more. CAASM
+merges those third-party views into one entity-resolved asset inventory and
+evaluates your *expected-coverage* policy over it — surfacing the assets a
+required tool does **not** see.
+
+## The merged asset inventory
+
+Records from connected sources are normalized and entity-resolved (by
+hostname, serial, MAC addresses, email, …) into one row per real asset,
+with per-source provenance retained:
+
+```bash
+limacharlie cloudsec caasm assets -q laptop --limit 50
+```
+
+Supported sources: `sentinelone`, `crowdstrike`, `defender`, `okta`,
+`entraid`, `ms_graph`, `wiz`. Telemetry the organization already ingests
+through USP adapters feeds the inventory automatically; anything else can be
+pushed through the ingest endpoint below.
+
+## Declare expected coverage
+
+Coverage evaluation is a no-op until you declare expectations — a labeled
+list of "assets of these kinds must be seen by a tool with this capability":
+
+```bash
+cat > coverage.json <<EOF
+{
+  "expect": [
+    {"label": "edr-on-devices", "capability": "edr", "kinds": ["device"]}
+  ]
+}
+EOF
+
+limacharlie cloudsec caasm policy set --input-file coverage.json
+limacharlie cloudsec caasm policy get
+```
+
+The policy is validated on write; an invalid policy is rejected loudly
+rather than silently ignored.
+
+## Coverage gaps
+
+Assets observed by at least one source but missing a required capability
+become `coverage_gap` findings — same shape and triage verbs as every other
+finding, pre-filtered here:
+
+```bash
+limacharlie cloudsec caasm coverage --status open --severity HIGH
+```
+
+"Seen by Okta, no EDR" is the canonical example: the asset exists, a human
+uses it, and your endpoint tooling is blind to it.
+
+## Pushing records in
+
+For sources without a live adapter, push raw vendor-shaped records directly.
+Ingestion is idempotent — re-sending identical records is a no-op:
+
+```bash
+# A batch from a file (chunk large imports; the request body caps at 1 MiB).
+limacharlie cloudsec caasm ingest --source okta --records-file users.json
+
+# A single record inline (the shape D&R-driven feeders use).
+limacharlie cloudsec caasm ingest --source crowdstrike --record-json '{...}'
+```
+
+The response carries the reconcile counters — `received`, `normalized`,
+`skipped`, `assets`, `created`, `updated`, `deleted` — so a feeder can
+observe exactly what its batch changed.
+
+!!! info "Permissions"
+    Reading assets and coverage requires `cloudsec.get`; setting the policy
+    and ingesting records require `cloudsec.set`.

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -1,0 +1,112 @@
+# Command Line Interface
+
+The `limacharlie cloudsec` command group (Python SDK/CLI v2) covers the full
+Cloud Security API surface. Every command supports the global options
+(`--oid`, `--output json|yaml|csv|table`, `--filter <jmespath>`), and every
+command and subgroup answers `--ai-help` with task-oriented guidance.
+
+```bash
+pip install limacharlie
+limacharlie cloudsec --help
+```
+
+Configuration (providers, policies, saved queries) is managed with the
+standard `limacharlie hive` commands — see
+[Configuration](configuration.md); this group is the query and triage
+surface.
+
+## At a glance
+
+```bash
+# Posture
+limacharlie cloudsec overview --trend-days 90
+limacharlie cloudsec changes --limit 100
+limacharlie cloudsec risk-trend
+limacharlie cloudsec scan-status --provider gcp
+
+# Findings worklist + triage
+limacharlie cloudsec finding list --severity CRITICAL --class toxic_combination --kev
+limacharlie cloudsec finding facets --status open
+limacharlie cloudsec finding get fnd_0a1b...
+limacharlie cloudsec finding resolve fnd_0a1b... --kind mitigated --reason "SG tightened"
+limacharlie cloudsec finding resolve fnd_0a1b... --kind open          # reopen
+limacharlie cloudsec finding bulk-resolve --finding-id fnd_a --finding-id fnd_b --kind accepted
+limacharlie cloudsec finding set-owner fnd_0a1b... --owner alice@acme.com
+limacharlie cloudsec finding set-ticket fnd_0a1b... --ticket JIRA-1234
+
+# Attack paths, chokepoints
+limacharlie cloudsec attack-path list --severity CRITICAL
+limacharlie cloudsec chokepoint list
+limacharlie cloudsec chokepoint dismiss "lcrn:..." --reason "bastion by design"
+limacharlie cloudsec chokepoint restore "lcrn:..."
+
+# Identity & data
+limacharlie cloudsec ciem public-access
+limacharlie cloudsec ciem facets
+limacharlie cloudsec data-security facets
+
+# Inventory & graph
+limacharlie cloudsec inventory list --type <resource-type> -q prod --limit 50
+limacharlie cloudsec inventory facets
+limacharlie cloudsec resource get "lcrn:..."
+limacharlie cloudsec graph neighbors "lcrn:..." --limit 200
+limacharlie cloudsec query list
+limacharlie cloudsec query run --named public-buckets
+limacharlie cloudsec query run --text "public bucket with sensitive data"
+
+# Compliance
+limacharlie cloudsec compliance report --framework cis-gcp
+limacharlie cloudsec compliance report --assignment prod-cis
+limacharlie cloudsec compliance frameworks
+limacharlie cloudsec compliance assignments
+
+# Sensors <-> cloud assets
+limacharlie cloudsec resolve sensors $SID1 $SID2
+limacharlie cloudsec resolve assets "lcrn:..."
+
+# CAASM
+limacharlie cloudsec caasm assets -q laptop
+limacharlie cloudsec caasm coverage --status open
+limacharlie cloudsec caasm policy get
+limacharlie cloudsec caasm policy set --input-file coverage.json
+limacharlie cloudsec caasm ingest --source okta --records-file users.json
+
+# Provider preflight
+limacharlie cloudsec provider test --input-file provider.json
+```
+
+## Filtering and pagination
+
+List commands accept repeatable filters (OR within a key, AND across keys),
+free-text search, sorting, and keyset pagination:
+
+```bash
+limacharlie cloudsec finding list \
+  --severity CRITICAL --severity HIGH \
+  --status open -q payment \
+  --sort lc_risk --order desc \
+  --limit 50
+# ...then pass the returned next_cursor back:
+limacharlie cloudsec finding list --cursor "<next_cursor>" --limit 50
+```
+
+Boolean tri-state flags (`--kev/--no-kev`, `--reachable/--no-reachable`)
+send the filter only when given, so the server default applies otherwise.
+
+## Scripting
+
+The SDK class behind the CLI is available directly:
+
+```python
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.cloudsec import CloudSec
+
+cs = CloudSec(Organization(Client(oid="...")))
+page = cs.list_findings(severity=["CRITICAL"], kev=True, limit=100)
+for f in page["findings"]:
+    print(f["lc_risk"], f["title"], f["resource_urn"])
+```
+
+Each method mirrors one API route and returns the raw response dict; see the
+[API Reference](api-reference.md) for response shapes.

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -1,0 +1,68 @@
+# Compliance
+
+Cloud Security evaluates compliance frameworks continuously against the live
+estate: each control maps to detection rules, and a control fails when open
+findings prove the violation — so the compliance report is always as fresh
+as the last sweep, with finding-level evidence per control.
+
+## The report
+
+```bash
+# Whole-estate assessment against a framework (default: cis-gcp).
+limacharlie cloudsec compliance report --framework cis-gcp
+
+# Which frameworks are available?
+limacharlie cloudsec compliance frameworks
+```
+
+The report is per-control pass/fail with the proving finding ids as
+evidence, plus a summary score. The frameworks list carries `id`, `name`,
+`version`, and control counts — treat it as the source of truth for valid
+`--framework` values.
+
+For auditors, the same report exports as CSV — one row per control including
+the evidence finding ids — via the API's `?format=csv`
+(see [Automation & IaC](automation.md#csv-export)).
+
+## Scoped assignments
+
+A whole-estate score is often the wrong altitude: production must meet the
+bar, the sandbox does not. A `compliance`-typed `cloudsec_policy` record
+creates a **named, scoped assignment** — a framework evaluated over a subset
+of the estate:
+
+```bash
+cat > prod-cis.json <<EOF
+{
+  "policy_type": "compliance",
+  "compliance": {
+    "framework_id": "cis-gcp",
+    "description": "Production accounts only",
+    "scope": [
+      {"account_glob": ["proj-prod-*"]}
+    ]
+  }
+}
+EOF
+
+limacharlie hive set --hive-name cloudsec_policy --key prod-cis \
+  --oid $OID --input-file prod-cis.json --enabled
+```
+
+Scope matchers support `account_contains`, `account_glob`, `name_contains`,
+and `name_glob`; an empty scope means the whole estate.
+
+List assignments (each with its own scoped score) and evaluate one:
+
+```bash
+limacharlie cloudsec compliance assignments
+limacharlie cloudsec compliance report --assignment prod-cis
+```
+
+When `--assignment` is set, its framework is used and `--framework` is
+ignored.
+
+!!! info "Permissions"
+    Reading compliance requires `cloudsec.get`. Assignments are Hive policy
+    records, so creating them follows the `cloudsec_policy` hive
+    permissions.

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -80,11 +80,20 @@ Rule matchers (shared by every policy type that scopes over resources):
 `account_contains`, `account_glob`, `name_contains`, `name_glob`,
 `label` (key→value), `label_key_present`, `tag`.
 
-### `coverage` — CAASM expectations
+### `coverage` — workload coverage expectations
 
-The expected-coverage declaration, with `required` and `exempt` rule lists.
-Equivalent to (and kept in sync with) `limacharlie cloudsec caasm policy set`
-— see [CAASM](caasm.md#declare-expected-coverage).
+Declares which **cloud workloads** are expected to run a LimaCharlie
+sensor, with `required` and `exempt` resource-rule lists — the "EDR on
+production VMs" expectation, evaluated over the cloud inventory.
+
+!!! note "Distinct from the CAASM expected-coverage policy"
+    `limacharlie cloudsec caasm policy set` manages a **separate**
+    policy with a different shape (`{expect: [{label, capability,
+    kinds}]}`) evaluated over the merged *third-party asset* inventory
+    ("seen by the IdP, no EDR") — see
+    [CAASM](caasm.md#declare-expected-coverage). The two are not synced:
+    this hive record drives cloud-workload coverage findings; the CAASM
+    policy drives `coverage_gap` findings over third-party assets.
 
 ### `scanning` — agentless content scanning
 

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -1,0 +1,157 @@
+# Configuration Reference
+
+Cloud Security is configured entirely through three Hive types. Anything the
+console can configure, `limacharlie hive set` can configure — which makes
+tenant onboarding and fleet-wide policy a script, not a UI workflow (see
+[Automation & IaC](automation.md) for recipes).
+
+| Hive | Records | Purpose |
+|---|---|---|
+| `cloudsec_provider` | one per cloud / IdP connection | what to collect and with which credential |
+| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, scanning, emission, exclusions, suppression, compliance assignments |
+| `cloudsec_query` | one per saved query | shared saved graph queries |
+
+!!! info "Permissions"
+    `cloudsec_provider` records are gated by the dedicated
+    `cloudsec_provider.get/set/del` permissions; `cloudsec_policy` and
+    `cloudsec_query` follow `cloudsec.get`/`cloudsec.set`.
+
+## cloudsec_provider
+
+One record per provider connection. `provider_type` discriminates; each type
+reads its own scope fields.
+
+Common fields:
+
+| Field | Meaning |
+|---|---|
+| `provider_type` | `gcp` \| `aws` \| `azure` \| `okta` \| `1password` \| `google_workspace` \| `cloudflare` |
+| `credentials` | A `hive://secret/<name>` reference. The credential itself lives in the secret hive — it is **not** stored inline. |
+| `internal_domains` | Your own email domains (bare domains, no `@`) beyond the discoverable primary — identities outside this set are classified external. |
+| `sync_now` | Opaque nonce; change its value to trigger an on-demand sweep. |
+| `refresh` | Periodic re-enumeration cadence as a duration string (e.g. `"6h"`); empty uses the service default. |
+| `feed_subscription` | Optional fully-qualified Pub/Sub subscription carrying a cloud change feed, for event-driven freshness between full sweeps. |
+
+Per-provider scope fields:
+
+| `provider_type` | Fields |
+|---|---|
+| `gcp` | `gcp_scope`: `projects/{id}`, `folders/{id}`, or `organizations/{id}` (optional `gcp_project`) |
+| `aws` | `aws_role_arn` (the read-only role to assume), `aws_external_id`, optional `aws_regions`, optional `aws_member_role_name` — the role *name* assumed in each member account of an AWS Organization (defaults to the name in `aws_role_arn`, the common StackSet pattern) |
+| `azure` | `azure_tenant_id`, `azure_client_id`, `azure_subscription_id` (service-principal auth) |
+| `okta` | `okta_org_url` — the org base URL; the credential is an SSWS API token or an API Services app (client credentials) |
+| `google_workspace` | `workspace_customer_id` — `my_customer` or an explicit customer id; the credential is a service-account key with domain-wide delegation plus the admin subject to impersonate |
+| `1password` | `onepassword_scim_url` — the SCIM bridge URL; the credential is the SCIM bearer token |
+| `cloudflare` | `cloudflare_account_id` — the 32-hex account id |
+
+Use `limacharlie cloudsec provider test` to preflight a record before saving
+it — see [Getting Started](getting-started.md#test-the-credential-before-saving).
+
+## cloudsec_policy
+
+Each record declares exactly one `policy_type` and fills the matching
+sub-object.
+
+### `classification` — crown jewels
+
+Declares which resources are sensitive (nothing is sensitive by default).
+Rules match resources by account/name/label/tag and assign classes:
+
+```json
+{
+  "policy_type": "classification",
+  "classification": {
+    "data_stores": [
+      {"name_contains": ["customer", "pii"], "classes": ["pii"]}
+    ],
+    "compute": [
+      {"label": {"tier": "crown-jewel"}, "classes": ["critical-infra"]}
+    ],
+    "auto_classify": true
+  }
+}
+```
+
+`auto_classify: true` opts into content-based detection of sensitive data
+(sampled during agentless scanning); the explicit policy always remains
+authoritative.
+
+Rule matchers (shared by every policy type that scopes over resources):
+`account_contains`, `account_glob`, `name_contains`, `name_glob`,
+`label` (key→value), `label_key_present`, `tag`.
+
+### `coverage` — CAASM expectations
+
+The expected-coverage declaration, with `required` and `exempt` rule lists.
+Equivalent to (and kept in sync with) `limacharlie cloudsec caasm policy set`
+— see [CAASM](caasm.md#declare-expected-coverage).
+
+### `scanning` — agentless content scanning
+
+Names the YARA rules to run against snapshot-scanned workloads and the
+classification each match assigns, plus an optional resource `scope`:
+
+```json
+{
+  "policy_type": "scanning",
+  "scanning": {
+    "rules": [{"yara_rule": "hive://yara/crypto-miners", "classification": "malware"}],
+    "scope": [{"account_glob": ["proj-prod-*"]}]
+  }
+}
+```
+
+### `emission` — the event feed
+
+Controls which Cloud Security events reach the organization's event stream:
+
+| Field | Meaning |
+|---|---|
+| `resource_events` | `cloud_resource.*` inventory change events |
+| `finding_events` | `cloud_finding.*` lifecycle events |
+| `ops_events` | operational events (sweep start/complete, errors) |
+| `severity_floor` | drop finding events below this severity |
+| `suppress_first_sync` | don't flood the stream with the initial enumeration |
+
+### `exclusions` — the escape hatch
+
+Excludes matching resources from `collection`, `scanning`, or `emission`
+(three independent rule lists; rules add `services` and `resource_types`
+matchers on top of the shared resource matchers). Use it for the
+million-object bucket that should not be enumerated, or the noisy account
+that should not emit events. Removal takes effect on the next sweep.
+
+### `suppression` — finding disposition policy
+
+Auto-dispositions matching findings — see
+[Automation & IaC](automation.md#suppression-rules-finding-disposition-policy)
+for semantics and a worked example. Match fields: `finding_class`, `rule`,
+`account`, `urn_prefix`, `max_severity`; effect: `kind`
+(`accepted`/`false_positive`/`mitigated`), `reason`, `ttl_days`.
+
+### `compliance` — scoped assignments
+
+A named framework assignment over a scoped subset of the estate — see
+[Compliance](compliance.md#scoped-assignments). Fields: `framework_id`
+(required, lowercase slug), `description`, `scope` (v1 supports the
+account/name matchers only).
+
+## cloudsec_query
+
+A saved graph query, shared org-wide:
+
+```json
+{
+  "version": 1,
+  "name": "Exposed VMs reaching sensitive data",
+  "description": "Weekly review lens",
+  "query": {"text": "..."},
+  "project": "rows",
+  "tags": ["weekly"]
+}
+```
+
+`query` takes one of `named` (a query-pack reference), `text`, or `ast` (the
+raw DSL). Optional `ui` hints (view, columns) shape how the console renders
+results. `schedule` and `detection` blocks are accepted so IaC written today
+survives the scheduled-query phase, but are not yet active.

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -1,0 +1,129 @@
+# Findings & Triage
+
+Everything Cloud Security detects lands in one place: a merged, risk-ranked
+findings worklist. CSPM misconfigurations, graph-derived attack paths, and
+identity (CIEM) risks are all findings with the same shape, the same triage
+verbs, and the same automation events.
+
+## The worklist
+
+Findings are ordered by `lc_risk` — a 0–1000 composite that weighs severity,
+exposure, reachability, exploit intelligence (KEV / EPSS), and whether the
+resource is sensitive. Each finding carries:
+
+- `finding_id` (stable, prefixed `fnd_`) and `fingerprint` — the identity of
+  the *condition*; the same misconfiguration on the same resource keeps the
+  same fingerprint across sweeps.
+- `finding_class` — one of `toxic_combination`, `public_exposure`,
+  `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
+  `malware`, `secret`, `scan_finding`, `coverage_gap`.
+- `severity` (`CRITICAL` … `INFO`), `lc_risk`, and a `risk_breakdown`
+  explaining the score.
+- The affected resource (`resource_urn`, `resource_name`, `resource_type`,
+  `account`, `region`), related resources, and — for path findings — the
+  full `path` of hops.
+- `evidence` (the offending configuration) and `remediation` (what to
+  change).
+- Vulnerability context where applicable: `vulns` (CVEs with fix versions),
+  `epss`, `in_kev`.
+- Runtime context: `runtime_sids` — the LimaCharlie sensors running on the
+  affected asset, when the fusion mapping resolves any.
+
+List, filter, and paginate server-side:
+
+```bash
+limacharlie cloudsec finding list \
+  --severity CRITICAL --severity HIGH \
+  --class toxic_combination --status open \
+  --kev --limit 50
+```
+
+Repeatable filters are OR within a key and AND across keys. Free-text search
+is `-q`; pagination is keyset-based (`next_cursor` from one page becomes
+`--cursor` for the next). `finding facets` returns the cross-filtered facet
+counts that drive the console's filter rail, and `finding get <id>` returns
+one finding in full.
+
+## Dispositions
+
+A finding is `open` until the sweep observes the condition gone (automatic
+close) or an operator dispositions it:
+
+| Kind | Meaning |
+|---|---|
+| `mitigated` | The risk was fixed operator-side; treated as closed. |
+| `accepted` | Known and accepted, optionally until an expiry (`expires_at`, unix seconds) — after which it reopens. |
+| `false_positive` | The finding was wrong. |
+| `open` | Clears a previous disposition and reopens the finding (owner and ticket are kept). |
+
+```bash
+# Accept a known risk for 90 days.
+limacharlie cloudsec finding resolve fnd_0a1b... --kind accepted \
+  --reason "sandbox accepted risk (SEC-123)" --expires-at 1767225600
+
+# Reopen it.
+limacharlie cloudsec finding resolve fnd_0a1b... --kind open
+
+# Disposition a batch at once.
+limacharlie cloudsec finding bulk-resolve \
+  --finding-id fnd_0a1b... --finding-id fnd_2c3d... \
+  --kind false_positive --reason "scanner artifact"
+```
+
+Ownership and ticket linkage are separate, lighter-weight fields:
+
+```bash
+limacharlie cloudsec finding set-owner fnd_0a1b... --owner alice@acme.com
+limacharlie cloudsec finding set-ticket fnd_0a1b... --ticket JIRA-1234
+```
+
+Dispositions can also be applied *as policy* — a `suppression`-typed
+`cloudsec_policy` record auto-dispositions matching findings (see
+[Automation & IaC](automation.md#suppression-rules-finding-disposition-policy)).
+An operator's explicit disposition always wins over policy.
+
+!!! info "Permissions"
+    Reading findings requires `cloudsec.get`; every disposition, owner,
+    ticket, and chokepoint write requires `cloudsec.set`.
+
+## Chokepoints — fix one thing
+
+Attack paths tend to share hops. The chokepoint view ranks resources by how
+many distinct attack paths each one sits on, so remediation can be framed as
+"fixing this one security group closes 41 of 63 paths":
+
+```bash
+limacharlie cloudsec chokepoint list
+```
+
+A chokepoint that is understood and tolerated (e.g. a bastion by design) can
+be dismissed from the risk overview — and restored later:
+
+```bash
+limacharlie cloudsec chokepoint dismiss "lcrn:..." --reason "bastion by design"
+limacharlie cloudsec chokepoint restore "lcrn:..."
+```
+
+## Overview, changes, and trend
+
+Three read endpoints power the at-a-glance layer:
+
+```bash
+# Score, severity distribution, top paths, coverage, trend — one call.
+limacharlie cloudsec overview --trend-days 90
+
+# The created/closed feed, newest first.
+limacharlie cloudsec changes --limit 100
+
+# The risk-score history on its own.
+limacharlie cloudsec risk-trend --trend-days 90
+```
+
+## Findings are events too
+
+Every lifecycle transition emits an event into the organization's event
+stream: `cloud_finding.created`, `cloud_finding.closed`, and a daily
+`cloud_finding.still_open` for open findings with a linked ticket. D&R rules
+match them like any other event — see
+[Automation & IaC](automation.md#findings-cases-automation) for the
+ready-made Cases loop.

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -25,9 +25,12 @@ record references a [secret](../7-administration/config-hive/secrets.md) by
 `hive://secret/<name>`:
 
 ```bash
-limacharlie hive set --hive-name secret --key gcp-collector-sa \
-  --oid $OID --data '{"secret": "<service-account-key-json>"}'
+echo '{"secret": "<service-account-key-json>"}' | \
+  limacharlie hive set --hive-name secret --key gcp-collector-sa \
+    --oid $OID --enabled
 ```
+
+(`hive set` reads the record data from `--input-file` or piped stdin.)
 
 What the credential must be able to do depends on the provider — the
 credential test in the next step tells you exactly which permission surfaces

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -1,0 +1,151 @@
+# Getting Started with Cloud Security
+
+This page takes an organization from zero to a populated Cloud Security
+dashboard: subscribe the extension, store a credential, connect a provider,
+and run the first sweep.
+
+## 1. Subscribe the extension
+
+Cloud Security is enabled per organization by subscribing to the
+`ext-cloud-inventory` extension — the subscription is both the enable gate
+and the billing hook. In the web console, open the extension from the
+Add-Ons marketplace and click **Subscribe**, or from the CLI:
+
+```bash
+limacharlie extension subscribe --name ext-cloud-inventory --oid $OID
+```
+
+Until the organization is subscribed, every Cloud Security API route and
+console view returns `403`.
+
+## 2. Store the provider credential as a secret
+
+Collector credentials are never stored inline in the provider record — the
+record references a [secret](../7-administration/config-hive/secrets.md) by
+`hive://secret/<name>`:
+
+```bash
+limacharlie hive set --hive-name secret --key gcp-collector-sa \
+  --oid $OID --data '{"secret": "<service-account-key-json>"}'
+```
+
+What the credential must be able to do depends on the provider — the
+credential test in the next step tells you exactly which permission surfaces
+are missing.
+
+## 3. Connect a provider
+
+A provider connection is one `cloudsec_provider` Hive record. The full field
+reference is in [Configuration](configuration.md#cloudsec_provider); the
+short version per provider:
+
+| Provider | `provider_type` | Scope fields |
+|---|---|---|
+| Google Cloud | `gcp` | `gcp_scope` (`projects/{id}`, `folders/{id}`, or `organizations/{id}`) |
+| AWS | `aws` | `aws_role_arn` + `aws_external_id`, optional `aws_regions`, optional `aws_member_role_name` for AWS Organizations |
+| Azure | `azure` | `azure_tenant_id`, `azure_client_id`, `azure_subscription_id` |
+| Okta | `okta` | `okta_org_url` (e.g. `https://acme.okta.com`) |
+| Google Workspace | `google_workspace` | `workspace_customer_id` (`my_customer` or an explicit id) |
+| 1Password | `1password` | `onepassword_scim_url` |
+| Cloudflare | `cloudflare` | `cloudflare_account_id` |
+
+Example — a GCP organization:
+
+```bash
+cat > provider.json <<EOF
+{
+  "provider_type": "gcp",
+  "gcp_scope": "organizations/123456789",
+  "credentials": "hive://secret/gcp-collector-sa",
+  "internal_domains": ["acme.com", "acme.io"]
+}
+EOF
+
+limacharlie hive set --hive-name cloudsec_provider --key acme-gcp \
+  --oid $OID --input-file provider.json --enabled
+```
+
+!!! tip "internal_domains matters for CIEM"
+    List every email domain your own people use. A human identity whose
+    domain is not in the internal set is classified *external*, and external
+    access to sensitive resources is one of the highest-signal finding
+    classes. The collector discovers the primary cloud-org domain on its
+    own; secondary domains must be declared.
+
+### Test the credential before saving
+
+The provider test connects with the supplied credential and probes every
+permission surface a sweep needs, without storing anything:
+
+```bash
+limacharlie cloudsec provider test --input-file provider.json
+```
+
+The response is a per-check report: each check carries `id`, `name`,
+`required`, `ok`, and a human-readable `detail`. `report.ok` is the verdict
+over the *required* checks only — a failed optional check means that surface
+degrades gracefully (e.g. one inventory type missing) rather than the
+connection failing.
+
+!!! info "Permissions"
+    The provider test requires `cloudsec.set` — testing a credential is as
+    sensitive as saving one. For the test (and only the test) the credential
+    may be passed inline instead of as a `hive://secret/` reference; it is
+    used ephemerally and never stored or logged.
+
+## 4. Watch the first sweep
+
+Saving an enabled provider record starts collection. Check progress:
+
+```bash
+limacharlie cloudsec scan-status --provider gcp
+```
+
+The status carries whether a sweep is running, when the last one started and
+completed, the diff stats of the last run, and any error. To force an
+immediate re-enumeration later, change the record's `sync_now` value (any
+new value triggers a sweep); `refresh` sets the periodic cadence.
+
+## 5. Declare what matters
+
+Out of the box, **nothing is classified sensitive** — sensitivity is your
+declaration, made with a `classification`-typed `cloudsec_policy` record
+(crown jewels), optionally augmented by content-based auto-classification:
+
+```bash
+cat > classification.json <<EOF
+{
+  "policy_type": "classification",
+  "classification": {
+    "data_stores": [
+      {"name_contains": ["customer", "pii"], "classes": ["pii"]}
+    ],
+    "auto_classify": true
+  }
+}
+EOF
+
+limacharlie hive set --hive-name cloudsec_policy --key classification \
+  --oid $OID --input-file classification.json --enabled
+```
+
+Sensitivity drives the attack-path and CIEM analytics: "exposed workload
+that can reach *sensitive* data" and "external identity with access to
+*sensitive* store" both need to know what sensitive means in your estate.
+
+## 6. Look at the result
+
+```bash
+# The composed risk overview: score, severity distribution, top paths.
+limacharlie cloudsec overview
+
+# The findings worklist, worst first.
+limacharlie cloudsec finding list --severity CRITICAL --severity HIGH
+
+# What you own.
+limacharlie cloudsec inventory facets
+```
+
+From here, continue with [Findings & Triage](findings.md) for the day-to-day
+workflow, or [Automation & IaC](automation.md) to wire findings into Cases
+and onboard more tenants as code.

--- a/docs/cloud-security/graph.md
+++ b/docs/cloud-security/graph.md
@@ -1,0 +1,128 @@
+# Security Graph & Queries
+
+Every sweep builds a graph of the estate: resources, identities, and data
+stores as nodes; reachability, exposure, permissions, and vulnerability
+relationships as edges. The graph is what turns three individually-boring
+facts into one critical finding — and it is directly explorable.
+
+## The graph model
+
+Nodes are addressed by URN (the same `lcrn:` identifiers used across the
+API) and carry type-specific properties: exposure (`is_public`), sensitivity
+(`is_sensitive`), vulnerability context (`cve`, `severity`, `in_kev`,
+`cvss_score`), and identity insight (human/service kind, external flag, MFA
+posture, dormancy, escalation potential, least-privilege suggestions).
+
+Edges carry the relationship semantics:
+
+| Edge | Meaning |
+|---|---|
+| `can_reach` | Network reachability between workloads |
+| `exposed_to` | Exposure to the internet / an external boundary |
+| `has_vulnerability` | Workload → CVE (with package and fix version) |
+| `has_permission_on` | Identity → resource (with role and effect) |
+| `can_assume` | Identity → identity (role assumption / impersonation) |
+| `is_member_of` | Identity → group / account membership |
+| `has_app_access` | Identity → application assignment (IdP surfaces) |
+
+## Attack paths
+
+The headline analytic: an internet-exposed workload with a known-exploited
+vulnerability that can reach a sensitive resource. Each path is scored and
+surfaced both as a `toxic_combination` finding and in the dedicated view:
+
+```bash
+limacharlie cloudsec attack-path list --severity CRITICAL
+```
+
+## Exploring the graph
+
+Expand outward from any resource, one hop at a time — the API behind
+click-to-expand on the console's graph canvas:
+
+```bash
+limacharlie cloudsec graph neighbors "lcrn:gcp:...instance/web-1" --limit 200
+```
+
+The result is an induced subgraph (`nodes` + `edges`), ranked so sensitive
+and public neighbors surface first, with `truncated` set when the node has
+more neighbors than the cap (hard cap 500).
+
+## Graph queries
+
+Ask questions of the whole graph. Three input forms, one endpoint:
+
+```bash
+# A named query from the built-in query pack:
+limacharlie cloudsec query list
+limacharlie cloudsec query run --named public-buckets
+
+# Free-text:
+limacharlie cloudsec query run --text "public bucket with sensitive data"
+
+# The raw query DSL:
+limacharlie cloudsec query run --query-json '{...}' --project a,b
+```
+
+Results are rows of alias → URN bindings; use
+`limacharlie cloudsec resource get <urn>` to hydrate any URN into its full
+canonical record (this also works for derived nodes — vulnerabilities,
+identities — that have no inventory row).
+
+Queries worth keeping become `cloudsec_query` Hive records — shared,
+versioned, and IaC-manageable (see
+[Configuration](configuration.md#cloudsec_query)).
+
+## Identity: CIEM views
+
+Two dedicated identity reads sit on top of the graph:
+
+```bash
+# Public / external access to sensitive resources — the headline CIEM view.
+limacharlie cloudsec ciem public-access
+
+# Identity facet counts (kinds, external/public splits).
+limacharlie cloudsec ciem facets
+```
+
+Identity findings (dormant privileged identities, escalation edges, unused
+privileges) surface in the main worklist under the `ciem_risk` and
+`privilege_escalation` classes. External-vs-internal classification is
+driven by the provider record's `internal_domains` — keep it complete.
+
+## Data security: DSPM facets
+
+```bash
+limacharlie cloudsec data-security facets
+```
+
+Returns the data-store posture rollup: total stores, sensitive, public, and
+public-*and*-sensitive counts, plus store-kind / sensitivity / exposure
+histograms. Sensitivity is your declaration (the `classification` policy)
+optionally augmented by content-based auto-classification — see
+[Getting Started](getting-started.md#5-declare-what-matters).
+
+## Inventory
+
+The system-of-record behind the graph is queryable directly:
+
+```bash
+limacharlie cloudsec inventory list --type <resource-type> --region us-central1 -q prod
+limacharlie cloudsec inventory facets
+```
+
+## Sensors ↔ cloud assets
+
+The fusion mapping resolves both directions between runtime (sensors) and
+posture (cloud assets), in bulk:
+
+```bash
+# Which cloud asset does each sensor run on?
+limacharlie cloudsec resolve sensors $SID1 $SID2
+
+# Which sensors run on this asset?
+limacharlie cloudsec resolve assets "lcrn:...instance/web-1"
+```
+
+Each response splits `resolved` and `unresolved`, so a pivot from a cloud
+finding to live endpoint telemetry (or the reverse) is one call.

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -1,5 +1,10 @@
 # Cloud Security
 
+!!! warning "Private Beta"
+    Cloud Security is currently in **Private Beta**. Features, APIs, and
+    configuration formats described here may change before general
+    availability. Contact us if you would like access.
+
 LimaCharlie Cloud Security is an agentless cloud-native application protection
 platform (CNAPP) built into the same tenant, permission model, and automation
 surface as the rest of LimaCharlie. It continuously enumerates your cloud and

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -1,0 +1,90 @@
+# Cloud Security
+
+LimaCharlie Cloud Security is an agentless cloud-native application protection
+platform (CNAPP) built into the same tenant, permission model, and automation
+surface as the rest of LimaCharlie. It continuously enumerates your cloud and
+identity estate, builds a security graph out of it, and turns what it finds
+into a single risk-ranked worklist of findings — connected to the sensors,
+D&R rules, Cases, and Outputs you already use.
+
+!!! tip "In one sentence"
+    Connect a cloud account or identity provider with a read-only credential,
+    and LimaCharlie shows you what you own, what is exposed, who can reach
+    what, and exactly which fix breaks the most attack paths — with every
+    finding automatable through the standard LimaCharlie event pipeline.
+
+## What it covers
+
+| Capability | What you get |
+|---|---|
+| **Inventory (CSPM)** | A continuously refreshed system-of-record of your cloud resources — compute, storage, networking, identities — with misconfiguration findings per resource. |
+| **Attack paths** | Toxic combinations across resources: an internet-exposed workload with a known-exploited vulnerability that can reach sensitive data is one finding, not three disconnected ones. |
+| **Identity (CIEM)** | Who — human or service — can access what: public/external access to sensitive resources, privilege-escalation edges, dormant privileged identities. |
+| **Data security (DSPM)** | Which data stores exist, which are sensitive (you declare it by policy, or opt into content-based auto-classification), and which sensitive stores are exposed. |
+| **Compliance** | Per-control pass/fail assessment of frameworks (e.g. `cis-gcp`) over the live estate, whole-estate or scoped to named assignments. |
+| **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources) with coverage-gap findings — "seen by the identity provider, no EDR". |
+| **Security graph** | An explorable graph of resources, identities, and their relationships (`can_reach`, `exposed_to`, `has_permission_on`, `can_assume`, …) with a query language and saved queries. |
+| **Runtime fusion** | Bidirectional resolution between LimaCharlie sensors and the cloud assets they run on — pivot from a cloud finding to the live endpoint and back. |
+
+## Supported providers
+
+Cloud infrastructure: **GCP**, **AWS** (including multi-account AWS
+Organizations), **Azure**. Identity and SaaS surfaces: **Okta**,
+**Google Workspace**, **1Password**, **Cloudflare**.
+
+All collection is agentless and read-only: you grant a scoped read credential
+(stored as a LimaCharlie [secret](../7-administration/config-hive/secrets.md), referenced —
+never inlined — from the provider record), and the platform sweeps the estate
+on a schedule, on demand, or continuously from a change feed.
+
+## How it works
+
+1. **Subscribe** the organization to the `ext-cloud-inventory` extension —
+   this is the product's enable (and billing) gate.
+2. **Connect providers**: one `cloudsec_provider` Hive record per cloud
+   account / IdP tenant. A pre-save credential test probes every permission
+   the collector needs and reports which are missing.
+3. **Sweeps build the graph**: each enumeration updates the resource
+   system-of-record and the security graph, then re-derives findings.
+   Closed conditions close their findings automatically.
+4. **You work the findings**: one worklist ordered by `lc_risk`, with
+   dispositions (mitigated / accepted / false positive), owners, tickets,
+   chokepoint analysis, and full automation through `cloud_finding.*`
+   events.
+
+Everything the console shows is also available through the
+[REST API](api-reference.md), the [CLI](cli.md), and — for configuration —
+plain [Hive records](configuration.md), so a fleet of tenants can be
+onboarded and governed as code.
+
+## Permissions
+
+!!! info "Permissions"
+    - `cloudsec.get` — read access to every Cloud Security view (findings,
+      inventory, graph, compliance, CAASM).
+    - `cloudsec.set` — finding triage and other writes (dispositions,
+      owners/tickets, chokepoint dismissal, CAASM policy/ingest, provider
+      credential tests).
+    - `cloudsec_provider.get` / `.set` / `.del` — manage provider
+      connection records in the Hive.
+
+    Every route additionally requires the organization to be subscribed to
+    `ext-cloud-inventory`; unsubscribed organizations receive `403`.
+
+## Documentation
+
+- [Getting Started](getting-started.md) — subscribe, connect a provider, run
+  your first sweep.
+- [Findings & Triage](findings.md) — the worklist, finding classes,
+  dispositions, chokepoints.
+- [Security Graph & Queries](graph.md) — attack paths, graph queries, CIEM,
+  DSPM, sensor↔asset resolution.
+- [Compliance](compliance.md) — frameworks, reports, scoped assignments.
+- [CAASM](caasm.md) — third-party asset inventory and coverage gaps.
+- [Configuration Reference](configuration.md) — the `cloudsec_provider`,
+  `cloudsec_policy`, and `cloudsec_query` Hive records.
+- [Command Line Interface](cli.md) — the `limacharlie cloudsec` command
+  group.
+- [API Reference](api-reference.md) — the `/cloudsec` REST surface.
+- [Automation & IaC](automation.md) — onboarding recipes, CSV exports, and
+  the findings↔Cases loop.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -564,6 +564,18 @@ nav:
           - Case-Reviewer Agent: 9-ai-sessions/compliance/case-reviewer-agent.md
           - Gap Analysis: 9-ai-sessions/compliance/gap-analysis.md
 
+  - Cloud Security:
+      - Overview: cloud-security/index.md
+      - Getting Started: cloud-security/getting-started.md
+      - Findings & Triage: cloud-security/findings.md
+      - Security Graph & Queries: cloud-security/graph.md
+      - Compliance: cloud-security/compliance.md
+      - CAASM: cloud-security/caasm.md
+      - Configuration Reference: cloud-security/configuration.md
+      - Command Line Interface: cloud-security/cli.md
+      - API Reference: cloud-security/api-reference.md
+      - Automation & IaC: cloud-security/automation.md
+
   - Apps:
       - Overview: apps/index.md
       - Creating & Managing Apps: apps/creating-and-managing-apps.md


### PR DESCRIPTION
## Summary

Adds a new top-level **Cloud Security** section (10 pages) documenting the CNAPP product end to end, modeled on the AI Sessions / Apps section structure. **This is now the single CNAPP docs PR — it supersedes and absorbs #291 (closed).**

| Page | Covers |
|---|---|
| Overview | capability map (inventory/CSPM, attack paths, CIEM, DSPM, compliance, CAASM, security graph, runtime fusion), the 7 supported providers, how it works, permissions |
| Getting Started | `ext-cloud-inventory` subscription, secret-backed provider records for every provider type, the pre-save credential test, first sweep, crown-jewel classification |
| Findings & Triage | worklist / `lc_risk` / finding classes, dispositions (incl. reopen and accepted-with-expiry), owner/ticket, chokepoints, overview/changes/risk-trend |
| Security Graph & Queries | node/edge model, attack paths, 1-hop neighbors, query pack + text/DSL queries, CIEM views, DSPM facets, inventory, sensor↔asset resolution |
| Compliance | live per-control reports, frameworks, scoped assignments (`compliance` policy) |
| CAASM | merged third-party asset inventory, expected-coverage policy, coverage gaps, record ingest |
| Configuration Reference | `cloudsec_provider` / `cloudsec_policy` (all 7 `policy_type` variants) / `cloudsec_query` record schemas |
| CLI | the `limacharlie cloudsec` command group (python-limacharlie PR #310) |
| API Reference | the full `/v1/cloudsec/{oid}` REST surface: 26 reads + 9 writes, finding shape, `cloud_finding.*` events, bulk-resolve caps and CSV export |
| Automation & IaC | tenant onboarding + multi-tenant policy recipes, suppression rules, server-side CSV export, the findings↔Cases D&R loop |

All schemas and routes were verified against the current implementation (hive record definitions, gateway route registrations) rather than the stale design docs.

## Absorbed from #291

The API/CSV/IaC/case-automation reference content now lives in the API Reference and Automation & IaC pages, including the overview `usage` metering block and chokepoint principal-exposure metrics, with the provider-record example corrected to the actual schema (`gcp_scope` + `credentials: hive://secret/…` instead of `scope` + `secret.secret_name`).

## Notes

- No screenshots yet — the UI walkthrough imagery can be added in the pre-GA pass.
- The orphaned marketing page `1-getting-started/use-cases/cloud-security.md` (not in nav) was left untouched; it may deserve a cross-link or retirement when this ships.
- `mkdocs build --strict` and `markdownlint-cli2` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrqM5AzjBtH7F9hFN4aGjw