### PR TITLE
docs: correct payload RECEIPT stdout/stderr cap to 1 MB

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/payloads.md
+++ b/docs/2-sensors-deployment/endpoint-agent/payloads.md
@@ -19,7 +19,7 @@ It is possible to set the Payload's file extension on the endpoint by making the
 
 Payloads are uploaded to the LimaCharlie platform and given a name. The task `run` can then be used with the `--payload-name MY-PAYLOAD --arguments "-v EulaAccepted"` can be used to run the payload with optional arguments.
 
-The STDOUT and STDERR data will be returned in a related `RECEIPT` event, up to ~10 MB. If your payload generates more data, we recommend to pipe the data to a file on disk and use the `log_get` command to retrieve it.
+The STDOUT and STDERR data will be returned in a related `RECEIPT` event, up to 1 MB. If your payload generates more data, we recommend to pipe the data to a file on disk and use the `log_get` command to retrieve it.
 
 The payload is retrieved by the endpoint agent over HTTPS to the Ingestion API DNS endpoint. This DNS entry is available from the Sensor Download section of the web app if you need to allow it.
 


### PR DESCRIPTION
The Payloads page said STDOUT/STDERR come back in the `RECEIPT` event "up to ~10 MB", but the `run` task hardcodes the max size sent to the sensor at 1 MB, which is what the sensor enforces when capturing the output buffers. Corrected to 1 MB; the existing guidance to pipe larger output to a file and use `log_get` stays.

Follow-up from customer questions on `run` receipt semantics (same thread that prompted #302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UqKFhW4MXA1B33f6ohJ8D