### PR TITLE
docs(sensors): document upgrade_core command and uninstall --native flag

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/service-upgrades.md
+++ b/docs/2-sensors-deployment/endpoint-agent/service-upgrades.md
@@ -63,6 +63,26 @@ The `-u` flag requires sensor version **4.33.28 or later**.
     hcp_win_x64_release_4.33.28.exe -u
     ```
 
+## Upgrade from the Cloud with the `upgrade_core` Command (Beta)
+
+Instead of running an installer on the host, you can task a sensor to upgrade its own on-disk agent with the `upgrade_core` sensor command. The sensor downloads, verifies, and installs the requested release itself — no local shell access or installer download is required. The automatic rollback on a failed start applies here as well.
+
+The native upgrade procedure is currently in beta, so the `--beta` flag is required; the command is rejected without it.
+
+```bash
+limacharlie sensor task <SID> upgrade_core --beta
+```
+
+Optional flags:
+
+- `--force`: upgrade even if the sensor already reports the latest available release.
+- `--version`: pin the exact release to install (e.g. `5.3.3`) instead of the latest; downgrades are allowed.
+
+!!! note
+The `upgrade_core` command requires sensor version **5.3.3 or later**. Sensors running an older version silently drop the request and no upgrade takes place.
+
+See the [endpoint commands reference](../../8-reference/endpoint-commands.md#upgrade_core) for more detail.
+
 ## Advanced: Forcing an Upgrade
 
 By default an in-place upgrade (`-u`) only replaces the installed service when the supplied binary is newer than what is installed. To re-apply or move to a build that is not strictly newer (for example to re-deploy a known-good version), set the `LC_UPGRADE_SKIP_VERSION_CHECK` environment variable to `1` (or `true`) on the upgrade process. This bypasses the version comparison and replaces the installed service unconditionally.

--- a/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/uninstallation.md
@@ -12,9 +12,24 @@ Details on manual uninstallation is found at the bottom of each respective OS' i
 
 ### Sensor Commands
 
-For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. See the [endpoint commands reference](../../8-reference/endpoint-commands.md) for more detail.
+For macOS and Windows operating systems, you can uninstall a sensor with the `uninstall` command. See the [endpoint commands reference](../../8-reference/endpoint-commands.md#uninstall) for more detail.
 
 On Windows, the command defaults to uninstalling the sensor as if installed from the direct installer exe. If an MSI was used for installation, you can add a `--msi` flag to the `uninstall` command to trigger an uninstallation that is compatible with MSI.
+
+#### Native vs Legacy Uninstall
+
+By default, the `uninstall` command uses the legacy procedure: the sensor runs a shell command that invokes the on-disk agent's own uninstaller. This works on every sensor version.
+
+Adding the `--native` flag instead instructs the sensor to uninstall itself using its built-in (native) uninstall procedure, without spawning a shell command:
+
+```bash
+uninstall --is-confirmed --native
+```
+
+!!! note
+    The `--native` flag requires sensor version **5.3.3 or later**. Sensors running an older version silently ignore the native uninstall request — the task appears to be sent successfully, but nothing happens on the endpoint. If you are unsure of a sensor's version, omit `--native` to use the legacy procedure.
+
+The `--msi` flag takes precedence over `--native`: the native procedure does not unregister the MSI product, so sensors installed via MSI should continue to use `--msi`.
 
 ### SDK
 

--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -53,7 +53,8 @@ For commands which emit a report/reply event type from the agent, the correspond
 | [segregate\_network](#segregate_network) | [SEGREGATE\_NETWORK](edr-events.md#segregate_network) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | set\_performance\_mode | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | shutdown |  | ☑️ | ☑️ | ☑️ |  |  |
-| uninstall | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [uninstall](#uninstall) | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [upgrade\_core](#upgrade_core) | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | [yara\_scan](#yara_scan) | [YARA\_DETECTION](edr-events.md#yara_detection) | ☑️ | ☑️ | ☑️ |  |  |
 | yara\_update | N/A | ☑️ | ☑️ | ☑️ |  |  |
 | epp\_status | [EPP\_STATUS\_REP] | ☑️ |  |  |  |  |
@@ -939,6 +940,60 @@ Isolate a sensor from the network (except LimaCharlie cloud connectivity).
 
 ```bash
 limacharlie sensor task <SID> segregate_network
+```
+
+---
+
+### uninstall
+
+Uninstall the sensor from the endpoint.
+
+**Platforms:** macOS | Windows | Linux
+
+**Parameters:**
+
+- `--is-confirmed` (required): Must be specified as a confirmation that you want to uninstall the sensor
+- `--msi` (optional): Windows only — must be specified if the sensor was installed via MSI
+- `--native` (optional): Use the sensor's built-in (native) uninstall procedure instead of the default legacy shell-based procedure
+
+By default, the sensor uninstalls itself by running a shell command that invokes the on-disk agent's own uninstaller. This legacy procedure works on every sensor version. With `--native`, the sensor performs the uninstallation itself without spawning a shell command.
+
+> **Note:** `--native` requires sensor version 5.3.3 or later. Older sensors silently ignore the native uninstall request — nothing happens on the endpoint. If you are unsure of a sensor's version, omit `--native`.
+
+`--msi` takes precedence over `--native`: the native procedure does not unregister the MSI product, so sensors installed via MSI should use `--msi`.
+
+**Response Event:** None (sensor uninstalls and disconnects)
+
+**Usage Example:**
+
+```bash
+limacharlie sensor task <SID> uninstall --is-confirmed
+limacharlie sensor task <SID> uninstall --is-confirmed --native
+```
+
+---
+
+### upgrade_core
+
+Task the sensor to upgrade its own on-disk agent (the installed service) to a new release. The sensor downloads, verifies, and installs the release itself; if the new version fails to start, it automatically rolls back to the previous one. See [Service Upgrades](../2-sensors-deployment/endpoint-agent/service-upgrades.md) for the full upgrade procedure.
+
+**Platforms:** macOS | Windows | Linux
+
+**Parameters:**
+
+- `--beta` (required): Opt in to the native upgrade procedure; the command is rejected without it while the feature is in beta
+- `--force` (optional): Upgrade even if the sensor already reports the latest available release
+- `--version` (optional): Pin the exact release to install (e.g. `5.3.3`), downgrades included; defaults to the latest available release
+
+> **Note:** Requires sensor version 5.3.3 or later. Sensors running an older version silently drop the request and no upgrade takes place.
+
+**Response Event:** None
+
+**Usage Example:**
+
+```bash
+limacharlie sensor task <SID> upgrade_core --beta
+limacharlie sensor task <SID> upgrade_core --beta --version 5.3.3
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documents the two new sensor lifecycle commands added in legion_tasking-go. Both route to the sensor's native (collector_35) lifecycle procedures introduced in sensor release **v5.3.3** — sensors on older versions silently drop the requests.

- **`docs/8-reference/endpoint-commands.md`**: added `upgrade_core` to the supported-commands table and wrote full reference entries for `uninstall` (`--is-confirmed`, `--msi`, `--native`) and `upgrade_core` (`--beta`, `--force`, `--version`), each with the 5.3.3 version note and usage examples.
- **`docs/2-sensors-deployment/endpoint-agent/uninstallation.md`**: new "Native vs Legacy Uninstall" subsection — the default remains the legacy shell-based procedure (works on every sensor version), `--native` opts into the sensor's built-in uninstall (5.3.3+), and `--msi` takes precedence over `--native` since the native path does not unregister the MSI product.
- **`docs/2-sensors-deployment/endpoint-agent/service-upgrades.md`**: new "Upgrade from the Cloud with the `upgrade_core` Command (Beta)" section — the sensor downloads, verifies, and installs the release itself with automatic rollback; `--beta` is strictly required, with optional `--force` and `--version` (downgrades allowed).

Markdownlint passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)