### PR TITLE
docs(reference): fix dir_list command syntax in endpoint commands

### DIFF
--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -98,16 +98,16 @@ List files and directories at a specified path on the endpoint.
 
 **Parameters:**
 
-- `dir_path` (required): Directory path to list
-- `depth` (optional): Recursion depth (default: 0 = no recursion)
-- `file_pattern` (optional): File pattern filter (e.g., "*.exe")
+- `rootdir` (positional): Root directory where to begin the listing from
+- `fileexp` (positional): File name expression supporting basic wildcards like `*` and `?` (e.g., "*.exe")
+- `-d, --depth` (optional): Maximum depth of the listing, defaults to a single level
 
 **Response Event:** DIR_LIST_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> dir_list --dir_path "C:\\Windows\\System32" --depth 1
+limacharlie task send --sid <SID> --task 'dir_list "C:\\Windows\\System32" "*.exe" --depth 1'
 ```
 
 **Sample Response:**


### PR DESCRIPTION
## Summary

The `dir_list` section in `docs/8-reference/endpoint-commands.md` documented named flags (`--dir_path`, `--file_pattern`) that the command parser does not accept — copying the usage example results in a parse error.

The actual syntax is:

```
dir_list ROOTDIR FILEEXP [-d|--depth DEPTH]
```

- `rootdir` (positional): root directory where to begin the listing from
- `fileexp` (positional): file name expression supporting basic wildcards like `*` and `?`
- `-d, --depth` (optional): maximum depth of the listing, defaults to a single level

## Changes

- Replaced the invented flags with the actual positional parameters and `--depth` flag
- Updated the usage example to the current CLI form, verified against the stable `limacharlie` 5.5.1 release on PyPI: `limacharlie task send --sid <SID> --task 'dir_list "C:\\Windows\\System32" "*.exe" --depth 1'`

Note: several other command sections in this file have the same invented-flag issue (e.g. `file_get`, `file_hash`, `dns_resolve`, `file_mov`). This PR only fixes `dir_list`; a broader sweep can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)