### PR TITLE
Document Plaso send_to_timeline timeline ingestion option

### DIFF
--- a/docs/5-integrations/extensions/third-party/plaso.md
+++ b/docs/5-integrations/extensions/third-party/plaso.md
@@ -45,9 +45,23 @@ The following events will be pushed to the `ext-plaso` sensor timeline:
 
 - `job_queued`: indicates that `ext-plaso` has received and queued a request to process data
 - `job_started`: indicates that `ext-plaso` has started processing the data
+- `job_failed`: indicates that the processing job failed; the `error` field contains the reason
 - `pinfo`: contains the `pinfo.py` output summarizing the results of the plaso file generation
 - `plaso`: contains the `artifact_id` of the plaso file that was uploaded to LimaCharlie
-- `csv`: contains the `artifact_id` of the CSV file that was uploaded to LimaCharlie
+- `csv`: contains the `artifact_id` of the CSV file that was uploaded to LimaCharlie; when timeline ingestion is enabled, it also reports `events_sent_to_timeline` and `rows_skipped`
+- `plaso_event`: one event per row of the generated timeline, only when timeline ingestion is enabled (see [Timeline Ingestion](#timeline-ingestion))
+
+## Timeline Ingestion
+
+By default, the generated timeline is only available as downloadable `.plaso` and `.csv` artifacts. Setting the optional `send_to_timeline` parameter to `true` on a `generate` request additionally ingests every row of the generated CSV timeline as an individual `plaso_event` event on the `ext-plaso` sensor timeline.
+
+Each `plaso_event` carries the timeline columns under `results`, including the forensic timestamp (`results/datetime`), the plaso parser that produced the entry, and the event message. Rows are ingested in chronological order (as sorted by `psort`), making the full forensic timeline searchable with LCQL and usable in D&R rules. Combined with the automation below, this enables an end-to-end triage workflow — collection, timeline generation, and detection — entirely within LimaCharlie.
+
+Ingestion Volume
+
+A Plaso timeline for a full triage collection can contain hundreds of thousands to millions of rows. Enabling `send_to_timeline` ingests all of them as events, which is billed as regular event ingestion volume.
+
+Rows of the CSV that cannot be parsed are skipped rather than failing the job; the final `csv` status event reports how many events were ingested (`events_sent_to_timeline`) and how many rows were skipped (`rows_skipped`).
 
 ## Usage & Automation
 
@@ -82,7 +96,10 @@ If you use the LimaCharlie [Velociraptor](velociraptor.md) extension, a good use
      extension name: ext-plaso
      extension request:
          artifact_id: '{{ .routing.log_id }}'
+         send_to_timeline: true
    ```
+
+   The `send_to_timeline` parameter is optional; when set to `true`, the resulting timeline rows are also ingested as `plaso_event` events (see [Timeline Ingestion](#timeline-ingestion)).
 
 2. Launch a `Windows.KapeFiles.Targets` artifact collection in the LimaCharlie Velociraptor extension. This instructs Velociraptor to gather all endpoint artifacts defined in [this KAPE Target file](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/KapeTriage.tkape).
 
@@ -188,3 +205,7 @@ Running the extension generates the following useful outputs:
    The downloadable `.plaso` file contains the raw output of `log2timeline.py` and can be [imported into Timesketch](https://timesketch.org/guides/user/upload-data/) as a timeline.
 - `csv` artifact
    The downloadable `.csv` file can be easily viewed in any CSV viewer, but a highly recommended tool for this is [Timeline Explorer](https://ericzimmerman.github.io/) from Eric Zimmerman.
+
+### Timeline Events
+
+If the request was made with `send_to_timeline: true`, the full timeline is also available as `plaso_event` events on the `ext-plaso` sensor timeline, where it can be explored chronologically, queried with LCQL, and matched by D&R rules. See [Timeline Ingestion](#timeline-ingestion).


### PR DESCRIPTION
Documents the new `send_to_timeline` option of the Plaso extension:

- New **Timeline Ingestion** section: opting in ingests every row of the generated CSV timeline as a `plaso_event` event on the `ext-plaso` sensor timeline (chronological order, forensic timestamp and parser under `results`), making the full forensic timeline LCQL-searchable and usable in D&R rules; includes the ingestion-volume/billing caveat and the skipped-rows behavior.
- Updated the sensor-timeline events list: new `job_failed` and `plaso_event` events, and the `events_sent_to_timeline` / `rows_skipped` fields on the `csv` event.
- The Velociraptor triage automation example now shows the optional `send_to_timeline` parameter in the D&R extension request.
- New **Timeline Events** note under Working with the Output.

Matches ext-plaso as of v1.0.18. markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q3qRXuhUQ8ZqgtNmCxno3