### PR TITLE
docs(cloud-security): refresh product docs to current backend + web UI

### DIFF
--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -16,15 +16,27 @@ All Cloud Security routes live under `https://api.limacharlie.io/v1/cloudsec/{oi
 and appear in the public OpenAPI spec at
 [`/openapi`](https://api.limacharlie.io/openapi). Reads require the `cloudsec.get`
 permission, finding-triage writes require `cloudsec.set`, and every route requires
-the organization to be subscribed to the cloud security extension (a `403` tells
-you to subscribe).
+the organization to be subscribed to the `ext-cloud-security` extension (a `403`
+tells you to subscribe).
 
 The read surface includes: `findings` (risk-ranked worklist with keyset pagination
-and server-side filters), `findings/facets`, `attack-paths` (with the same filter
-selectors), `chokepoints` (incl. the principal-exposure metrics), `ciem/public-access`,
-`inventory` (+`inventory/facets`), `compliance` (+`compliance/frameworks`),
-`overview` (incl. the per-tenant `usage` metering block), `risk-trend`, `changes`,
-`scan-status`, `query` (the graph DSL), and `graph/neighbors`.
+and server-side filters), `findings/facets`, `findings/classes` (the canonical
+finding-class enum), `attack-paths` (with the same filter selectors), `chokepoints`
+(incl. the principal-exposure metrics), `ciem/public-access`, `ciem/facets`,
+`ciem/identity` (the Identity 360 view, `?urn=`), `inventory` (+`inventory/facets`),
+`data-security/facets`, `topology` (server-side estate aggregates), `compliance`
+(+`compliance/frameworks`, `compliance/assignments`), `policy/vocabulary` (the
+classification-policy vocabulary), `providers/manifest` (what a provider collects),
+`caasm/assets`, `caasm/coverage`, `caasm/policy`, `overview` (incl. the per-tenant
+`usage` metering block), `risk-trend`, `changes`, `scan-status`, `query` (the graph
+DSL), and `graph/neighbors`. There is also a multi-org (no `{oid}`)
+`fleet/overview` route that rolls risk up across every tenant you manage. Three
+read-only preview POSTs help you author policy before you commit it —
+`simulate/resources` (test a classification/coverage/exclusion matcher against
+stored inventory), `simulate/findings` (test a suppression matcher against open
+findings), and `policy/suggest` (live matcher-value autocomplete from the tenant
+estate). See the [API Reference](../cloud-security/api-reference.md) for the full
+route list and response shapes.
 
 ### CSV export
 
@@ -50,8 +62,8 @@ multi-tenant policy management a script, not a UI workflow.
 
 | Hive | Record | Purpose |
 |---|---|---|
-| `cloudsec_provider` | one per cloud/IdP connection | what to collect (GCP / AWS / Azure / Okta / Google Workspace) |
-| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation), `scanning` (agentless YARA), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules) |
+| `cloudsec_provider` | one per connection | what to collect — one of thirteen connectors spanning cloud infra, identity/IdP, SaaS, AI, and LimaCharlie self-inventory (see [Providers](../cloud-security/providers.md) for the full list) |
+| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation), `scanning` (agentless YARA), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
 | `cloudsec_query` | one per saved query | org-shared saved graph queries (the Query Console library) |
 
 ### Onboarding a tenant (recipe)
@@ -64,8 +76,9 @@ limacharlie extension subscribe --name ext-cloud-security --oid $OID
 cat > provider.json <<EOF
 {
   "provider_type": "gcp",
-  "scope": "organizations/123456789",
-  "secret": {"secret_name": "hive://secret/gcp-collector-sa"},
+  "gcp_scope": "organizations/123456789",
+  "credentials": "hive://secret/gcp-collector-sa",
+  "internal_domains": ["acme.com"],
   "sync_now": "onboard-1"
 }
 EOF
@@ -151,6 +164,10 @@ the internally-provisioned `cloudsec` webhook adapter: `cloud_finding.created`
 (`{finding_id, fingerprint, finding_class}`), and `cloud_finding.still_open`
 (re-asserted at most once per day for open findings with a linked ticket). D&R
 rules match these like any event; the Cases extension actions close the loop.
+For richer automation the same stream also carries `cloud_finding.updated` (an
+open finding's content materially changed — a severity flip or vuln-set change)
+and the operator-disposition verbs `cloud_finding.resolved` / `.dismissed` /
+`.reopened` / `.assigned` (for auditing human triage decisions).
 
 The console installs these three rules with one click (Settings → Cloud Security →
 Cases, an opt-in), or write them yourself:

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -11,10 +11,14 @@ OpenAPI spec at [`/openapi`](https://api.limacharlie.io/openapi).
 Authentication is the standard `Authorization: Bearer <JWT>` header.
 
 !!! info "Permissions & enable gate"
-    Reads require `cloudsec.get`; writes require `cloudsec.set`. Every route
-    requires the organization to be subscribed to `ext-cloud-security` — a
-    `403` on any route means subscribe first. The `oid` is always taken from
-    the authorized path.
+    Reads — and the read-only preview `POST`s (`query`, `simulate/resources`,
+    `simulate/findings`, `policy/suggest`) — require `cloudsec.get`; every
+    other write requires `cloudsec.set`. Every route requires the
+    organization to be subscribed to `ext-cloud-security` — a `403` on any
+    route means subscribe first. The `oid` is always taken from the
+    authorized path. Provider *records* are not `/cloudsec` routes: their
+    CRUD goes through Hive (`cloudsec_provider` hive, gated by
+    `cloudsec_provider.get/set/del`).
 
 Shared behaviors:
 
@@ -23,9 +27,11 @@ Shared behaviors:
   OR within a key, AND across keys. At most 100 values per filter key.
 - **Keyset pagination**: pages carry `next_cursor`; pass it back as
   `?cursor=`. `limit` is clamped to 1000.
-- **CSV export**: `findings`, `inventory`, `compliance`, and `query` accept
-  `?format=csv` to stream the full filtered set as a CSV attachment
-  (server-side walk, capped at 100,000 rows, in-band `#` truncation notice).
+- **CSV export**: exactly four routes accept `?format=csv` to stream the
+  full filtered set as a CSV attachment — `findings`, `inventory`, and
+  `compliance` (`GET`), and `query` (`POST`). The stream is a server-side
+  keyset walk, capped at 100,000 rows, with an in-band `#`-comment truncation
+  notice when the cap is hit.
 
 ## Reads
 
@@ -33,16 +39,21 @@ Shared behaviors:
 |---|---|
 | `GET /findings` | `{findings, next_cursor}` — the risk-ranked worklist. Filters: `severity[]`, `finding_class[]`, `status[]`, `account[]`, `reachable`, `kev`, `q`, `sort`, `order`, `cursor`, `limit`. |
 | `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors. |
+| `GET /findings/classes` | `{classes}` — the canonical `finding_class` enum (the 11 values), for building selectors. |
 | `GET /findings/{finding_id}` | `{finding}` — one finding in full. |
 | `GET /attack-paths` | `{paths}` — marquee toxic-combination paths. Filters: `severity[]`, `account[]`, `status[]`, `q`. |
 | `GET /chokepoints` | `{chokepoints, total_paths}` — shared attack-path hops ranked by paths broken, including the principal-exposure metrics. |
 | `GET /ciem/public-access` | `{access}` — public/external access to sensitive resources. |
 | `GET /ciem/facets` | `{facets}` — identity facet counts. |
-| `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `account`, `region`, `q`, paging. |
+| `GET /ciem/identity?urn=` | `{identity}` — the Identity 360 single-identity rollup for one principal URN: its grants, reachable sensitive resources, access levels, and escalation paths. |
+| `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `provider`, `account`, `region`, `q`, paging. |
 | `GET /inventory/facets` | Inventory facet counts by type/account/region. |
 | `GET /data-security/facets` | `{facets}` — DSPM data-store rollup. |
 | `GET /resource?urn=` | `{resource}` — the canonical record for any URN (null when unknown). |
 | `GET /graph/neighbors?urn=` | `{graph: {nodes, edges}}` — 1-hop expansion; `limit` default 200, cap 500; `truncated` flag. |
+| `GET /topology` | `{scopes, edges, available}` — the server-side estate aggregate behind the Topology diagram (scope nodes + the edges between them). The `available` flag is `false` when the estate is too large to aggregate inline. |
+| `GET /policy/vocabulary` | `{vocabulary}` — the classification-policy vocabulary: the per-surface matcher-capability table, closed vocabularies (resource types, content classes), and the org's in-use value histograms. |
+| `GET /providers/manifest?type=` | `{manifest}` — the per-provider coverage manifest ("what you get"): the resource kinds, edges, and checks a given `provider_type` produces. |
 | `GET /queries` | `{queries}` — the named query pack (name, title, description, query). |
 | `POST /query` | `{rows}` — run a graph query. Body: exactly one of `named` / `text` / `query` (DSL object), optional `project`. |
 | `GET /compliance` | `{report}` — per-control assessment. Params: `framework` (default `cis-gcp`) or `assignment` (overrides `framework`). |
@@ -57,6 +68,20 @@ Shared behaviors:
 | `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, paging. |
 | `GET /caasm/coverage` | `{findings, next_cursor}` — coverage-gap findings. Params: `status[]`, `severity[]`, `q`, `sort`, `order`, paging. |
 | `GET /caasm/policy` | Resource-list shape: zero rows (no policy) or one row whose `props` is the policy. |
+
+!!! note "`ciem/*` and `providers/*` families"
+    `ciem/*` now has three members — `public-access`, `facets`, and
+    `identity`. `providers/*` has two — `test` (`POST`, below) and `manifest`
+    (`GET`, above). Creating, editing, and deleting provider *records* is not
+    a `/cloudsec` route: it goes through the `cloudsec_provider` Hive.
+
+## Fleet (multi-org)
+
+One route sits outside the `{oid}` path — the MSSP cross-tenant board:
+
+| Route | Returns |
+|---|---|
+| `GET /cloudsec/fleet/overview` | `{orgs, rollups, total_orgs, skipped, next_cursor}` — risk posture rolled up across many organizations, with the tenants that could not be included counted in `skipped`. Params: `oids[]` (repeat to select tenants), `group` (a saved fleet group), `trend_days`, `cursor`, `limit`. Requires `cloudsec.get` on each tenant in scope. |
 
 ## Writes
 
@@ -82,6 +107,23 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
   -d '{"resolution": {"kind": "accepted", "reason": "SEC-123", "expires_at": 1767225600}}'
 ```
 
+## Policy authoring: Simulate & vocabulary
+
+These `POST` routes back the console's policy-authoring aids (matcher
+preview and value autocomplete). They never mutate state, so they require
+only `cloudsec.get`. There is **no CLI command** for them — they are
+console + REST-API only.
+
+| Route | Body | Returns |
+|---|---|---|
+| `POST /simulate/resources` | `{rules, target, resource_types?, sample_limit?}` — `rules` is a list of matcher rules, `target` names the surface (e.g. `data_stores`, `compute`, `identities`). | `{evaluated, matched, indeterminate, truncated, sample}` — preview a classification / coverage / exclusion matcher against stored inventory. |
+| `POST /simulate/findings` | `{match, sample_limit?}` — a suppression matcher. | `{evaluated, matched, indeterminate, truncated, sample}` — preview it against currently-open findings. |
+| `POST /policy/suggest` | `{dimension, q, target, limit?}` — `dimension` is `name` or `account`. | `{suggestions}` — live matcher-value autocomplete drawn from the tenant estate. |
+
+Pair these with `GET /policy/vocabulary` (the closed vocabularies and
+per-surface capability table) and `GET /findings/classes` (the
+`finding_class` enum) when building a classification or suppression policy.
+
 ## Finding shape
 
 The finding object (list, get, and the `cloud_finding.created` event all
@@ -90,13 +132,14 @@ carry the same shape) — key fields:
 | Field | Meaning |
 |---|---|
 | `finding_id`, `fingerprint` | Stable identity of the condition (`fnd_` + fingerprint prefix). |
-| `rule_id`, `finding_class`, `classification` | What detected it and its class (`toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`). |
+| `rule_id`, `finding_class`, `classification` | What detected it and its class — one of the 11 values: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`. |
 | `severity`, `lc_risk`, `risk_breakdown` | `CRITICAL`–`INFO`, the 0–1000 composite, and its explanation. |
 | `title`, `resource_urn`, `resource_name`, `resource_type`, `account`, `region` | The affected resource. |
-| `related_urns`, `path` | Related resources; the hop list for path findings. |
+| `related_urns`, `path`, `path_kind` | Related resources; the hop list for path findings and the kind of path it represents. |
+| `source_scope`, `target_scope` | For attack-path / toxic findings, the durable workload group at each end (GKE/EKS/AKS node pool, MIG, ASG, VMSS) — `group_urn`, `group_kind`, `member_count`, `affected_count`, `members` — so the finding headlines the shared-fix group, not a churny ephemeral node. |
 | `reachable`, `in_kev`, `vulns`, `epss`, `epss_percentile` | Exposure and exploit intelligence; `vulns` entries carry `cve`, `package`, `package_version`, `fix_version`, `cvss_score`. |
 | `evidence`, `remediation` | The offending configuration and the fix. |
-| `ciem_access` | For identity findings: role, identity kind, public/external/privileged flags, grant path. |
+| `ciem_access` | For identity findings: role, identity kind, public/external/privileged flags, grant path, and the classified data-plane **access level** / capability (`data_admin` > `data_write` > `data_read` > `metadata` > `none`) the grant confers. |
 | `runtime_sids` | Sensors resolved onto the affected asset. |
 | `status`, `resolution`, `resolved_by`, `resolution_expires_at`, `owner`, `ticket` | The triage overlay. |
 | `first_seen`, `last_seen` | Lifecycle timestamps. |
@@ -105,13 +148,34 @@ carry the same shape) — key fields:
 
 With finding/resource emission enabled (see the
 [`emission` policy](configuration.md#emission-the-event-feed)), the
-platform emits into the organization's event stream:
+platform emits into the organization's event stream.
 
-- `cloud_finding.created` — full finding under `event/finding`.
+**Detection-truth lifecycle** (from the projector):
+
+- `cloud_finding.created` — the full finding (including `runtime_sids`)
+  under `event/finding`.
+- `cloud_finding.updated` — an open finding materially changed (severity
+  flip, vuln set). Payload `{finding_id, fingerprint, finding_class,
+  changed, old_severity, new_severity, finding}`.
 - `cloud_finding.closed` — `{finding_id, fingerprint, finding_class}`.
-- `cloud_finding.still_open` — re-asserted at most daily for open findings
-  with a linked ticket.
-- `cloud_resource.*` — inventory change events.
+- `cloud_finding.still_open` — re-asserted at most once a day for open
+  findings with a linked ticket (the case-sync verb).
+
+**Operator disposition** (from the triage write handlers) — flat payload
+`{finding_id, fingerprint, finding_class, actor, note?}`:
+
+- `cloud_finding.resolved`, `cloud_finding.dismissed`,
+  `cloud_finding.reopened`, `cloud_finding.assigned`.
+
+**Summary & inventory:**
+
+- `cloudsec.sync_completed` — emitted once on the first-ever (or rebuilt)
+  projection in place of a per-finding `created` flood; payload
+  `{total, by_class, by_severity}`.
+- `cloud_resource.created`, `cloud_resource.updated`,
+  `cloud_resource.deleted` — inventory change events (off by default).
+
+Every payload also carries `event_type` and `oid`.
 
 See [Automation & IaC](automation.md#findings-cases-automation) for D&R
 rules that consume them.

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -60,6 +60,13 @@ for OID in $(cat tenant-oids.txt); do
 done
 ```
 
+!!! tip "Fleet-wide roll-up"
+    Beyond pushing policy to N orgs, the cross-tenant fleet board rolls risk
+    up across every org you manage — `limacharlie cloudsec fleet overview`
+    (see the [CLI](cli.md)), the multi-org `fleet/overview` route (see the
+    [API Reference](api-reference.md)), and the console's Cloud Security Fleet
+    view. It's the MSSP read half of the same fleet story.
+
 ## Suppression rules (finding disposition policy)
 
 A `suppression`-typed `cloudsec_policy` record dispositions matching
@@ -126,7 +133,9 @@ ids — the auditor-facing evidence export.
 !!! note "CLI `--output csv` is per-page"
     The CLI's global `--output csv` formats the rows the command returned —
     one page. For a full-estate export use the `?format=csv` server-side
-    walk above.
+    walk above, or the `limacharlie cloudsec export` subgroup
+    (`export findings|inventory|compliance|query [-o file]`), which drives the
+    same server-side full-set walk and writes the CSV to a file.
 
 ## Findings ↔ Cases automation
 
@@ -198,6 +207,28 @@ the finding fingerprint), so the rules never need a case number; a finding
 with no linked case is a no-op. Cases never close findings — findings are
 detection truth and close when the sweep confirms the fix (or via
 operator/policy disposition).
+
+!!! info "More lifecycle events for richer automation"
+    The `created` / `closed` / `still_open` verbs above are the Cases loop,
+    but D&R rules can key off more of the finding lifecycle:
+
+    - `cloud_finding.updated` — an **open** finding's content materially
+      changed (a severity flip or a change to its vuln set) without re-firing
+      on every sweep. Payload carries `changed[]` (the fields that moved),
+      `old_severity`, `new_severity`, and the full `finding` — the hook for
+      reacting to escalation (e.g. re-notify only when a finding crosses into
+      CRITICAL).
+    - `cloud_finding.resolved` / `.dismissed` / `.reopened` / `.assigned` —
+      the operator-disposition verbs, flat payload with an `actor` field, for
+      auditing human triage decisions (who accepted/muted/reopened what).
+    - `cloudsec.sync_completed` — the first-sync summary
+      (`{total, by_class, by_severity}`) emitted once instead of a
+      per-finding `created` flood, so onboarding a large estate is one event,
+      not thousands.
+    - `cloud_resource.created` / `.updated` / `.deleted` — inventory-level
+      change events, gated by the [`emission`
+      policy](configuration.md#emission-the-event-feed)'s `resource_events`
+      flag (**off by default**).
 
 **Non-Cases shops:** route the same `cloud_finding.*` events to
 Jira/ServiceNow via an Output and key your tickets on `fingerprint` the same

--- a/docs/cloud-security/caasm.md
+++ b/docs/cloud-security/caasm.md
@@ -13,18 +13,45 @@ required tool does **not** see.
 
 ## The merged asset inventory
 
-Records from connected sources are normalized and entity-resolved (by
-hostname, serial, MAC addresses, email, …) into one row per real asset,
-with per-source provenance retained:
+Records from connected sources are normalized and entity-resolved
+(**merge-on-read**) into one canonical asset per real device. Resolution is a
+union-find that joins records sharing a strong identifier, in priority order —
+serial, then MAC address, then cloud id, then hostname, then email — so the
+same laptop seen by the EDR, the IdP, and MDM collapses to a single row with
+per-source provenance retained:
 
 ```bash
 limacharlie cloudsec caasm assets -q laptop --limit 50
 ```
 
 Supported sources: `sentinelone`, `crowdstrike`, `defender`, `okta`,
-`entraid`, `ms_graph`, `wiz`. Telemetry the organization already ingests
-through USP adapters feeds the inventory automatically; anything else can be
-pushed through the ingest endpoint below.
+`entraid`, `ms_graph`, `wiz`, plus two **native** sources — `limacharlie`
+(your own LimaCharlie sensors, capability `edr`) and `google_workspace`
+(managed devices from the Workspace directory, capability `mdm`). The native
+sources feed automatically once the corresponding provider or sensor telemetry
+is connected — no ingest needed. Other telemetry the organization already
+pulls through USP adapters also feeds the inventory automatically; anything
+else can be pushed through the ingest endpoint below.
+
+### Managed devices and device posture
+
+Because assets are resolved per real device, CAASM can reason about **managed
+device posture**. When a source positively asserts a non-compliant state on an
+asset, CAASM raises a `device_posture` finding:
+
+| Asserted state | Severity |
+|---|---|
+| `compromised` | High |
+| `encryption` off | Medium |
+| `screen_lock` off | Low |
+| `developer_mode` on | Low |
+| `auto_update` off / OS past end-of-life | Medium |
+
+Posture checks fire only on a positive assertion — an asset that simply never
+reported a field is not flagged. A device owned by a privileged identity
+raises the finding rather than swallowing it, and `owns-device` edges
+(identity → device) join owners to their devices in the
+[security graph](graph.md), so "who owns this at-risk laptop" is one hop away.
 
 ## Declare expected coverage
 
@@ -35,7 +62,14 @@ list of "assets of these kinds must be seen by a tool with this capability":
 cat > coverage.json <<EOF
 {
   "expect": [
-    {"label": "edr-on-devices", "capability": "edr", "kinds": ["device"]}
+    {
+      "label": "edr-on-devices",
+      "capability": "edr",
+      "kinds": ["device"],
+      "severity": "HIGH",
+      "max_age_days": 30,
+      "source_max_age_days": 7
+    }
   ]
 }
 EOF
@@ -44,8 +78,30 @@ limacharlie cloudsec caasm policy set --input-file coverage.json
 limacharlie cloudsec caasm policy get
 ```
 
-The policy is validated on write; an invalid policy is rejected loudly
-rather than silently ignored.
+The policy shape is `{expect: [ ... ]}`, and each expectation rule takes:
+
+- `label` **(required)** — names the expectation; it anchors the resulting
+  finding.
+- `kinds` — asset kinds the rule applies to; defaults to `["device"]`.
+- `capability` **or** `sources` **(one required)** — either a required
+  capability (`edr`, `idp`, `mdm`, `vuln_scanner`, or `cloud_scanner`) or an
+  explicit list of source names that must see the asset.
+- `severity` — severity of the gap finding; defaults to `MEDIUM`.
+- `max_age_days` / `source_max_age_days` — staleness gates: an asset (or a
+  source's view of it) older than the window is treated as no longer covered,
+  so a stale sensor does not silently count as coverage.
+
+With no policy set, there are **no gap findings** — coverage expectations are
+entirely user-declared. The policy is validated on write; an invalid policy is
+rejected loudly rather than silently ignored.
+
+!!! note "Distinct from the `coverage` cloudsec_policy"
+    This CAASM expected-coverage policy evaluates **third-party assets** (the
+    merged device inventory: "seen by the IdP, no EDR"). It is separate from
+    the `coverage`-typed `cloudsec_policy`, which declares an EDR expectation
+    over **cloud workloads** — see
+    [Coverage — workload coverage expectations](configuration.md#coverage-workload-coverage-expectations).
+    The two are not synced.
 
 ## Coverage gaps
 

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -51,7 +51,7 @@ limacharlie cloudsec ciem facets
 limacharlie cloudsec data-security facets
 
 # Inventory & graph
-limacharlie cloudsec inventory list --type <resource-type> -q prod --limit 50
+limacharlie cloudsec inventory list --type <resource-type> --provider gcp -q prod --limit 50
 limacharlie cloudsec inventory facets
 limacharlie cloudsec resource get "lcrn:..."
 limacharlie cloudsec graph neighbors "lcrn:..." --limit 200
@@ -76,9 +76,41 @@ limacharlie cloudsec caasm policy get
 limacharlie cloudsec caasm policy set --input-file coverage.json
 limacharlie cloudsec caasm ingest --source okta --records-file users.json
 
-# Provider preflight
+# Provider preflight + coverage manifest
 limacharlie cloudsec provider test --input-file provider.json
+limacharlie cloudsec provider manifest --type gcp        # "what you get" for a provider
+
+# Full-set CSV export (server-side walk of the entire filtered set)
+limacharlie cloudsec export findings -o findings.csv
+limacharlie cloudsec export inventory -o inventory.csv
+limacharlie cloudsec export compliance --framework cis-gcp -o compliance.csv
+limacharlie cloudsec export query --named public-buckets -o public-buckets.csv
+
+# Fleet — cross-tenant (MSSP) roll-up, no single --oid
+limacharlie cloudsec fleet overview --oid $OID1 --oid $OID2 --trend-days 30
+limacharlie cloudsec fleet overview --group prod --limit 100
 ```
+
+The `export` subgroup streams the **entire** filtered set as a CSV
+(server-side keyset walk, capped at 100,000 rows) — use it for offline
+analysis. It is distinct from the per-page `--output csv`, which serializes
+only the current page of a normal list command. `export findings`,
+`export inventory`, and `export compliance` take the same filters as their
+`finding list` / `inventory list` / `compliance report` counterparts;
+`export query` takes the same `--named` / `--text` / `--query-json`
+selectors as `query run`.
+
+`fleet overview` is the multi-org board for MSSPs: pass `--oid` repeatedly
+(or `--group` to select a saved fleet group) to roll risk posture up across
+tenants. It carries `--trend-days`, `--limit`, and `--cursor` for paging the
+tenant list, and is the one command that does not resolve a single `--oid`.
+
+!!! note "CLI is the query & triage surface"
+    Simulate/preview, policy-matcher autocomplete, Topology, Identity 360,
+    scheduled queries, and workload-group views are **console + REST-API**
+    features with no CLI command — the CLI covers reads, findings triage,
+    exports, and fleet roll-up. Provider and policy *records* are managed
+    with `limacharlie hive` (see [Configuration](configuration.md)).
 
 ## Filtering and pagination
 

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -20,10 +20,31 @@ limacharlie cloudsec compliance report --framework cis-gcp
 limacharlie cloudsec compliance frameworks
 ```
 
-The report is per-control pass/fail with the proving finding ids as
-evidence, plus a summary score. The frameworks list carries `id`, `name`,
-`version`, and control counts — treat it as the source of truth for valid
+Ten frameworks ship today — `cis-aws`, `cis-azure`, `cis-gcp` (the default),
+`soc2`, `pci-dss`, `hipaa`, `iso-27001`, `nist-csf`, `nist-ai-rmf`, and
+`owasp-llm`. The last two are AI frameworks: they assess the OpenAI and
+Anthropic estate connected through the
+[AI providers](providers.md#ai-security-aispm). The set
+grows over time, so `limacharlie cloudsec compliance frameworks`
+(`GET /compliance/frameworks`) — which carries each framework's `id`, `name`,
+`version`, and control counts — is the source of truth for valid
 `--framework` values.
+
+The report is per-control, and each control lands in one of four states:
+
+- **PASS** — no open finding proves a violation of the control.
+- **FAIL** — one or more open findings prove it; their `finding_id`s are
+  attached as evidence.
+- **NOT_ASSESSED** — the control has no mapped rule yet, so nothing was
+  evaluated.
+- **NOT_APPLICABLE** — the control maps to resource types that are not in
+  scope for this assessment.
+
+A framework scoped to a single cloud assesses only that cloud's findings —
+`cis-aws` looks at AWS findings, `cis-gcp` at GCP. A framework with no
+in-scope resource types comes back **NOT_APPLICABLE** rather than a vacuous
+PASS, so an empty estate never reads as compliant. Alongside the controls the
+report carries a summary score.
 
 For auditors, the same report exports as CSV — one row per control including
 the evidence finding ids — via the API's `?format=csv`

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -12,7 +12,7 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 
 | Hive | Records | Purpose |
 |---|---|---|
-| `cloudsec_provider` | one per cloud / IdP connection | what to collect and with which credential |
+| `cloudsec_provider` | one per cloud / IdP / SaaS / AI connection | what to collect and with which credential |
 | `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, scanning, emission, exclusions, suppression, compliance assignments |
 | `cloudsec_query` | one per saved query | shared saved graph queries |
 
@@ -24,15 +24,18 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 ## cloudsec_provider
 
 One record per provider connection. `provider_type` discriminates; each type
-reads its own scope fields.
+reads its own scope fields. The full per-provider walkthrough — including the
+credential shape for each — is in [Connecting Providers](providers.md); this is
+the field reference.
 
-Common fields:
+Common fields (all provider types):
 
 | Field | Meaning |
 |---|---|
-| `provider_type` | `gcp` \| `aws` \| `azure` \| `okta` \| `1password` \| `google_workspace` \| `cloudflare` |
-| `credentials` | A `hive://secret/<name>` reference. The credential itself lives in the secret hive — it is **not** stored inline. |
-| `internal_domains` | Your own email domains (bare domains, no `@`) beyond the discoverable primary — identities outside this set are classified external. |
+| `provider_type` | `gcp` \| `aws` \| `azure` \| `okta` \| `entra` \| `google_workspace` \| `1password` \| `auth0` \| `cloudflare` \| `github` \| `openai` \| `anthropic` \| `limacharlie` |
+| `credentials` | A `hive://secret/<name>` reference. The credential itself lives in the secret Hive — it is **not** stored inline. |
+| `compliance_credentials` | Optional second `hive://secret/<name>` reference for providers with a second credential plane (today: Anthropic's compliance/analytics key). |
+| `internal_domains` | Your own email domains (bare domains, no `@`) beyond the discoverable primary — human identities outside this set are classified external. |
 | `sync_now` | Opaque nonce; change its value to trigger an on-demand sweep. |
 | `refresh` | Periodic re-enumeration cadence as a duration string (e.g. `"6h"`); empty uses the service default. |
 | `feed_subscription` | Optional fully-qualified Pub/Sub subscription carrying a cloud change feed, for event-driven freshness between full sweeps. |
@@ -42,63 +45,115 @@ Per-provider scope fields:
 | `provider_type` | Fields |
 |---|---|
 | `gcp` | `gcp_scope`: `projects/{id}`, `folders/{id}`, or `organizations/{id}` (optional `gcp_project`) |
-| `aws` | `aws_role_arn` (the read-only role to assume), `aws_external_id`, optional `aws_regions`, optional `aws_member_role_name` — the role *name* assumed in each member account of an AWS Organization (defaults to the name in `aws_role_arn`, the common StackSet pattern) |
+| `aws` | `aws_role_arn` (the read-only role to assume), `aws_external_id`, optional `aws_regions`, optional `aws_member_role_name` — the role *name* assumed in each member account of an AWS Organization (defaults to the name in `aws_role_arn`) |
 | `azure` | `azure_tenant_id`, `azure_client_id`, `azure_subscription_id` (service-principal auth) |
 | `okta` | `okta_org_url` — the org base URL; the credential is an SSWS API token or an API Services app (client credentials) |
+| `entra` | `entra_tenant_id`, `entra_client_id` — a standalone Entra directory connection (no Azure subscription); service-principal auth |
 | `google_workspace` | `workspace_customer_id` — `my_customer` or an explicit customer id; the credential is a service-account key with domain-wide delegation plus the admin subject to impersonate |
 | `1password` | `onepassword_scim_url` — the SCIM bridge URL; the credential is the SCIM bearer token |
+| `auth0` | `auth0_domain` — the canonical tenant domain (`*.auth0.com`); the credential is an M2M app authorized for the Management API |
 | `cloudflare` | `cloudflare_account_id` — the 32-hex account id |
+| `github` | `github_org`, `github_app_id`, `github_installation_id` — a GitHub App installed on the org; the App private key is the credential |
+| `openai` | optional `openai_org_id` (`org-...`); the credential is an Admin API key with `api.management.read` |
+| `anthropic` | optional `anthropic_org_uuid` (required when only the compliance plane is connected); Console Admin key in `credentials`, optional compliance key in `compliance_credentials` |
+| `limacharlie` | exactly one of `limacharlie_oid` (org key) or `limacharlie_uid` (user key — the MSSP fleet case) |
 
-Use `limacharlie cloudsec provider test` to preflight a record before saving
-it — see [Getting Started](getting-started.md#test-the-credential-before-saving).
+Use `limacharlie cloudsec provider test` to preflight a record before saving it
+— see [Getting Started](getting-started.md#test-the-credential-before-saving).
 
 ## cloudsec_policy
 
 Each record declares exactly one `policy_type` and fills the matching
 sub-object.
 
+### Rule matchers — read this first
+
+Several policy types scope over resources with **rules**, and every rule shares
+the same matcher grammar:
+
+| Matcher | Matches |
+|---|---|
+| `account_contains` / `account_glob` | the resource's account (substring / glob) |
+| `name_contains` / `name_glob` | the resource's name (substring / glob) |
+| `resource_type` | the normalized resource type (e.g. `bucket`, `compute_instance`, `service_account`) |
+| `provider` | the producing provider (`gcp`, `aws`, `okta`, …) |
+| `region` | the region (globs) |
+| `label` | a set of `key: value` label pairs — **all** must be present |
+| `label_key_present` | a set of label keys — **all** must be present |
+| `tag` | a set of tags (compute only) — **all** must be present |
+| `public` | tri-state exposure (`true` / `false`) |
+| `content_class` | detected sensitive-content classes on a data store (`pii`, `pci`, `phi`, `financial`) |
+
+!!! warning "Matchers within a rule are ANDed"
+    A rule matches a resource only when **every populated dimension matches**.
+    Within a single-valued dimension the listed patterns are OR alternatives
+    (`account_glob: ["a-*", "b-*"]` matches either); set-valued dimensions
+    (`label`, `tag`) require **all** entries. A **rule with no matcher matches
+    nothing**, and a populated dimension that cannot be evaluated for a given
+    resource **fails** the rule rather than being ignored. Separate rules in a
+    list compose with OR.
+
+    (This is a change from earlier behavior, where dimensions within a rule were
+    ORed. The `store_kind` matcher has been folded into `resource_type`.)
+
+Not every dimension is honored on every surface — `tag` is compute-only,
+`content_class`/`public`/`classes` apply to data stores, and the `exclusions`
+emission list honors only account/name/provider. The console's policy editors
+enforce this per surface and offer live value **autocomplete** from your actual
+estate, plus a **Simulate** preview that shows which resources a rule matches
+before you save (see [Previewing policies](#previewing-policies)).
+
+Assign-side fields (not matchers): `name` (provenance), `classes` (the classes a
+`classification` data-store rule assigns), and `tier`
+(`critical`/`high`/`medium`/`low`).
+
 ### `classification` — crown jewels
 
-Declares which resources are sensitive (nothing is sensitive by default).
-Rules match resources by account/name/label/tag and assign classes:
+Declares which resources are sensitive (nothing is sensitive by default). Rules
+match resources and assign classes and/or a criticality tier, in three sections
+— `data_stores`, `compute`, `identities`:
 
 ```json
 {
   "policy_type": "classification",
   "classification": {
     "data_stores": [
-      {"name_contains": ["customer", "pii"], "classes": ["pii"]}
+      {"name_contains": ["customer", "pii"], "classes": ["pii"]},
+      {"content_class": ["pci"], "classes": ["pci"]}
     ],
     "compute": [
-      {"label": {"tier": "crown-jewel"}, "classes": ["critical-infra"]}
-    ],
-    "auto_classify": true
+      {"label": {"tier": "crown-jewel"}, "tier": "critical"}
+    ]
   }
 }
 ```
 
-`auto_classify: true` opts into content-based detection of sensitive data
-(sampled during agentless scanning); the explicit policy always remains
+Content-based sensitivity is expressed with `content_class` rules: the agentless
+scanner samples data stores and surfaces detected content classes (`pii`, `pci`,
+`phi`, `financial`) as facts on the resource, and a `content_class` rule is what
+turns a detection into a sensitivity claim. Your explicit policy always remains
 authoritative.
 
-Rule matchers (shared by every policy type that scopes over resources):
-`account_contains`, `account_glob`, `name_contains`, `name_glob`,
-`label` (key→value), `label_key_present`, `tag`.
+!!! note "auto_classify has been replaced"
+    Earlier versions accepted an `auto_classify: true` boolean. It has been
+    retired in favor of explicit, previewable `content_class` rules — the same
+    detection, but visible in the policy and testable with Simulate. Remove
+    `auto_classify` from any existing record.
 
 ### `coverage` — workload coverage expectations
 
-Declares which **cloud workloads** are expected to run a LimaCharlie
-sensor, with `required` and `exempt` resource-rule lists — the "EDR on
-production VMs" expectation, evaluated over the cloud inventory.
+Declares which **cloud workloads** are expected to run a LimaCharlie sensor,
+with `required` and `exempt` resource-rule lists — the "EDR on production VMs"
+expectation, evaluated over the cloud inventory. An empty `required` means every
+compute resource is expected to be covered; `exempt` wins.
 
 !!! note "Distinct from the CAASM expected-coverage policy"
-    `limacharlie cloudsec caasm policy set` manages a **separate**
-    policy with a different shape (`{expect: [{label, capability,
-    kinds}]}`) evaluated over the merged *third-party asset* inventory
-    ("seen by the IdP, no EDR") — see
-    [CAASM](caasm.md#declare-expected-coverage). The two are not synced:
-    this hive record drives cloud-workload coverage findings; the CAASM
-    policy drives `coverage_gap` findings over third-party assets.
+    `limacharlie cloudsec caasm policy set` manages a **separate** policy with a
+    different shape (`{expect: [{label, capability, kinds}]}`) evaluated over the
+    merged *third-party asset* inventory ("seen by the IdP, no EDR") — see
+    [CAASM](caasm.md#declare-expected-coverage). The two are not synced: this
+    hive record drives cloud-workload coverage findings; the CAASM policy drives
+    `coverage_gap` findings over third-party assets.
 
 ### `scanning` — agentless content scanning
 
@@ -119,36 +174,38 @@ classification each match assigns, plus an optional resource `scope`:
 
 Controls which Cloud Security events reach the organization's event stream:
 
-| Field | Meaning |
-|---|---|
-| `resource_events` | `cloud_resource.*` inventory change events |
-| `finding_events` | `cloud_finding.*` lifecycle events |
-| `ops_events` | operational events (sweep start/complete, errors) |
-| `severity_floor` | drop finding events below this severity |
-| `suppress_first_sync` | don't flood the stream with the initial enumeration |
+| Field | Meaning | Default |
+|---|---|---|
+| `resource_events` | `cloud_resource.*` inventory change events | off |
+| `finding_events` | `cloud_finding.*` lifecycle events | on |
+| `ops_events` | operational events (sweep/scan failures) | off |
+| `severity_floor` | drop finding events below this severity | none |
+| `suppress_first_sync` | emit one summary instead of a per-finding flood on the first / rebuild sweep | on |
+
+See [Findings are events too](findings.md#findings-are-events-too) for the full
+event taxonomy.
 
 ### `exclusions` — the escape hatch
 
-Excludes matching resources from `collection`, `scanning`, or `emission`
-(three independent rule lists; rules add `services` and `resource_types`
-matchers on top of the shared resource matchers). Use it for the
-million-object bucket that should not be enumerated, or the noisy account
-that should not emit events. Removal takes effect on the next sweep.
+Excludes matching resources from `collection`, `scanning`, or `emission` (three
+independent rule lists; collection rules add `services` and `resource_types`
+matchers on top of the shared resource matchers). Use it for the million-object
+bucket that should not be enumerated, or the noisy account that should not emit
+events. Removal takes effect on the next sweep.
 
 ### `suppression` — finding disposition policy
 
 Auto-dispositions matching findings — see
 [Automation & IaC](automation.md#suppression-rules-finding-disposition-policy)
-for semantics and a worked example. Match fields: `finding_class`, `rule`,
-`account`, `urn_prefix`, `max_severity`; effect: `kind`
-(`accepted`/`false_positive`/`mitigated`), `reason`, `ttl_days`.
+for semantics and a worked example. Ordered `rules`; each rule's `match` accepts
+`finding_class`, `rule`, `account`, `urn_prefix`, `max_severity`; the `effect`
+is `kind` (`accepted`/`false_positive`), `reason` (required), `ttl_days`.
 
 ### `compliance` — scoped assignments
 
 A named framework assignment over a scoped subset of the estate — see
 [Compliance](compliance.md#scoped-assignments). Fields: `framework_id`
-(required, lowercase slug), `description`, `scope` (v1 supports the
-account/name matchers only).
+(required, lowercase slug), `description`, `scope` (the account/name matchers).
 
 ## cloudsec_query
 
@@ -165,7 +222,25 @@ A saved graph query, shared org-wide:
 }
 ```
 
-`query` takes one of `named` (a query-pack reference), `text`, or `ast` (the
-raw DSL). Optional `ui` hints (view, columns) shape how the console renders
-results. `schedule` and `detection` blocks are accepted so IaC written today
-survives the scheduled-query phase, but are not yet active.
+`query` takes one of `named` (a query-pack reference), `text`, or `ast` (the raw
+DSL). Optional `ui` hints (view, columns) shape how the console renders results;
+the query appears in the [Query console and as an Explore lens](graph.md#graph-queries).
+`schedule` and `detection` blocks are accepted for forward-compatibility;
+turning a saved query into a scheduled detection source (emitting `cloud_query.*`
+events) is an emerging capability.
+
+## Previewing policies
+
+Two read-only, `cloudsec.get`-gated aids make policy authoring safe — both are
+in the console policy editors and on the API (there is no CLI command for them):
+
+- **Simulate** evaluates an in-progress matcher against your real data before you
+  save. A resource matcher (classification / coverage / exclusions) is previewed
+  against stored inventory; a suppression matcher is previewed against open
+  findings. The result is a match count plus a bounded sample.
+- **Vocabulary & autocomplete** feed the editors the closed vocabularies
+  (resource types, providers, tiers, content classes) and live value suggestions
+  drawn from your estate's actual accounts and names.
+
+See the [API Reference](api-reference.md#policy-authoring-simulate-vocabulary)
+for the underlying routes.

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -10,6 +10,12 @@ findings worklist. CSPM misconfigurations, graph-derived attack paths, and
 identity (CIEM) risks are all findings with the same shape, the same triage
 verbs, and the same automation events.
 
+!!! info "In the console it's called **Risks**"
+    The worklist is the **Risks** page. Lens tabs slice it without losing the
+    unified ranking: *All risks*, *Public exposure & misconfig*, *Identity*,
+    *Workload*, *Vulnerabilities*, and *Data*. Everything below is the same
+    data through the CLI/API.
+
 ## The worklist
 
 Findings are ordered by `lc_risk` — a 0–1000 composite that weighs severity,
@@ -21,7 +27,7 @@ resource is sensitive. Each finding carries:
   same fingerprint across sweeps.
 - `finding_class` — one of `toxic_combination`, `public_exposure`,
   `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
-  `malware`, `secret`, `scan_finding`, `coverage_gap`.
+  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`.
 - `severity` (`CRITICAL` … `INFO`), `lc_risk`, and a `risk_breakdown`
   explaining the score.
 - The affected resource (`resource_urn`, `resource_name`, `resource_type`,
@@ -33,6 +39,18 @@ resource is sensitive. Each finding carries:
   `epss`, `in_kev`.
 - Runtime context: `runtime_sids` — the LimaCharlie sensors running on the
   affected asset, when the fusion mapping resolves any.
+
+Attack-path and `toxic_combination` findings headline the durable **workload
+group** rather than a single ephemeral node: a GKE/EKS/AKS node pool, a GCE
+managed instance group, an AWS Auto Scaling group, or an Azure VM scale set.
+The group is carried on `source_scope` / `target_scope`, so remediation reads
+as one shared fix for the whole pool instead of one finding per short-lived VM.
+
+For identity (CIEM) findings, access is scored by the **capability** a grant
+confers — `data_admin` › `data_write` › `data_read` › `metadata` › `none` —
+not by the mere existence of the grant. "Reaches sensitive data" gates on
+`data_read`-or-higher; `metadata`/`none` grants surface as a lower-severity
+reconnaissance signal, not a top data-access risk.
 
 List, filter, and paginate server-side:
 
@@ -74,6 +92,25 @@ limacharlie cloudsec finding bulk-resolve \
   --finding-id fnd_0a1b... --finding-id fnd_2c3d... \
   --kind false_positive --reason "scanner artifact"
 ```
+
+The `bulk-resolve` route applies one disposition to many findings at once, but
+it does **not** accept `open` — reopen findings one at a time with
+`finding resolve <id> --kind open`.
+
+In the console, the same dispositions are one-click buttons on a finding, plus
+the workflow actions built on top of them:
+
+| Button | What it does |
+|---|---|
+| **Mark fixed** | disposition `mitigated` |
+| **Accept risk** | disposition `accepted`, with an optional re-surface expiry |
+| **Mute** | disposition `false_positive` |
+| **Reopen** | clears the disposition |
+| **Assign owner** | sets/clears `owner` |
+| **Link ticket** | sets/clears `ticket` |
+| **Create case** | one-click, idempotent — opens (or updates) the linked case |
+| **Create suppression rule** | opens a prefilled `suppression` policy rule |
+| **Create D&R rule** | opens a prefilled detection & response rule |
 
 Ownership and ticket linkage are separate, lighter-weight fields:
 
@@ -127,8 +164,34 @@ limacharlie cloudsec risk-trend --trend-days 90
 ## Findings are events too
 
 Every lifecycle transition emits an event into the organization's event
-stream: `cloud_finding.created`, `cloud_finding.closed`, and a daily
-`cloud_finding.still_open` for open findings with a linked ticket. D&R rules
-match them like any other event — see
-[Automation & IaC](automation.md#findings-cases-automation) for the
-ready-made Cases loop.
+stream, so D&R rules, Outputs, and the Cases loop consume findings like any
+other telemetry. Two families:
+
+**Detection-truth lifecycle** (emitted by the projector as the sweep observes
+the world):
+
+- `cloud_finding.created` — a new finding; the full finding object rides under
+  `event/finding` (including `runtime_sids`).
+- `cloud_finding.updated` — the content of an already-open finding materially
+  changed (a severity flip, a changed vuln set); payload names the
+  `changed` fields, `old_severity`/`new_severity`, and carries the current
+  `finding`.
+- `cloud_finding.closed` — the condition is gone; `{finding_id, fingerprint,
+  finding_class}`.
+- `cloud_finding.still_open` — re-asserted at most once per day for open
+  findings that carry a linked ticket, the heartbeat that keeps a Case honest
+  when the cloud was never actually fixed.
+
+**Operator-disposition verbs** (emitted by the write handlers, flat payload
+`{finding_id, fingerprint, finding_class, actor, note?}`):
+`cloud_finding.resolved`, `cloud_finding.dismissed`, `cloud_finding.reopened`,
+`cloud_finding.assigned`.
+
+**Summary:** on the first-ever projection (or a rebuild) the platform emits a
+single `cloudsec.sync_completed` (`{total, by_class, by_severity}`) instead of
+a per-finding `created` flood — first-sync suppression.
+
+See [Automation & IaC](automation.md#findings-cases-automation) for the
+ready-made Cases loop that keys on `fingerprint`, and the
+[`emission` policy](configuration.md#emission-the-event-feed) for the feed
+controls (severity floor, which families are on).

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -5,16 +5,17 @@
     configuration formats described here may change before general
     availability. Contact us if you would like access.
 
-This page takes an organization from zero to a populated Cloud Security
-dashboard: subscribe the extension, store a credential, connect a provider,
-and run the first sweep.
+This guide takes an organization from zero to a populated Cloud Security
+dashboard: enable the product, connect a provider, run the first sweep, and
+declare what matters. You can do all of it in the console or entirely as code —
+both are shown.
 
-## 1. Subscribe the extension
+## 1. Enable Cloud Security
 
 Cloud Security is enabled per organization by subscribing to the
-`ext-cloud-security` extension — the subscription is both the enable gate
-and the billing hook. In the web console, open the extension from the
-Add-Ons marketplace and click **Subscribe**, or from the CLI:
+`ext-cloud-security` extension — the subscription is both the enable gate and
+the billing hook. In the web console, open the extension from the Add-Ons
+marketplace and click **Subscribe**, or from the CLI:
 
 ```bash
 limacharlie extension subscribe --name ext-cloud-security --oid $OID
@@ -23,43 +24,45 @@ limacharlie extension subscribe --name ext-cloud-security --oid $OID
 Until the organization is subscribed, every Cloud Security API route and
 console view returns `403`.
 
-## 2. Store the provider credential as a secret
+Once enabled, **Cloud Security** appears as a workspace in the organization
+sidebar.
 
-Collector credentials are never stored inline in the provider record — the
-record references a [secret](../7-administration/config-hive/secrets.md) by
-`hive://secret/<name>`:
+## 2. Connect a provider
+
+A provider connection is one `cloudsec_provider` record. Each provider needs a
+scope (which account/tenant/org to enumerate) and a read-only credential. The
+[Connecting Providers](providers.md) page has the full per-provider setup — the
+steps below use Google Cloud as the worked example.
+
+### In the console
+
+1. Open **Cloud Security → Settings → Providers** and click **+ Add provider**.
+2. Give the connection a **name**, pick the **provider type**, and fill the
+   type-specific connection fields (for GCP, the scope — a project, folder, or
+   organization).
+3. Supply the **credential**: either reference an existing
+   [secret](../7-administration/config-hive/secrets.md) by
+   `hive://secret/<name>`, or paste the credential to have the console store it
+   as a new secret for you. Credentials are always stored as a secret and
+   referenced — never inlined into the provider record.
+4. Click **Test Provider** to run the read-only preflight (see below), then
+   save. Saving an enabled connection starts collection.
+
+The provider row then shows its sync status, resource count, and per-row actions
+(**What you get**, **Sync now**, **Edit**, **Delete**).
+
+### As code
+
+The credential lives in the secret Hive; the provider record references it:
 
 ```bash
+# Store the collector credential as a secret (hive set reads the record
+# data from --input-file or piped stdin).
 echo '{"secret": "<service-account-key-json>"}' | \
   limacharlie hive set --hive-name secret --key gcp-collector-sa \
     --oid $OID --enabled
-```
 
-(`hive set` reads the record data from `--input-file` or piped stdin.)
-
-What the credential must be able to do depends on the provider — the
-credential test in the next step tells you exactly which permission surfaces
-are missing.
-
-## 3. Connect a provider
-
-A provider connection is one `cloudsec_provider` Hive record. The full field
-reference is in [Configuration](configuration.md#cloudsec_provider); the
-short version per provider:
-
-| Provider | `provider_type` | Scope fields |
-|---|---|---|
-| Google Cloud | `gcp` | `gcp_scope` (`projects/{id}`, `folders/{id}`, or `organizations/{id}`) |
-| AWS | `aws` | `aws_role_arn` + `aws_external_id`, optional `aws_regions`, optional `aws_member_role_name` for AWS Organizations |
-| Azure | `azure` | `azure_tenant_id`, `azure_client_id`, `azure_subscription_id` |
-| Okta | `okta` | `okta_org_url` (e.g. `https://acme.okta.com`) |
-| Google Workspace | `google_workspace` | `workspace_customer_id` (`my_customer` or an explicit id) |
-| 1Password | `1password` | `onepassword_scim_url` |
-| Cloudflare | `cloudflare` | `cloudflare_account_id` |
-
-Example — a GCP organization:
-
-```bash
+# Connect the provider.
 cat > provider.json <<EOF
 {
   "provider_type": "gcp",
@@ -73,17 +76,22 @@ limacharlie hive set --hive-name cloudsec_provider --key acme-gcp \
   --oid $OID --input-file provider.json --enabled
 ```
 
+The full field reference is in
+[Configuration](configuration.md#cloudsec_provider), and every provider's scope
+fields and credential shape are in [Connecting Providers](providers.md).
+
 !!! tip "internal_domains matters for CIEM"
-    List every email domain your own people use. A human identity whose
-    domain is not in the internal set is classified *external*, and external
-    access to sensitive resources is one of the highest-signal finding
-    classes. The collector discovers the primary cloud-org domain on its
-    own; secondary domains must be declared.
+    List every email domain your own people use. A human identity whose domain
+    is not in the internal set is classified *external*, and external access to
+    sensitive resources is one of the highest-signal finding classes. The
+    collector discovers the primary cloud-org domain on its own; secondary
+    domains must be declared.
 
 ### Test the credential before saving
 
 The provider test connects with the supplied credential and probes every
-permission surface a sweep needs, without storing anything:
+permission surface a sweep needs, without storing anything — the same check the
+console's **Test Provider** button runs:
 
 ```bash
 limacharlie cloudsec provider test --input-file provider.json
@@ -101,7 +109,7 @@ connection failing.
     may be passed inline instead of as a `hive://secret/` reference; it is
     used ephemerally and never stored or logged.
 
-## 4. Watch the first sweep
+## 3. Watch the first sweep
 
 Saving an enabled provider record starts collection. Check progress:
 
@@ -110,15 +118,17 @@ limacharlie cloudsec scan-status --provider gcp
 ```
 
 The status carries whether a sweep is running, when the last one started and
-completed, the diff stats of the last run, and any error. To force an
-immediate re-enumeration later, change the record's `sync_now` value (any
-new value triggers a sweep); `refresh` sets the periodic cadence.
+completed, the diff stats of the last run, and any error. To force an immediate
+re-enumeration later, change the record's `sync_now` value (any new value
+triggers a sweep) or use **Sync now** on the provider row; `refresh` sets the
+periodic cadence.
 
-## 5. Declare what matters
+## 4. Declare what matters
 
 Out of the box, **nothing is classified sensitive** — sensitivity is your
-declaration, made with a `classification`-typed `cloudsec_policy` record
-(crown jewels), optionally augmented by content-based auto-classification:
+declaration, made with a `classification`-typed `cloudsec_policy` record (your
+crown jewels). Rules match resources by account, name, resource type, label, or
+tag and assign classes:
 
 ```bash
 cat > classification.json <<EOF
@@ -127,8 +137,7 @@ cat > classification.json <<EOF
   "classification": {
     "data_stores": [
       {"name_contains": ["customer", "pii"], "classes": ["pii"]}
-    ],
-    "auto_classify": true
+    ]
   }
 }
 EOF
@@ -137,11 +146,28 @@ limacharlie hive set --hive-name cloudsec_policy --key classification \
   --oid $OID --input-file classification.json --enabled
 ```
 
-Sensitivity drives the attack-path and CIEM analytics: "exposed workload
-that can reach *sensitive* data" and "external identity with access to
-*sensitive* store" both need to know what sensitive means in your estate.
+Sensitivity drives the attack-path and CIEM analytics: "exposed workload that
+can reach *sensitive* data" and "external identity with access to *sensitive*
+store" both need to know what sensitive means in your estate.
 
-## 6. Look at the result
+!!! tip "Content-based classification"
+    Beyond declaring crown jewels by name/label, you can add `content_class`
+    rules so that data stores where the agentless scanner samples sensitive
+    content (`pii`, `pci`, `phi`, `financial`) are treated as sensitive. Detected
+    content classes are always surfaced as facts on a resource; a `content_class`
+    rule is what turns a detection into a sensitivity claim. See
+    [Configuration](configuration.md#classification-crown-jewels). (The former
+    `auto_classify` boolean has been replaced by these explicit, previewable
+    rules.)
+
+In the console, the same policy is authored on **Cloud Security → Policies →
+Data classification**, where a live **Simulate** panel shows exactly which
+resources a rule matches before you save it.
+
+## 5. Look at the result
+
+In the console, the **Overview** page is the at-a-glance risk layer and
+**Risks** is the worklist. From the CLI:
 
 ```bash
 # The composed risk overview: score, severity distribution, top paths.
@@ -155,5 +181,6 @@ limacharlie cloudsec inventory facets
 ```
 
 From here, continue with [Findings & Triage](findings.md) for the day-to-day
-workflow, or [Automation & IaC](automation.md) to wire findings into Cases
-and onboard more tenants as code.
+workflow, [Connecting Providers](providers.md) to add more of your estate, or
+[Automation & IaC](automation.md) to wire findings into Cases and onboard more
+tenants as code.

--- a/docs/cloud-security/graph.md
+++ b/docs/cloud-security/graph.md
@@ -25,7 +25,7 @@ Edges carry the relationship semantics:
 | `can_reach` | Network reachability between workloads |
 | `exposed_to` | Exposure to the internet / an external boundary |
 | `has_vulnerability` | Workload → CVE (with package and fix version) |
-| `has_permission_on` | Identity → resource (with role and effect) |
+| `has_permission_on` | Identity → resource; carries the classified **access level** (the capability the grant confers — `data_admin` › `data_write` › `data_read` › `metadata` › `none`), which is the edge verb the UI shows |
 | `can_assume` | Identity → identity (role assumption / impersonation) |
 | `is_member_of` | Identity → group / account membership |
 | `has_app_access` | Identity → application assignment (IdP surfaces) |
@@ -52,6 +52,21 @@ limacharlie cloudsec graph neighbors "lcrn:gcp:...instance/web-1" --limit 200
 The result is an induced subgraph (`nodes` + `edges`), ranked so sensitive
 and public neighbors surface first, with `truncated` set when the node has
 more neighbors than the cap (hard cap 500).
+
+## Topology
+
+The interactive **Security graph** above (the Explore page canvas) is for
+traversal — expanding one hop at a time from a starting node. **Topology** is
+the other view: an aggregated, explorable diagram of the whole estate,
+laid out Provider → Account → Region → Resource. A node-type declutter filter
+hides the classes you don't care about, and the current view (filters,
+expansion) is captured in a shareable URL so a colleague opens exactly what
+you're looking at.
+
+Because it is backed by **server-side aggregates**, the counts on every node
+are exact at any scale — Topology never walks a capped page and then guesses.
+It is served by `GET /topology` (see [API Reference](api-reference.md)); there
+is no CLI command for it.
 
 ## Graph queries
 
@@ -80,7 +95,8 @@ versioned, and IaC-manageable (see
 
 ## Identity: CIEM views
 
-Two dedicated identity reads sit on top of the graph:
+The console calls this area **Identity & Access**. Two dedicated identity
+reads sit on top of the graph:
 
 ```bash
 # Public / external access to sensitive resources — the headline CIEM view.
@@ -90,10 +106,28 @@ limacharlie cloudsec ciem public-access
 limacharlie cloudsec ciem facets
 ```
 
+Access is scored by the **capability** a grant confers, not the mere existence
+of a grant: the effective action set is classified to an access level —
+`data_admin` › `data_write` › `data_read` › `metadata` › `none`. "Reaches
+sensitive data" gates on `data_read`-or-higher; `metadata`/`none` grants are a
+lower-severity reconnaissance signal rather than a top data-access risk. That
+level is stamped on the `has_permission_on` edge and is the verb the UI shows.
+
 Identity findings (dormant privileged identities, escalation edges, unused
 privileges) surface in the main worklist under the `ciem_risk` and
 `privilege_escalation` classes. External-vs-internal classification is
 driven by the provider record's `internal_domains` — keep it complete.
+
+### Identity 360
+
+For a single identity, **Identity 360** is the one-screen view of everything
+it can reach — direct grants, group-inherited permissions, identities it can
+assume, and application assignments — plus a **devices** lane pulling in the
+endpoints associated with that identity. Each reach edge carries its classified
+access level, so the whole effective blast radius is visible in one place. It
+is the console's Identity & Access → *(an identity)* drill-down, served by
+`GET /cloudsec/{oid}/ciem/identity?urn=<identity-urn>` (see
+[API Reference](api-reference.md)); there is no CLI command for it.
 
 ## Data security: DSPM facets
 
@@ -103,18 +137,28 @@ limacharlie cloudsec data-security facets
 
 Returns the data-store posture rollup: total stores, sensitive, public, and
 public-*and*-sensitive counts, plus store-kind / sensitivity / exposure
-histograms. Sensitivity is your declaration (the `classification` policy)
-optionally augmented by content-based auto-classification — see
-[Getting Started](getting-started.md#5-declare-what-matters).
+histograms. Sensitivity is your declaration: `classification`-policy
+`content_class` and name/`resource_type` rules decide what counts as sensitive
+(the retired `auto_classify` boolean is gone). The agentless scanner still
+detects content classes and surfaces them as facts on a resource, but only a
+matching `content_class` rule turns a detection into a sensitivity claim — see
+[Configuration](configuration.md#classification-crown-jewels).
 
 ## Inventory
 
-The system-of-record behind the graph is queryable directly:
+The system-of-record behind the graph is queryable directly, filtered by
+`--type`, `--provider`, `--account`, `--region`, and free-text `-q`:
 
 ```bash
-limacharlie cloudsec inventory list --type <resource-type> --region us-central1 -q prod
+limacharlie cloudsec inventory list \
+  --type <resource-type> --provider gcp --region us-central1 -q prod
 limacharlie cloudsec inventory facets
 ```
+
+This is the first-party cloud inventory. **Third-party (CAASM) assets** — the
+entity-resolved devices and identities merged from EDR, IdP, MDM, and scanner
+sources — live in their own inventory tab and have their own reads; see
+[CAASM](caasm.md).
 
 ## Sensors ↔ cloud assets
 

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -7,15 +7,15 @@
 
 LimaCharlie Cloud Security is an agentless cloud-native application protection
 platform (CNAPP) built into the same tenant, permission model, and automation
-surface as the rest of LimaCharlie. It continuously enumerates your cloud and
-identity estate, builds a security graph out of it, and turns what it finds
-into a single risk-ranked worklist of findings — connected to the sensors,
-D&R rules, Cases, and Outputs you already use.
+surface as the rest of LimaCharlie. It continuously enumerates your cloud,
+identity, SaaS, and AI estate, builds a security graph out of it, and turns what
+it finds into a single risk-ranked worklist — connected to the sensors, D&R
+rules, Cases, and Outputs you already use.
 
 !!! tip "In one sentence"
-    Connect a cloud account or identity provider with a read-only credential,
-    and LimaCharlie shows you what you own, what is exposed, who can reach
-    what, and exactly which fix breaks the most attack paths — with every
+    Connect a cloud account, identity provider, or AI platform with a read-only
+    credential, and LimaCharlie shows you what you own, what is exposed, who can
+    reach what, and exactly which fix breaks the most attack paths — with every
     finding automatable through the standard LimaCharlie event pipeline.
 
 ## What it covers
@@ -24,31 +24,41 @@ D&R rules, Cases, and Outputs you already use.
 |---|---|
 | **Inventory (CSPM)** | A continuously refreshed system-of-record of your cloud resources — compute, storage, networking, identities — with misconfiguration findings per resource. |
 | **Attack paths** | Toxic combinations across resources: an internet-exposed workload with a known-exploited vulnerability that can reach sensitive data is one finding, not three disconnected ones. |
-| **Identity (CIEM)** | Who — human or service — can access what: public/external access to sensitive resources, privilege-escalation edges, dormant privileged identities. |
-| **Data security (DSPM)** | Which data stores exist, which are sensitive (you declare it by policy, or opt into content-based auto-classification), and which sensitive stores are exposed. |
-| **Compliance** | Per-control pass/fail assessment of frameworks (e.g. `cis-gcp`) over the live estate, whole-estate or scoped to named assignments. |
-| **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources) with coverage-gap findings — "seen by the identity provider, no EDR". |
-| **Security graph** | An explorable graph of resources, identities, and their relationships (`can_reach`, `exposed_to`, `has_permission_on`, `can_assume`, …) with a query language and saved queries. |
+| **Identity (CIEM)** | Who — human or service — can access what: public/external access to sensitive resources, privilege-escalation edges, dormant privileged identities. Access is scored by the *capability* a grant actually confers, not by the mere existence of a grant. |
+| **Data security (DSPM)** | Which data stores exist, which are sensitive (you declare it by policy, optionally augmented by content-based classification rules), and which sensitive stores are exposed. |
+| **AI security (AISPM)** | Your OpenAI and Anthropic organizations as first-class estate: members, API keys, projects, and posture — with the same findings and compliance lenses (`nist-ai-rmf`, `owasp-llm`). |
+| **Compliance** | Per-control pass/fail assessment of frameworks over the live estate, whole-estate or scoped to named assignments. |
+| **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources, including LimaCharlie's own sensors) with coverage-gap and device-posture findings — "seen by the identity provider, no EDR". |
+| **Security graph & topology** | An explorable graph of resources, identities, and their relationships (`can_reach`, `exposed_to`, `has_permission_on`, `can_assume`, …) plus an aggregated estate topology view, with a query language and saved queries. |
 | **Runtime fusion** | Bidirectional resolution between LimaCharlie sensors and the cloud assets they run on — pivot from a cloud finding to the live endpoint and back. |
+| **MSSP fleet** | A cross-tenant fleet board that rolls up risk across every organization you manage. |
 
 ## Supported providers
 
-Cloud infrastructure: **GCP**, **AWS** (including multi-account AWS
-Organizations), **Azure**. Identity and SaaS surfaces: **Okta**,
-**Google Workspace**, **1Password**, **Cloudflare**.
+Thirteen connectors across five surfaces, all agentless and read-only:
 
-All collection is agentless and read-only: you grant a scoped read credential
-(stored as a LimaCharlie [secret](../7-administration/config-hive/secrets.md), referenced —
-never inlined — from the provider record), and the platform sweeps the estate
-on a schedule, on demand, or continuously from a change feed.
+- **Cloud infrastructure** — Google Cloud (`gcp`, including folders/organizations),
+  AWS (`aws`, including multi-account AWS Organizations), Azure (`azure`).
+- **Identity** — Okta (`okta`), Microsoft Entra ID (`entra`), Google Workspace
+  (`google_workspace`), 1Password (`1password`), Auth0 (`auth0`).
+- **SaaS** — Cloudflare (`cloudflare`), GitHub (`github`).
+- **AI** — OpenAI (`openai`), Anthropic (`anthropic`).
+- **LimaCharlie** — your own LimaCharlie tenancy as a self-inventoried estate
+  (`limacharlie`), including the MSSP fleet case.
+
+You grant a scoped read credential (stored as a LimaCharlie
+[secret](../7-administration/config-hive/secrets.md), referenced — never inlined —
+from the provider record), and the platform sweeps the estate on a schedule, on
+demand, or continuously from a change feed. See
+[Connecting Providers](providers.md) for the per-provider setup.
 
 ## How it works
 
 1. **Subscribe** the organization to the `ext-cloud-security` extension —
    this is the product's enable (and billing) gate.
 2. **Connect providers**: one `cloudsec_provider` Hive record per cloud
-   account / IdP tenant. A pre-save credential test probes every permission
-   the collector needs and reports which are missing.
+   account / IdP tenant / AI org. A pre-save credential test probes every
+   permission the collector needs and reports which are missing.
 3. **Sweeps build the graph**: each enumeration updates the resource
    system-of-record and the security graph, then re-derives findings.
    Closed conditions close their findings automatically.
@@ -62,11 +72,34 @@ Everything the console shows is also available through the
 plain [Hive records](configuration.md), so a fleet of tenants can be
 onboarded and governed as code.
 
+## In the console
+
+Cloud Security is a top-level workspace in the organization sidebar. Its pages
+map onto the capabilities above:
+
+| Page | What it is |
+|---|---|
+| **Overview** | The risk overview: score, severity distribution, top attack paths and the marquee chokepoint. |
+| **Risks** | The findings worklist, with lenses (Public exposure & misconfig / Identity / Workload / Vulnerabilities / Data) and per-finding triage. |
+| **Attack Paths** | The toxic-combination paths, grouped by shared fix. |
+| **Identity & Access** | CIEM — who can reach what, with a single-identity "Identity 360" view. |
+| **Data Security** | DSPM — data-store posture and exposure. |
+| **Inventory** | The resource system-of-record, plus Third-party assets and Sensor coverage (CAASM) tabs. |
+| **Topology** | An aggregated, explorable diagram of the estate. |
+| **Compliance** | Per-control framework assessment and scoped assignments. |
+| **Explore** | The interactive Security graph and the Query console. |
+| **Policies** | Data classification (crown jewels), workload scanning, coverage, asset coverage, exclusions, and suppression. |
+| **Settings** | Provider connections and the Cases integration. |
+
+A separate cross-tenant **Cloud Security Fleet** board rolls risk up across every
+organization you manage.
+
 ## Permissions
 
 !!! info "Permissions"
     - `cloudsec.get` — read access to every Cloud Security view (findings,
-      inventory, graph, compliance, CAASM).
+      inventory, graph, topology, identity, compliance, CAASM) and the
+      read-only policy previews.
     - `cloudsec.set` — finding triage and other writes (dispositions,
       owners/tickets, chokepoint dismissal, CAASM policy/ingest, provider
       credential tests).
@@ -80,16 +113,18 @@ onboarded and governed as code.
 
 - [Getting Started](getting-started.md) — subscribe, connect a provider, run
   your first sweep.
+- [Connecting Providers](providers.md) — the thirteen connectors, their
+  credentials, and what each collects.
 - [Findings & Triage](findings.md) — the worklist, finding classes,
   dispositions, chokepoints.
-- [Security Graph & Queries](graph.md) — attack paths, graph queries, CIEM,
-  DSPM, sensor↔asset resolution.
+- [Security Graph & Queries](graph.md) — attack paths, topology, graph
+  queries, CIEM, DSPM, sensor↔asset resolution.
 - [Compliance](compliance.md) — frameworks, reports, scoped assignments.
-- [CAASM](caasm.md) — third-party asset inventory and coverage gaps.
+- [CAASM](caasm.md) — third-party asset inventory, coverage gaps, device posture.
 - [Configuration Reference](configuration.md) — the `cloudsec_provider`,
   `cloudsec_policy`, and `cloudsec_query` Hive records.
 - [Command Line Interface](cli.md) — the `limacharlie cloudsec` command
   group.
 - [API Reference](api-reference.md) — the `/cloudsec` REST surface.
-- [Automation & IaC](automation.md) — onboarding recipes, CSV exports, and
-  the findings↔Cases loop.
+- [Automation & IaC](automation.md) — onboarding recipes, CSV exports, fleet
+  management, and the findings↔Cases loop.

--- a/docs/cloud-security/providers.md
+++ b/docs/cloud-security/providers.md
@@ -1,0 +1,195 @@
+# Connecting Providers
+
+!!! warning "Private Beta"
+    Cloud Security is currently in **Private Beta**. Features, APIs, and
+    configuration formats described here may change before general
+    availability. Contact us if you would like access.
+
+A provider connection is one `cloudsec_provider` Hive record: a `provider_type`,
+the scope to enumerate, and a read-only credential. All collection is agentless.
+The credential itself always lives in the [secret](../7-administration/config-hive/secrets.md)
+Hive and is referenced by `hive://secret/<name>` from the `credentials` field —
+it is never stored inline on the provider record.
+
+Connect a provider in the console at **Cloud Security → Settings → Providers**
+(the **Add provider** button), or as code with `limacharlie hive set --hive-name
+cloudsec_provider` (see [Getting Started](getting-started.md#2-connect-a-provider)).
+Either way, run the [credential test](getting-started.md#test-the-credential-before-saving)
+first — it probes every permission a sweep needs and reports exactly which are
+missing.
+
+## The thirteen connectors
+
+| `provider_type` | Surface | Scope field(s) | Credential (JSON stored in the secret) |
+|---|---|---|---|
+| `gcp` | Cloud infra | `gcp_scope` (`projects/{id}`, `folders/{id}`, or `organizations/{id}`) | Service-account key JSON |
+| `aws` | Cloud infra | `aws_role_arn` (+ `aws_external_id`, `aws_regions`, `aws_member_role_name`) | STS AssumeRole (secret optional) |
+| `azure` | Cloud infra | `azure_tenant_id` + `azure_subscription_id` (+ `azure_client_id`) | `{"client_secret": "...", "client_id": "..."}` |
+| `okta` | Identity | `okta_org_url` | `{"api_token": "..."}` (SSWS) or an API Services app |
+| `entra` | Identity | `entra_tenant_id` (+ `entra_client_id`) | `{"client_secret": "..."}` (service principal) |
+| `google_workspace` | Identity | `workspace_customer_id` | SA key with domain-wide delegation + `admin_email` |
+| `1password` | Identity | `onepassword_scim_url` | `{"scim_url": "...", "scim_token": "..."}` |
+| `auth0` | Identity | `auth0_domain` | `{"client_id": "...", "client_secret": "..."}` (M2M) |
+| `cloudflare` | SaaS | `cloudflare_account_id` | `{"api_token": "...", "user_api_token": "..."}` |
+| `github` | SaaS | `github_org` + `github_app_id` + `github_installation_id` | `{"private_key": "-----BEGIN..."}` (GitHub App) |
+| `openai` | AI | *(optional `openai_org_id`)* | `{"admin_api_key": "sk-admin-..."}` |
+| `anthropic` | AI | *(optional `anthropic_org_uuid`)* | `{"admin_api_key": "sk-ant-admin01-..."}` (+ optional compliance key) |
+| `limacharlie` | LimaCharlie | one of `limacharlie_oid` or `limacharlie_uid` | `{"api_key": "..."}` |
+
+Every record also accepts the shared fields common to all providers —
+`internal_domains`, `sync_now`, `refresh`, and `feed_subscription` — documented
+in [Configuration](configuration.md#cloudsec_provider).
+
+## Cloud infrastructure
+
+### Google Cloud (`gcp`)
+
+Set `gcp_scope` to a single project (`projects/{id}`), a folder
+(`folders/{id}`), or a whole organization (`organizations/{id}`); the collector
+enumerates every project in scope. The credential is a service-account key JSON
+with read-only roles across the resource surface (compute, storage, IAM,
+networking, KMS, BigQuery, Cloud SQL, Secret Manager, Pub/Sub, …). The test
+report names any missing role.
+
+### AWS (`aws`)
+
+The collector assumes a read-only IAM role you designate in `aws_role_arn`,
+using an `aws_external_id` for the confused-deputy guard. For a single account
+that is all that's needed. For an **AWS Organization**, the collector chains from
+the management role into each member account, assuming the role *named* by
+`aws_member_role_name` in every member (defaults to the role name parsed from
+`aws_role_arn` — the common StackSet pattern, e.g.
+`OrganizationAccountAccessRole`). Restrict enumeration to specific regions with
+`aws_regions`. The secret may carry base credentials for the initial assume, or
+be omitted to use the collector's default chain.
+
+### Azure (`azure`)
+
+Set `azure_tenant_id` and `azure_subscription_id`, and the app-registration
+(service-principal) client id in `azure_client_id`. The credential secret carries
+the client secret: `{"client_secret": "..."}`. For an Entra directory with **no**
+Azure infrastructure to enumerate, use the standalone `entra` provider instead.
+
+## Identity providers
+
+Identity providers ingest a directory — users, groups, and app assignments —
+into the identity graph rather than cloud infrastructure. They unify with cloud
+IAM principals by email, which is what makes cross-surface CIEM ("this Workspace
+user has admin on that GCP bucket") possible.
+
+### Okta (`okta`)
+
+Set `okta_org_url` to the org base URL (e.g. `https://acme.okta.com`). The
+credential is either a user-owned SSWS token (`{"api_token": "..."}`) or an API
+Services app using client credentials (`{"client_id": "...", "private_key":
+"..."}` or `client_secret`), which is the recommended, non-user-bound option.
+
+### Microsoft Entra ID (`entra`)
+
+A standalone directory-only connection for organizations that have M365/Entra
+but no Azure subscription to enumerate. Set `entra_tenant_id` and the
+app-registration client id in `entra_client_id`; the client secret goes in the
+credential secret. It collects users, groups, service principals, and
+conditional-access posture. If you also run an `azure` connection for the same
+tenant, the Azure connection defers its directory collection to the standalone
+`entra` record so the directory is never collected twice.
+
+### Google Workspace (`google_workspace`)
+
+Set `workspace_customer_id` to `my_customer` (the delegated super-admin's own
+account, the common case) or an explicit customer id. The credential is a GCP
+service-account key with **domain-wide delegation**, plus the super-admin subject
+to impersonate; store it as `{"service_account_json": "...", "admin_email":
+"admin@acme.com"}`. It ingests users, groups, membership, and managed devices,
+unifying by email with the GCP IAM principals it references.
+
+### 1Password (`1password`)
+
+Set `onepassword_scim_url` to the account's SCIM bridge URL; the credential is
+the SCIM bearer token: `{"scim_url": "...", "scim_token": "..."}`. It collects
+users and groups into the identity graph.
+
+### Auth0 (`auth0`)
+
+Set `auth0_domain` to the tenant's canonical domain (e.g. `acme.us.auth0.com` or
+the legacy `acme.auth0.com` — not a custom domain). The credential is a
+Machine-to-Machine application authorized for the Management API with read-only
+scopes: `{"client_id": "...", "client_secret": "..."}`. It collects users, roles,
+applications, and connections.
+
+## SaaS
+
+### Cloudflare (`cloudflare`)
+
+Set `cloudflare_account_id` to the 32-hex account id from the dashboard. The
+credential is a read-only account-scoped API token: `{"api_token": "..."}`. An
+optional `user_api_token` covers user-scoped endpoints (account members, API
+token enumeration); without it those surfaces degrade to unobserved. It collects
+zones, DNS posture, R2 buckets, members, API tokens, Access applications, and
+Security Center insights.
+
+### GitHub (`github`)
+
+Auth is a **GitHub App installed on the organization** — an App, not a personal
+access token — so access is org-scoped, read-only, and uses short-lived
+installation tokens. Set `github_org` (the org login), `github_app_id`, and
+`github_installation_id`; the App private key goes in the credential secret:
+`{"private_key": "-----BEGIN RSA PRIVATE KEY-----..."}`. It collects org
+settings/members/teams (identities), repositories (data stores), installed Apps /
+webhooks / deploy keys / Actions secrets (non-human identities), and the Actions
+OIDC subject configuration.
+
+## AI security (AISPM)
+
+AI providers bring your model-platform organizations into the estate as
+first-class subjects, with the same findings and the `nist-ai-rmf` and
+`owasp-llm` compliance frameworks.
+
+### OpenAI (`openai`)
+
+The credential is an **Admin API key** created *with* the `api.management.read`
+scope at creation time (a freshly created key — scope-upgraded keys have had
+missing-scope issues): `{"admin_api_key": "sk-admin-..."}`. `openai_org_id`
+(`org-...`) is optional — the key already implies the org, but when set it is
+verified against the discovered org so a mismatch fails the connection early. It
+collects the organization, members, projects, and API keys.
+
+### Anthropic (`anthropic`)
+
+Anthropic has two credential planes and either may stand alone:
+
+- **Console** — an Admin key in `credentials`: `{"admin_api_key":
+  "sk-ant-admin01-..."}`. Anthropic Console Admin keys carry no scopes (every
+  Admin key is full read/write); the collector uses it strictly read-only.
+- **Compliance / Analytics** — an optional second secret referenced by
+  `compliance_credentials`: `{"compliance_api_key": "sk-ant-api01-..."}` with the
+  read-only compliance/analytics scopes. This unlocks enforced-settings posture
+  and the activity feed.
+
+Set `anthropic_org_uuid` when connecting **only** the compliance plane (the
+Compliance API is addressed by org uuid); with a Console key present it is
+discovered automatically. The credential secret may also optionally carry an
+`org_oauth_token` to reach the Workload Identity Federation admin plane. Findings
+degrade gracefully to whatever plane is connected.
+
+## LimaCharlie (`limacharlie`)
+
+Inventory your **own** LimaCharlie tenancy as an estate — useful both directly
+and as the CAASM source that unifies your sensors with the rest of your assets.
+Set exactly one of:
+
+- `limacharlie_oid` — an **org** API key, scoping collection to that one
+  organization.
+- `limacharlie_uid` — a **user** API key, which enumerates every organization
+  the user reaches (the MSSP fleet case — one connection covers the fleet).
+
+The API key goes in the credential secret: `{"api_key": "..."}`.
+
+## Refresh and event-driven freshness
+
+Every connection re-enumerates on the `refresh` cadence (a duration such as
+`"6h"`; empty uses the service default) and on demand whenever `sync_now`
+changes. For sub-sweep freshness on GCP, `feed_subscription` names a Pub/Sub
+subscription carrying a cloud change feed, so targeted re-sweeps reflect changes
+in seconds; the periodic sweep remains the safety net. See
+[Configuration](configuration.md#cloudsec_provider) for these shared fields.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -577,6 +577,7 @@ nav:
   - Cloud Security:
       - Overview: cloud-security/index.md
       - Getting Started: cloud-security/getting-started.md
+      - Connecting Providers: cloud-security/providers.md
       - Findings & Triage: cloud-security/findings.md
       - Security Graph & Queries: cloud-security/graph.md
       - Compliance: cloud-security/compliance.md


### PR DESCRIPTION
Catches the **Cloud Security (CNAPP)** documentation up to the product as it stands after the last ~2 weeks of changes. Every command, route, Hive field, event name, and provider was verified against the current backend, Python CLI/SDK, REST API gateway, and web UI — not memory.

## What changed

**Providers (7 → 13).** New [Connecting Providers](docs/cloud-security/providers.md) page covering all connectors across cloud infra / identity / SaaS / AI / LimaCharlie self-inventory — adds **OpenAI**, **Anthropic**, **LimaCharlie**, **Auth0**, **GitHub**, and **Entra**, with each one's scope fields and credential shape.

**Classification v2.** The retired `auto_classify` boolean is replaced by explicit, previewable `content_class` / `resource_type` rules. Documents the **OR → AND** matcher semantics (a rule matches only when every populated dimension matches; a rule with no matcher matches nothing), the new matcher fields (`resource_type`, `provider`, `region`, `public`), and that `store_kind` folded into `resource_type`.

**Findings & events.** Adds the `device_posture` finding class (11 total), workload-group shared-fix scoping (`source_scope`/`target_scope`), and the CIEM capability model (access scored by the capability a grant confers, not grant existence). Rewrites the event taxonomy to the current set — `cloud_finding.created`/`.updated`/`.closed`/`.still_open` plus the operator-disposition verbs (`.resolved`/`.dismissed`/`.reopened`/`.assigned`) and the `cloudsec.sync_completed` first-sync summary — with correct payload shapes.

**API & CLI.** Adds the new routes (`findings/classes`, `ciem/identity`, `topology`, `policy/vocabulary`, `providers/manifest`, `fleet/overview`, `simulate/resources`, `simulate/findings`, `policy/suggest`) and the new CLI commands (`fleet overview`, `provider manifest`, the `export` subgroup, `inventory --provider`). Notes which features are console + REST only (no CLI).

**Feature coverage.** Documents the Topology view, Identity 360, Simulate/preview + policy autocomplete, and the MSSP fleet board; updates the graph, CAASM (10 compliance frameworks; native `limacharlie` + `google_workspace` sources; managed devices + device posture), and compliance pages.

**Fixes.** The `8-reference` onboarding recipe used the wrong fields (`scope` + `secret.secret_name`) — corrected to `gcp_scope` + `credentials: hive://secret/...`; stale 5-provider list refreshed.

**Getting Started.** Rewritten to cover both the console flow (Settings → Providers → Add provider → Test Provider) and the equivalent IaC/CLI path.

## Validation
- `mkdocs build --strict` passes (exit 0).
- `markdownlint-cli2` clean on all changed files.
- All internal cross-link anchors verified against the generated slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)