### PR TITLE
docs(cloud-security): glob dialect + '!' negation

### DIFF
--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -74,6 +74,9 @@ findings automatically — the "accept this known risk in the sandbox for 90
 days" mechanic. An operator's own disposition always wins; deleting a rule
 releases exactly its own findings on the next cycle; criticals are never
 auto-suppressed unless a rule's `max_severity` says `critical` explicitly.
+The `account` matcher takes globs, including leading-`!` negation —
+`"account": ["!prod-*"]` scopes a rule to every account **outside** `prod-*`
+(see [Glob syntax](configuration.md#glob-syntax)).
 
 ```json
 {

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -76,7 +76,9 @@ limacharlie hive set --hive-name cloudsec_policy --key prod-cis \
 ```
 
 Scope matchers support `account_contains`, `account_glob`, `name_contains`,
-and `name_glob`; an empty scope means the whole estate.
+and `name_glob` (globs use the shared dialect, including leading-`!`
+negation — see [Glob syntax](configuration.md#glob-syntax)); an empty scope
+means the whole estate.
 
 List assignments (each with its own scoped score) and evaluate one:
 

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -96,6 +96,32 @@ the same matcher grammar:
     (This is a change from earlier behavior, where dimensions within a rule were
     ORed. The `store_kind` matcher has been folded into `resource_type`.)
 
+#### Glob syntax
+
+Every glob dimension (`account_glob`, `name_glob`, `region`, and suppression
+`account` matchers) shares one dialect:
+
+| Pattern | Matches |
+|---|---|
+| `*` | any run of characters (not `/`) |
+| `?` | one character (not `/`) |
+| `[abc]`, `[a-z]` | a character class; `[^…]` or `[!…]` negates the class |
+| `{a,b}` | alternation — `proj-{prod,staging}-*` |
+| `**` | any run **including** `/` (only differs from `*` on values containing `/`) |
+| `\c` | the literal character `c` |
+
+A pattern whose **first character is `!` is a negation**: within one list the
+positive patterns OR together as before, and any matching negation **vetoes**
+the whole list. A list containing only negations matches everything it doesn't
+exclude — `account_glob: ["!legion-*"]` means "every account **without** the
+`legion-` prefix". `\!` matches a literal leading `!`. Case-insensitive
+dimensions stay case-insensitive under negation.
+
+```yaml
+account_glob: ["*-prod", "!legion-*"]   # every -prod account except legion ones
+region: ["!eu-*"]                        # everywhere outside the EU
+```
+
 Not every dimension is honored on every surface — `tag` is compute-only,
 `content_class`/`public`/`classes` apply to data stores, and the `exclusions`
 emission list honors only account/name/provider. The console's policy editors


### PR DESCRIPTION
Documents the policy matcher glob dialect shipped with go-cloudsec v1.2.0 (doublestar syntax + leading-`!` list negation): a syntax table + negation semantics under "Rule matchers", a suppression example, and a compliance-scope pointer.

Held until the backend deploy lands fleet-wide (same session), then merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9zNFzek2V5Vo9CdcGe9rK