### PR TITLE
Remove Workload Scanning docs (feature not enabled in production)

### DIFF
--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -63,7 +63,7 @@ multi-tenant policy management a script, not a UI workflow.
 | Hive | Record | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per connection | what to collect — one of thirteen connectors spanning cloud infra, identity/IdP, SaaS, AI, and LimaCharlie self-inventory (see [Providers](../cloud-security/providers.md) for the full list) |
-| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation), `scanning` (agentless YARA), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
+| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
 | `cloudsec_query` | one per saved query | org-shared saved graph queries (the Query Console library) |
 
 ### Onboarding a tenant (recipe)

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -132,7 +132,7 @@ carry the same shape) — key fields:
 | Field | Meaning |
 |---|---|
 | `finding_id`, `fingerprint` | Stable identity of the condition (`fnd_` + fingerprint prefix). |
-| `rule_id`, `finding_class`, `classification` | What detected it and its class — one of the 11 values: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`. |
+| `rule_id`, `finding_class`, `classification` | What detected it and its class — one of: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `coverage_gap`, `device_posture`. |
 | `severity`, `lc_risk`, `risk_breakdown` | `CRITICAL`–`INFO`, the 0–1000 composite, and its explanation. |
 | `title`, `resource_urn`, `resource_name`, `resource_type`, `account`, `region` | The affected resource. |
 | `related_urns`, `path`, `path_kind` | Related resources; the hop list for path findings and the kind of path it represents. |

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -13,7 +13,7 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 | Hive | Records | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per cloud / IdP / SaaS / AI connection | what to collect and with which credential |
-| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, scanning, emission, exclusions, suppression, compliance assignments |
+| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, emission, exclusions, suppression, compliance assignments |
 | `cloudsec_query` | one per saved query | shared saved graph queries |
 
 !!! info "Permissions"
@@ -181,21 +181,6 @@ compute resource is expected to be covered; `exempt` wins.
     hive record drives cloud-workload coverage findings; the CAASM policy drives
     `coverage_gap` findings over third-party assets.
 
-### `scanning` — agentless content scanning
-
-Names the YARA rules to run against snapshot-scanned workloads and the
-classification each match assigns, plus an optional resource `scope`:
-
-```json
-{
-  "policy_type": "scanning",
-  "scanning": {
-    "rules": [{"yara_rule": "hive://yara/crypto-miners", "classification": "malware"}],
-    "scope": [{"account_glob": ["proj-prod-*"]}]
-  }
-}
-```
-
 ### `emission` — the event feed
 
 Controls which Cloud Security events reach the organization's event stream:
@@ -204,7 +189,7 @@ Controls which Cloud Security events reach the organization's event stream:
 |---|---|---|
 | `resource_events` | `cloud_resource.*` inventory change events | off |
 | `finding_events` | `cloud_finding.*` lifecycle events | on |
-| `ops_events` | operational events (sweep/scan failures) | off |
+| `ops_events` | operational events (sweep failures) | off |
 | `severity_floor` | drop finding events below this severity | none |
 | `suppress_first_sync` | emit one summary instead of a per-finding flood on the first / rebuild sweep | on |
 
@@ -213,7 +198,7 @@ event taxonomy.
 
 ### `exclusions` — the escape hatch
 
-Excludes matching resources from `collection`, `scanning`, or `emission` (three
+Excludes matching resources from `collection` or `emission` (two
 independent rule lists; collection rules add `services` and `resource_types`
 matchers on top of the shared resource matchers). Use it for the million-object
 bucket that should not be enumerated, or the noisy account that should not emit

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -13,7 +13,7 @@ verbs, and the same automation events.
 !!! info "In the console it's called **Risks**"
     The worklist is the **Risks** page. Lens tabs slice it without losing the
     unified ranking: *All risks*, *Public exposure & misconfig*, *Identity*,
-    *Workload*, *Vulnerabilities*, and *Data*. Everything below is the same
+    *Vulnerabilities*, and *Data*. Everything below is the same
     data through the CLI/API.
 
 ## The worklist
@@ -27,7 +27,7 @@ resource is sensitive. Each finding carries:
   same fingerprint across sweeps.
 - `finding_class` — one of `toxic_combination`, `public_exposure`,
   `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
-  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`.
+  `coverage_gap`, `device_posture`.
 - `severity` (`CRITICAL` … `INFO`), `lc_risk`, and a `risk_breakdown`
   explaining the score.
 - The affected resource (`resource_urn`, `resource_name`, `resource_type`,

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -88,7 +88,7 @@ map onto the capabilities above:
 | **Topology** | An aggregated, explorable diagram of the estate. |
 | **Compliance** | Per-control framework assessment and scoped assignments. |
 | **Explore** | The interactive Security graph and the Query console. |
-| **Policies** | Data classification (crown jewels), workload scanning, coverage, asset coverage, exclusions, and suppression. |
+| **Policies** | Data classification (crown jewels), coverage, asset coverage, exclusions, and suppression. |
 | **Settings** | Provider connections and the Cases integration. |
 
 A separate cross-tenant **Cloud Security Fleet** board rolls risk up across every


### PR DESCRIPTION
Removes workload-scanning (agentless snapshot scanning / CWPP) material from the Cloud Security docs, since the feature is not enabled in any production deployment. Companion PRs remove the same surface from the web app UI and the Python CLI.

Removed:
- `configuration.md`: the `### scanning` policy section, `scanning` in the policy-type table, the scanning exclusion surface (now `collection`/`emission`), "scan failures" wording in `ops_events`.
- `findings.md` + `api-reference.md`: scanner-only finding classes (`malware`, `secret`, `scan_finding`) from the `finding_class` enums; the *Workload* lens from the Risks lens list.
- `index.md`: "workload scanning" from the Policies row.
- `8-reference/cloud-security-api-iac.md`: the `scanning` policy row.

Deliberately kept: collection-sweep status (`scan-status` CLI/API — that's inventory collection, not the scanner), vulnerability findings docs (collection-sourced via VM Manager), Data Security / `content_class` classification docs (the classification UI keeps content_class rules), CAASM `vuln_scanner`/`cloud_scanner` source docs, and release notes (historical record).

No `mkdocs.yml` nav change needed — no whole page was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT6t7WyXfsEfyCGahubzqa