### PR TITLE
Fix epp_add_exclusion / epp_rem_exclusion parameter documentation

### DIFF
--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -1167,42 +1167,43 @@ limacharlie sensor task <SID> epp_list_exclusions
 
 ### epp_add_exclusion
 
-Add a path or process to EPP scan exclusions.
+Add a path, process or file extension to EPP scan exclusions.
 
 **Platforms:** Windows
 
 **Parameters:**
 
-- `file_path` (optional): File/directory path to exclude
-- `process` (optional): Process name to exclude
+- `value` (positional, required): Value of the exclusion to add (a file/directory path, a process name, or a file extension)
+- `--type` / `-t` (required): Type of exclusion. Options are: `extension`, `path`, `process`
 
 **Response Event:** EPP_ADD_EXCLUSION_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> epp_add_exclusion --file_path "C:\\safe_app"
+limacharlie sensor task <SID> epp_add_exclusion "C:\\safe_app" --type path
+limacharlie sensor task <SID> epp_add_exclusion "safe_app.exe" --type process
 ```
 
 ---
 
 ### epp_rem_exclusion
 
-Remove a path or process from EPP scan exclusions.
+Remove a path, process or file extension from EPP scan exclusions.
 
 **Platforms:** Windows
 
 **Parameters:**
 
-- `file_path` (optional): File/directory path to remove from exclusions
-- `process` (optional): Process name to remove from exclusions
+- `value` (positional, required): Value of the exclusion to remove (a file/directory path, a process name, or a file extension)
+- `--type` / `-t` (required): Type of exclusion. Options are: `extension`, `path`, `process`
 
 **Response Event:** EPP_REM_EXCLUSION_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> epp_rem_exclusion --file_path "C:\\safe_app"
+limacharlie sensor task <SID> epp_rem_exclusion "C:\\safe_app" --type path
 ```
 
 ---


### PR DESCRIPTION
## Summary

The reference docs for `epp_add_exclusion` and `epp_rem_exclusion` documented `--file_path` and `--process` flags that do not exist. The actual commands take a **positional exclusion value** plus a required **`--type`** flag with options `extension`, `path`, `process`:

```
epp_add_exclusion "C:\\safe_app" --type path
epp_add_exclusion "safe_app.exe" --type process
```

Commands issued with the previously documented syntax fail command parsing at task submission and are never delivered to the sensor, which surfaced as "epp_add_exclusion does nothing / no REP event" in a support ticket.

Also mentions `extension` as a supported exclusion type, which was previously undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXzb5o9y2wqSuhtspi1SDX