### PR TITLE
docs(cloud-security): fix stale query examples and CLI-coverage claims

### DIFF
--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -111,12 +111,13 @@ curl -X POST -H "Authorization: Bearer $JWT" -H "Content-Type: application/json"
 
 These `POST` routes back the console's policy-authoring aids (matcher
 preview and value autocomplete). They never mutate state, so they require
-only `cloudsec.get`. There is **no CLI command** for them — they are
-console + REST-API only.
+only `cloudsec.get`. On the CLI they are `limacharlie cloudsec simulate
+resources` / `simulate findings`, `limacharlie cloudsec policy suggest`,
+and `limacharlie cloudsec policy vocabulary`.
 
 | Route | Body | Returns |
 |---|---|---|
-| `POST /simulate/resources` | `{rules, target, resource_types?, sample_limit?}` — `rules` is a list of matcher rules, `target` names the surface (e.g. `data_stores`, `compute`, `identities`). | `{evaluated, matched, indeterminate, truncated, sample}` — preview a classification / coverage / exclusion matcher against stored inventory. |
+| `POST /simulate/resources` | `{rules, target, resource_types?, sample_limit?}` — `rules` is a list of matcher rules, `target` scopes the walked surface (`data_store`, `compute`, `identity`, or `any` — the default). | `{evaluated, matched, indeterminate, truncated, sample}` — preview a classification / coverage / exclusion matcher against stored inventory. |
 | `POST /simulate/findings` | `{match, sample_limit?}` — a suppression matcher. | `{evaluated, matched, indeterminate, truncated, sample}` — preview it against currently-open findings. |
 | `POST /policy/suggest` | `{dimension, q, target, limit?}` — `dimension` is `name` or `account`. | `{suggestions}` — live matcher-value autocomplete drawn from the tenant estate. |
 

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -28,10 +28,12 @@ limacharlie cloudsec overview --trend-days 90
 limacharlie cloudsec changes --limit 100
 limacharlie cloudsec risk-trend
 limacharlie cloudsec scan-status --provider gcp
+limacharlie cloudsec topology
 
 # Findings worklist + triage
 limacharlie cloudsec finding list --severity CRITICAL --class toxic_combination --kev
 limacharlie cloudsec finding facets --status open
+limacharlie cloudsec finding classes                      # the finding_class enum
 limacharlie cloudsec finding get fnd_0a1b...
 limacharlie cloudsec finding resolve fnd_0a1b... --kind mitigated --reason "SG tightened"
 limacharlie cloudsec finding resolve fnd_0a1b... --kind open          # reopen
@@ -48,6 +50,7 @@ limacharlie cloudsec chokepoint restore "lcrn:..."
 # Identity & data
 limacharlie cloudsec ciem public-access
 limacharlie cloudsec ciem facets
+limacharlie cloudsec ciem identity "lcrn:..."             # Identity 360
 limacharlie cloudsec data-security facets
 
 # Inventory & graph
@@ -56,8 +59,8 @@ limacharlie cloudsec inventory facets
 limacharlie cloudsec resource get "lcrn:..."
 limacharlie cloudsec graph neighbors "lcrn:..." --limit 200
 limacharlie cloudsec query list
-limacharlie cloudsec query run --named public-buckets
-limacharlie cloudsec query run --text "public bucket with sensitive data"
+limacharlie cloudsec query run --named public_data_stores
+limacharlie cloudsec query run --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
 
 # Compliance
 limacharlie cloudsec compliance report --framework cis-gcp
@@ -80,11 +83,17 @@ limacharlie cloudsec caasm ingest --source okta --records-file users.json
 limacharlie cloudsec provider test --input-file provider.json
 limacharlie cloudsec provider manifest --type gcp        # "what you get" for a provider
 
+# Policy authoring aids + read-only matcher previews
+limacharlie cloudsec policy vocabulary
+limacharlie cloudsec policy suggest --dimension name -q prod
+limacharlie cloudsec simulate resources --input-file rules.json --target data_store
+limacharlie cloudsec simulate findings --input-file match.json
+
 # Full-set CSV export (server-side walk of the entire filtered set)
 limacharlie cloudsec export findings -o findings.csv
 limacharlie cloudsec export inventory -o inventory.csv
 limacharlie cloudsec export compliance --framework cis-gcp -o compliance.csv
-limacharlie cloudsec export query --named public-buckets -o public-buckets.csv
+limacharlie cloudsec export query --named public_data_stores -o data-stores.csv
 
 # Fleet — cross-tenant (MSSP) roll-up, no single --oid
 limacharlie cloudsec fleet overview --oid $OID1 --oid $OID2 --trend-days 30
@@ -106,11 +115,12 @@ tenants. It carries `--trend-days`, `--limit`, and `--cursor` for paging the
 tenant list, and is the one command that does not resolve a single `--oid`.
 
 !!! note "CLI is the query & triage surface"
-    Simulate/preview, policy-matcher autocomplete, Topology, Identity 360,
-    scheduled queries, and workload-group views are **console + REST-API**
-    features with no CLI command — the CLI covers reads, findings triage,
-    exports, and fleet roll-up. Provider and policy *records* are managed
-    with `limacharlie hive` (see [Configuration](configuration.md)).
+    Scheduled queries and workload-group views are **console + REST-API**
+    features with no CLI command — everything else (reads, findings triage,
+    graph queries, Topology, Identity 360, policy simulation and
+    autocomplete, exports, and fleet roll-up) is covered. Provider and
+    policy *records* are managed with `limacharlie hive` (see
+    [Configuration](configuration.md)).
 
 ## Filtering and pagination
 

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -243,7 +243,8 @@ events) is an emerging capability.
 ## Previewing policies
 
 Two read-only, `cloudsec.get`-gated aids make policy authoring safe — both are
-in the console policy editors and on the API (there is no CLI command for them):
+in the console policy editors, on the API, and on the CLI
+(`limacharlie cloudsec simulate` / `limacharlie cloudsec policy`):
 
 - **Simulate** evaluates an in-progress matcher against your real data before you
   save. A resource matcher (classification / coverage / exclusions) is previewed

--- a/docs/cloud-security/graph.md
+++ b/docs/cloud-security/graph.md
@@ -65,8 +65,8 @@ you're looking at.
 
 Because it is backed by **server-side aggregates**, the counts on every node
 are exact at any scale — Topology never walks a capped page and then guesses.
-It is served by `GET /topology` (see [API Reference](api-reference.md)); there
-is no CLI command for it.
+It is served by `GET /topology` (see [API Reference](api-reference.md)) and by
+`limacharlie cloudsec topology` on the CLI.
 
 ## Graph queries
 
@@ -75,14 +75,30 @@ Ask questions of the whole graph. Three input forms, one endpoint:
 ```bash
 # A named query from the built-in query pack:
 limacharlie cloudsec query list
-limacharlie cloudsec query run --named public-buckets
+limacharlie cloudsec query run --named public_data_stores
 
-# Free-text:
-limacharlie cloudsec query run --text "public bucket with sensitive data"
+# The text form — a compact MATCH ... RETURN pattern:
+limacharlie cloudsec query run --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
 
 # The raw query DSL:
 limacharlie cloudsec query run --query-json '{...}' --project a,b
 ```
+
+The text form is a compact graph-pattern grammar, not natural language:
+nodes are `(alias:Label {prop: value, ...})`, edges are `<-[:edge_name]-`
+(inbound to the previous node) or `-[:edge_name]->` (outbound), edge names
+use underscores, and the query ends with `RETURN alias, alias...`. Inline
+predicates are AND-ed equalities.
+
+The first node is the **anchor**, and every query must anchor on a
+*selective* set and traverse inward. Bounded node types (data stores,
+vulnerabilities, public endpoints, applications, accounts) anchor as-is;
+dense types (workloads, identities) must be narrowed by a selective
+predicate — `is_sensitive: true`, `is_public: true`, `is_external: true`,
+`in_kev: true`, or an exact `email` / `sid`. A query that fans out from the
+dense fabric is rejected by design: restructure it to start from the
+selective end (the sensitive store, the known-exploited vulnerability, the
+specific identity) and walk toward the dense side.
 
 Results are rows of alias → URN bindings; use
 `limacharlie cloudsec resource get <urn>` to hydrate any URN into its full
@@ -127,7 +143,8 @@ endpoints associated with that identity. Each reach edge carries its classified
 access level, so the whole effective blast radius is visible in one place. It
 is the console's Identity & Access → *(an identity)* drill-down, served by
 `GET /cloudsec/{oid}/ciem/identity?urn=<identity-urn>` (see
-[API Reference](api-reference.md)); there is no CLI command for it.
+[API Reference](api-reference.md)) and by
+`limacharlie cloudsec ciem identity "<identity-urn>"` on the CLI.
 
 ## Data security: DSPM facets
 


### PR DESCRIPTION
## What

Fixes stale content on the Cloud Security pages, found while writing AI guidance for the product:

- **Query examples referenced a pack query that does not exist**: `--named public-buckets` → `--named public_data_stores` (pack lookup is exact-match). Same fix in the `export query` example.
- **The `--text` examples showed natural language**, but the text form is a compact `MATCH ... RETURN` graph-pattern grammar — natural language does not parse. Replaced with a real example and documented the grammar plus the selective-anchor rule (why fan-out queries are rejected and how to restructure them), so users hitting a rejection can understand and fix it.
- **"Console + REST-API only, no CLI" claims are outdated**: `topology`, `ciem identity` (Identity 360), `policy vocabulary`/`policy suggest`, `simulate resources`/`simulate findings`, and `finding classes` all shipped in the CLI (limacharlie 5.5.3 on PyPI — verified). Updated `graph.md`, `cli.md` (including the At-a-glance tour and the coverage note), `configuration.md`, and `api-reference.md`.
- **Corrected the simulate `target` values** in the API reference to the accepted singular forms (`data_store`, `compute`, `identity`, `any` — the plural spellings were never accepted).

All command names, flags, pack-query names, and grammar verified against the released CLI (5.5.3) and current API behavior per the repo's snippet-accuracy policy. markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6ug17pCvjJYLveQv6iz81