### PR TITLE
docs: document the SOP hive

### DIFF
--- a/docs/7-administration/config-hive/index.md
+++ b/docs/7-administration/config-hive/index.md
@@ -10,6 +10,7 @@ The Config Hive is LimaCharlie's hierarchical configuration store. It provides a
 - [YARA](yara.md) - YARA rule storage and management
 - [Cloud Sensors](cloud-sensors.md) - Cloud sensor configurations
 - [Apps](apps.md) - User-authored, AI-generated mini web applications
+- [SOPs](../../9-ai-sessions/sops.md) - Standard Operating Procedures that AI agents read and follow
 
 ## Usage
 

--- a/docs/8-reference/permissions.md
+++ b/docs/8-reference/permissions.md
@@ -163,6 +163,16 @@ LimaCharlie uses a granular permission system that controls access to all platfo
 | playbook.get.mtd | View playbook metadata only |
 | playbook.set.mtd | Modify playbook metadata only |
 
+### SOPs
+
+| Permission | Description |
+| --- | --- |
+| sop.get | Access Standard Operating Procedures |
+| sop.set | Create and modify SOPs |
+| sop.del | Delete SOPs |
+| sop.get.mtd | View SOP metadata only |
+| sop.set.mtd | Modify SOP metadata only |
+
 ### Apps
 
 | Permission | Description |

--- a/docs/9-ai-sessions/sops.md
+++ b/docs/9-ai-sessions/sops.md
@@ -1,0 +1,202 @@
+# Standard Operating Procedures (SOPs)
+
+A Standard Operating Procedure is a document you store in your organization that
+tells AI agents how *your* team wants a job done. Where [AI Skills](skills.md) are
+reusable capabilities an agent can invoke and [AI Memory](memory.md) is what an agent
+has learned, an SOP is organizational policy: the escalation path for a ransomware
+detection, who must approve an endpoint isolation, which hosts are never to be
+touched during business hours.
+
+SOPs are plain documents — LimaCharlie does not execute them. They are written by
+humans, read by agents, and followed as instructions. That makes them the primary
+way to steer agent behaviour without editing agent prompts.
+
+SOPs live in the `sop` [Config Hive](../7-administration/config-hive/index.md),
+scoped to a single organization.
+
+## Record format
+
+Each SOP is one Hive record. The key is the SOP name, and the payload has two
+fields:
+
+| Field | Required | Purpose |
+|---|---|---|
+| `text` | Yes | The procedure itself. Free-form; markdown is the convention. |
+| `description` | No | A one-line summary used to decide whether the SOP applies. |
+
+```yaml
+data:
+  description: Standard procedure for confirmed ransomware on an endpoint
+  text: |
+    # Ransomware Response
+
+    ## Containment
+    1. Isolate the affected sensor immediately — do not wait for approval.
+    2. Tag the sensor `incident` and note the detection ID.
+
+    ## Escalation
+    - Page the on-call responder for any host tagged `prod`.
+    - Do not power off servers; collect memory first.
+
+    ## Out of scope
+    - Never delete artifacts or detections as part of containment.
+usr_mtd:
+  enabled: true
+  tags: [incident-response, tier-1]
+```
+
+The only validation applied is that `text` must be non-empty. Nothing else about
+the content is enforced, so write for the reader — an LLM deciding what to do next.
+
+### Writing an effective `description`
+
+The `description` is load-bearing. Agents scan the list of SOPs and match
+descriptions against the task in front of them, then fetch only the ones that look
+relevant. A vague description ("IR stuff") means the SOP is never opened; a specific
+one ("Standard procedure for confirmed ransomware on an endpoint") means it is.
+
+### Limits
+
+- Maximum record size: 1 MB per SOP.
+
+!!! warning "New SOPs are created disabled"
+    Like every Hive record, an SOP is created **disabled** unless you pass
+    `--enabled` or set `usr_mtd.enabled: true`. Set it deliberately — an SOP is only
+    meaningful if the agents reading it treat it as active policy.
+
+## How agents use SOPs
+
+Nothing injects SOPs into an agent automatically. Agents load them, on their own,
+in two steps:
+
+1. **List** the SOPs in the organization and read the names and descriptions.
+2. **Fetch by key** only the SOPs whose description matches the task at hand, then
+   follow the procedure.
+
+Agents built from the LimaCharlie agent library announce the match in their
+transcript — `Following SOP: <name>` — so you can audit adherence after the fact.
+
+This means the granularity of your SOPs matters. One giant `security-policy`
+document forces the agent to load everything for every task; a set of narrowly
+described SOPs (`ransomware-response`, `after-hours-escalation`,
+`isolation-approval`) lets it pull only what applies.
+
+!!! note "Listing returns full records"
+    `limacharlie sop list` and `GET /v1/hive/sop/{oid}` return every SOP in full,
+    including `text`. Agents are instructed to read only the names and descriptions
+    at that stage and re-fetch the body with `sop get`, but budget context
+    accordingly if you keep many large SOPs.
+
+## Permissions
+
+| Operation | Permission |
+|---|---|
+| List / read SOPs | `sop.get` |
+| Create / update an SOP | `sop.set` |
+| Delete an SOP | `sop.del` |
+| Read metadata | `sop.get.mtd` |
+| Update metadata | `sop.set.mtd` |
+
+An agent that only needs to follow procedures should be issued `sop.get` and
+`sop.get.mtd` — read-only. Grant `sop.set` only to agents that are expected to
+author policy.
+
+## Managing SOPs
+
+### Web interface
+
+SOPs are managed under **Automation → SOPs** in the organization view, where you can
+create, edit, tag, enable, and disable them. In an interactive AI session, the
+`/sops` [slash command](rich-cards.md) renders the same list inline.
+
+### CLI
+
+```bash
+# List every SOP in the organization.
+limacharlie sop list --oid <oid> --output yaml
+
+# Read one SOP.
+limacharlie sop get --key ransomware-response --oid <oid> --output yaml
+
+# Create or update an SOP from a file, enabled in one shot.
+limacharlie sop set --key ransomware-response \
+    --input-file ransomware-response.yaml --enabled --oid <oid>
+
+# Or pipe the record in.
+cat ransomware-response.yaml | limacharlie sop set \
+    --key ransomware-response --enabled --oid <oid>
+
+# Toggle without touching the content.
+limacharlie sop disable --key ransomware-response --oid <oid>
+limacharlie sop enable --key ransomware-response --oid <oid>
+
+# Organize with tags.
+limacharlie sop tag add --key ransomware-response -t incident-response --oid <oid>
+
+# Delete.
+limacharlie sop delete --key ransomware-response --confirm --oid <oid>
+```
+
+The input file takes the same shape as the record above — a `data` block with
+`text` and `description`, plus an optional `usr_mtd` block.
+
+### REST API
+
+SOPs use the standard Hive endpoints with a hive name of `sop` and the organization
+ID as the partition key:
+
+```bash
+# List all SOPs.
+curl -s "https://api.limacharlie.io/v1/hive/sop/$OID" \
+  -H "Authorization: Bearer $LC_JWT"
+
+# Read one SOP.
+curl -s "https://api.limacharlie.io/v1/hive/sop/$OID/ransomware-response/data" \
+  -H "Authorization: Bearer $LC_JWT"
+
+# Create or update.
+curl -s -X POST \
+  "https://api.limacharlie.io/v1/hive/sop/$OID/ransomware-response/data" \
+  -H "Authorization: Bearer $LC_JWT" \
+  --data-urlencode 'data={"text":"# Ransomware Response\n1. Isolate the sensor.","description":"Confirmed ransomware on an endpoint"}' \
+  --data-urlencode 'usr_mtd={"enabled":true}'
+```
+
+### Python SDK
+
+```python
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.hive import Hive, HiveRecord
+
+client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+org = Organization(client)
+sops = Hive(org, "sop")
+
+# Create or update an SOP.
+record = HiveRecord(
+    "ransomware-response",
+    data={
+        "text": "# Ransomware Response\n1. Isolate the sensor.",
+        "description": "Confirmed ransomware on an endpoint",
+    },
+)
+record.enabled = True
+record.tags = ["incident-response"]
+sops.set(record)
+
+# Read one SOP.
+sop = sops.get("ransomware-response")
+print(sop.data["text"])
+
+# List every SOP.
+for name, rec in sops.list().items():
+    print(name, rec.data.get("description"))
+```
+
+## Related
+
+- [AI Skills](skills.md) — reusable instruction sets an agent invokes as capabilities.
+- [AI Memory](memory.md) — what an agent has learned and should recall later.
+- [Config Hive](../7-administration/config-hive/index.md) — the store SOPs live in.
+- [Permissions](../8-reference/permissions.md) — the full permission reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -563,6 +563,7 @@ nav:
       - Rich Cards & Slash Commands: 9-ai-sessions/rich-cards.md
       - AI Skills: 9-ai-sessions/skills.md
       - AI Memory: 9-ai-sessions/memory.md
+      - SOPs: 9-ai-sessions/sops.md
       - Command Line Interface: 9-ai-sessions/cli.md
       - Alternative Providers: 9-ai-sessions/alternative-providers.md
       - API Reference: 9-ai-sessions/api-reference.md


### PR DESCRIPTION
## What

Standard Operating Procedures (the `sop` hive) had no documentation page. The only references anywhere in `docs/` were a row in the story-tags reference and `sop.get` / `sop.get.mtd` appearing in two compliance-agent permission tables — nothing describing what an SOP is, its record format, or how to manage one.

## Changes

- **`docs/9-ai-sessions/sops.md`** (new) — record format (`text` / `description`), the 1 MB limit, the disabled-by-default behavior, how agents discover and load SOPs, permissions, and management via the web UI, CLI, REST API and Python SDK.
- **`mkdocs.yml`** — nav entry under AI Sessions.
- **`docs/7-administration/config-hive/index.md`** — SOPs added to the Hive Types list.
- **`docs/8-reference/permissions.md`** — a `### SOPs` table; the hive permissions section had no SOP entry at all.

## Placement

Under AI Sessions rather than Config Hive, following the existing precedent that agent-facing hives live there (AI Skills, AI Memory), and because AI agents are the primary consumer. The Config Hive index links across to it.

## Verification

Record schema, validation rules and permission names were read from the hive service source; CLI subcommands and flags from the released `limacharlie` CLI source; SDK calls from the Python SDK's hive module; UI location and the `/sops` slash command from the web app. Nothing written from memory.

- `markdownlint-cli2` — clean
- `mkdocs build --strict` — clean, page renders and appears in the generated `llms.txt`
- `scripts/check-list-numbering.py` — no new breaks from this page

## Note

`limacharlie sop list` returns full records including `text`, so the "read names and descriptions first, fetch the body by key" pattern agents follow does not actually avoid the context cost at list time. The page documents this accurately rather than repeating the assumption. Making the list path metadata-only is a separate change outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwVp8Ug988F8G7G6tjkMaz