### PR TITLE
docs(cloud-security): full accuracy audit against the current product

### DIFF
--- a/docs/1-getting-started/use-cases/cloud-security.md
+++ b/docs/1-getting-started/use-cases/cloud-security.md
@@ -1,5 +1,16 @@
 # Cloud Security
 
+This page is about the telemetry side of cloud security: ingesting, monitoring,
+and retaining log data from cloud platforms and SaaS applications alongside the
+rest of your telemetry.
+
+!!! info "Looking for posture, inventory and attack paths?"
+    LimaCharlie also has a dedicated agentless cloud-native application
+    protection platform (CNAPP) — resource inventory, misconfiguration and
+    vulnerability findings, attack paths, identity (CIEM), data security
+    (DSPM), and compliance across your cloud, identity, SaaS, and AI estate.
+    See [Cloud Security](../../cloud-security/index.md).
+
 The Agentic SecOps Workspace simplifies the difficult task of securing cloud resources and managing complex cloud-based or hybrid infrastructure. LimaCharlie brings better visibility, robust interoperability, and better options for storing data to cloud and hybrid environments.
 
 ## Cloud security problems

--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -21,14 +21,18 @@ tells you to subscribe).
 
 The read surface includes: `findings` (risk-ranked worklist with keyset pagination
 and server-side filters), `findings/facets`, `findings/classes` (the canonical
-finding-class enum), `attack-paths` (with the same filter selectors), `chokepoints`
+finding-class enum), `findings/causes` (findings grouped by the object whose single
+edit fixes them), `attack-paths` (with the same filter selectors), `chokepoints`
 (incl. the principal-exposure metrics), `ciem/public-access`, `ciem/facets`,
-`ciem/identity` (the Identity 360 view, `?urn=`), `inventory` (+`inventory/facets`),
-`data-security/facets`, `topology` (server-side estate aggregates), `compliance`
-(+`compliance/frameworks`, `compliance/assignments`), `policy/vocabulary` (the
+`ciem/identities` (the filtered, paginated Access list), `ciem/identity` (the
+Identity 360 view of one principal, `?urn=`), `inventory` (+`inventory/facets`),
+`data-security/facets` (+`data-security/stores`), `topology` (server-side estate
+aggregates), `compliance` (+`compliance/frameworks`,
+`compliance/assignments`), `policy/vocabulary` (the
 classification-policy vocabulary), `providers/manifest` (what a provider collects),
 `caasm/assets`, `caasm/coverage`, `caasm/policy`, `overview` (incl. the per-tenant
-`usage` metering block), `risk-trend`, `changes`, `scan-status`, `query` (the graph
+`usage` metering block), `risk-trend`, `changes`, `scan-status`, `free-tier` (the
+org's free-tier standing and limits — descriptive, not a gate), `query` (the graph
 DSL), and `graph/neighbors`. There is also a multi-org (no `{oid}`)
 `fleet/overview` route that rolls risk up across every tenant you manage. Three
 read-only preview POSTs help you author policy before you commit it —
@@ -63,8 +67,19 @@ multi-tenant policy management a script, not a UI workflow.
 | Hive | Record | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per connection | what to collect — one of thirteen connectors spanning cloud infra, identity/IdP, SaaS, AI, and LimaCharlie self-inventory (see [Providers](../cloud-security/providers.md) for the full list) |
-| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
+| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation — accepted but not yet evaluated; see the [Configuration reference](../cloud-security/configuration.md)), `scanning` (the agentless snapshot scanner's ruleset), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
 | `cloudsec_query` | one per saved query | org-shared saved graph queries (the Query Console library) |
+
+The `scanning` type names the `yara` hive records the agentless snapshot scanner
+runs and how each one's hits are classified (into the `malware`, `secret`, and
+`scan_finding` finding classes), plus an optional compute scope. There is no
+built-in ruleset: creating the policy *is* the opt-in, the same user-declared-only
+stance as classification.
+
+!!! note "`limacharlie sync` does not cover these hives"
+    The `cloudsec_*` hives are outside the set `limacharlie sync` walks, so a
+    config pull/push will not round-trip them. Manage them with explicit
+    `limacharlie hive set` / `hive get` calls — the loops below are the pattern.
 
 ### Onboarding a tenant (recipe)
 
@@ -119,6 +134,19 @@ An operator's own disposition always wins, deleting a rule releases exactly its 
 findings on the next cycle, and criticals are never auto-suppressed unless a rule's
 `max_severity` says `critical` explicitly.
 
+`match` takes four selectors — OR within a selector, AND across them:
+`finding_class` (the class enum), `rule` (exact rule ids), `account` (shell globs,
+including leading-`!` negation — `"!prod-*"` scopes to every account that is *not*
+production), and `urn_prefix` (resource-URN prefixes), with `max_severity` as the
+inclusive ceiling.
+The record is validated on write and rejected unless every rule has a unique
+non-empty `name` (it becomes the disposition actor, `policy:<name>`), at least one
+of those four match keys with no empty entries, a well-formed account glob, a
+`max_severity` from the severity enum, an `effect.kind` of `accepted` or
+`false_positive` — `mitigated` is not a policy's call to make — and a non-empty
+`effect.reason`, since an unexplained auto-disposition is unauditable. Rules are
+ordered and first match wins.
+
 ```json
 {
   "policy_type": "suppression",
@@ -153,8 +181,17 @@ findings on the next cycle, and criticals are never auto-suppressed unless a rul
 ```
 
 Save it as a `cloudsec_query` record and it appears in every teammate's Query
-Console and as a pinnable Explore lens. The `schedule` and `detection` blocks are
-accepted (so IaC written today survives the scheduled-query phase) but inert.
+Console and as a pinnable lens on the Attack Surface page's lens rail.
+
+The `schedule` block is **active**: a record with `schedule.scheduled: true` is
+evaluated after each projection cycle — or on an optional cadence, one of
+`interval` (a duration of at least `5m`) or `cron` (standard 5-field) — and emits
+`cloud_query.match` / `cloud_query.resolved` as anchors enter and leave its
+match-set. A scheduled query must be an enabled record, since a disabled one has to
+stay inert. Anchors already suppressed by the org's suppression policy do not emit
+unless the schedule sets `emit_suppressed`. The `detection` block is still
+reserved: it is shape-checked on write, so IaC written today survives the
+promote-to-detection phase, but nothing consumes it yet.
 
 ## Findings ↔ Cases automation
 
@@ -162,12 +199,17 @@ Cloud findings emit lifecycle events into the organization's own event stream vi
 the internally-provisioned `cloudsec` webhook adapter: `cloud_finding.created`
 (carries the full finding under `finding`), `cloud_finding.closed`
 (`{finding_id, fingerprint, finding_class}`), and `cloud_finding.still_open`
-(re-asserted at most once per day for open findings with a linked ticket). D&R
-rules match these like any event; the Cases extension actions close the loop.
+(re-asserted at most once per day for open findings with a linked ticket, carrying
+that `ticket` in the payload). D&R rules match these like any event; the Cases
+extension actions close the loop.
 For richer automation the same stream also carries `cloud_finding.updated` (an
-open finding's content materially changed — a severity flip or vuln-set change)
-and the operator-disposition verbs `cloud_finding.resolved` / `.dismissed` /
-`.reopened` / `.assigned` (for auditing human triage decisions).
+open finding materially changed: a severity move in either direction, the
+subject becoming internet-reachable, or one of its CVEs entering CISA KEV)
+and the disposition verbs `cloud_finding.resolved` / `.dismissed` /
+`.reopened` / `.assigned`. Those last four cover both human triage and a
+`suppression` policy acting on its own: read `actor` to tell them apart (a user id
+versus `policy:<rule name>`), and branch on the payload's `resolution` rather than
+the verb, since an accepted risk and a fixed one both arrive as `.resolved`.
 
 The console installs these three rules with one click (Settings → Cloud Security →
 Cases, an opt-in), or write them yourself:

--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -67,14 +67,8 @@ multi-tenant policy management a script, not a UI workflow.
 | Hive | Record | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per connection | what to collect — one of thirteen connectors spanning cloud infra, identity/IdP, SaaS, AI, and LimaCharlie self-inventory (see [Providers](../cloud-security/providers.md) for the full list) |
-| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation — accepted but not yet evaluated; see the [Configuration reference](../cloud-security/configuration.md)), `scanning` (the agentless snapshot scanner's ruleset), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
+| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation — accepted but not yet evaluated; see the [Configuration reference](../cloud-security/configuration.md)), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
 | `cloudsec_query` | one per saved query | org-shared saved graph queries (the Query Console library) |
-
-The `scanning` type names the `yara` hive records the agentless snapshot scanner
-runs and how each one's hits are classified (into the `malware`, `secret`, and
-`scan_finding` finding classes), plus an optional compute scope. There is no
-built-in ruleset: creating the policy *is* the opt-in, the same user-declared-only
-stance as classification.
 
 !!! note "`limacharlie sync` does not cover these hives"
     The `cloudsec_*` hives are outside the set `limacharlie sync` walks, so a

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -73,7 +73,7 @@ Shared behaviors:
 | `GET /overview` | Composed risk overview in one round-trip: `score`, `severity_counts`, `open_count`, `reachable_open`, `reachable_criticals`, `top_paths`, `coverage`, `trend`, `recent_changes`, the per-tenant `usage` metering block, and `top_issue` when there is one. Also carries `estate_shape` (`cloud` \| `identity` \| `hybrid`) and, for an identity or hybrid estate, an `identity_summary` posture headline — both best-effort and omitted on a read failure. Param: `trend_days` (default 30). |
 | `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50, clamped to 1000). |
 | `GET /risk-trend` | `{trend}` — score history, oldest first. Param: `trend_days`. |
-| `GET /scan-status` | Collection run state. With `provider` set: `{status}` for that provider — ids are lowercase and the lookup is case-sensitive, so an unknown or miscased id reads as never-scanned. With `provider` omitted: `{coverage, workload, status}` — per-provider run state for every connected cloud provider, the agentless workload-scan state separately (it is a different pass, not cloud-inventory coverage), and `status` as the first cloud provider's state for backward compatibility. There is no default provider. |
+| `GET /scan-status` | Collection run state. With `provider` set: `{status}` for that provider — ids are lowercase and the lookup is case-sensitive, so an unknown or miscased id reads as never-scanned. With `provider` omitted: `{coverage, workload, status}` — per-provider run state for every connected cloud provider, `status` as the first cloud provider's state for backward compatibility, and a reserved `workload` section. There is no default provider. |
 | `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (server cap 500/request; keep URLs under ~8KB — the CLI/SDK chunks automatically). |
 | `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (same caps and chunking). |
 | `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, `kind[]`, `source[]` (which observing tool reported the asset), the four repeatable device-posture filters `posture_encryption`, `posture_screen_lock`, `posture_compromised`, `posture_managed`, `sort` (`urn` default, or `last_seen`), paging. Pass an **empty** value to a posture filter to select the assets no source reported that fact for — unreported is not the same as compliant. Also carries `served_from` / `data_as_of` when the page came from the materialized merged view. |
@@ -150,7 +150,7 @@ carry the same shape) — key fields:
 | Field | Meaning |
 |---|---|
 | `finding_id`, `fingerprint` | Stable identity of the condition (`fnd_` + fingerprint prefix). |
-| `rule_id`, `finding_class`, `classification` | What detected it and its class. The canonical enum, in picker order (paths → identity → posture → workload scan → coverage), is `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`. Of those, `malware`, `secret`, and `scan_finding` come from the agentless snapshot scanner. `workload_coverage_gap`, the cloud-workload flavor of a coverage gap, can additionally appear on a finding even though it is not one of the 11 picker values. |
+| `rule_id`, `finding_class`, `classification` | What detected it and its class. The canonical enum is `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture` (`malware`, `secret`, and `scan_finding` are reserved for capabilities not yet enabled). `workload_coverage_gap`, the cloud-workload flavor of a coverage gap, can additionally appear on a finding even though it is not one of the 11 picker values. |
 | `severity`, `lc_risk`, `risk_breakdown` | `CRITICAL`–`INFO`, the 0–1000 composite, and its explanation. |
 | `title`, `resource_urn`, `resource_name`, `resource_type`, `account`, `region` | The affected resource. |
 | `related_urns`, `path`, `path_kind` | Related resources; the hop list for path findings and the kind of path it represents. |
@@ -223,9 +223,8 @@ emits `cloud_query.match` once per new anchor entering its result set and
 findings — plus `cloud_query.overbudget` once on each transition into the
 over-budget state (rather than a match flood).
 
-**Operational:** `cloudsec.sweep_failed` and `cloudsec.scan_failed` report a
-collection or scan pass that failed. Off by default; opt in with the emission
-policy's `ops_events`.
+**Operational:** `cloudsec.sweep_failed` reports a collection pass that
+failed. Off by default; opt in with the emission policy's `ops_events`.
 
 Every payload also carries `event_type` and `oid`.
 

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -22,9 +22,17 @@ Authentication is the standard `Authorization: Bearer <JWT>` header.
 
 Shared behaviors:
 
-- **Repeatable filters** (`severity`, `finding_class`, `status`, `account`,
-  `sid`, `urn`) are passed as repeated query keys: `?severity=CRITICAL&severity=HIGH`.
-  OR within a key, AND across keys. At most 100 values per filter key.
+- **Repeatable filters** (`severity`, `finding_class`, `status`, `account`, and
+  the identity / Data Security / CAASM selectors listed per route below) are
+  passed as repeated query keys: `?severity=CRITICAL&severity=HIGH`. OR within a
+  key, AND across keys. A read filter takes at most 100 values per key and
+  quietly drops the rest; a *write* body over its own cap is rejected outright
+  rather than truncated, so a partial write is never silently reported as a
+  whole one. The `sid` and `urn` keys on the `/resolve/*` routes are not filters
+  but bulk lookup keys, with their own 500-per-request cap.
+- **Boolean selectors are tri-state**: an absent parameter means "not
+  filtered", which is *not* the same as passing `false`. Omit it for no
+  constraint; pass `false` to pin the negative case.
 - **Keyset pagination**: pages carry `next_cursor`; pass it back as
   `?cursor=`. `limit` is clamped to 1000.
 - **CSV export**: exactly four routes accept `?format=csv` to stream the
@@ -40,40 +48,45 @@ Shared behaviors:
 | `GET /findings` | `{findings, next_cursor}` — the risk-ranked worklist. Filters: `severity[]`, `finding_class[]`, `status[]`, `account[]`, `reachable`, `kev`, `q`, `sort`, `order`, `cursor`, `limit`. |
 | `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors. |
 | `GET /findings/classes` | `{classes}` — the canonical `finding_class` enum (the 11 values), for building selectors. |
+| `GET /findings/causes` | `{causes, distinct}` — findings grouped by their **cause**, the mutable object (a firewall rule, a role binding) whose single edit resolves all of them. Takes the full findings selectors, plus `cause` for the exact count of one cause and `limit` (default 20, max 200) for the top causes; `distinct` is the total number of causes matching the filter. |
 | `GET /findings/{finding_id}` | `{finding}` — one finding in full. |
 | `GET /attack-paths` | `{paths}` — marquee toxic-combination paths. Filters: `severity[]`, `account[]`, `status[]`, `q`. |
 | `GET /chokepoints` | `{chokepoints, total_paths}` — shared attack-path hops ranked by paths broken, including the principal-exposure metrics. |
-| `GET /ciem/public-access` | `{access}` — public/external access to sensitive resources. |
+| `GET /ciem/public-access` | `{access, identity_kpis, principals}` — public/external access to sensitive resources, the identity-posture headline counts, and the risk-ranked per-principal effective-access rollup (top 500). The two extra blocks are best-effort: a read failure omits the key rather than failing the call. |
 | `GET /ciem/facets` | `{facets}` — identity facet counts. |
+| `GET /ciem/identities` | `{principals, next_cursor}` — the same per-principal effective-access rows `public-access` carries, but server-filtered and keyset-paginated instead of a top-N. Takes the same selectors as `/ciem/facets`, so the rail's counts always describe the population in the list. Ranked by risk score by default, so a walk that spans a projector rebuild can move a row across the cursor — use it for browsing, and `/inventory` with `type=Identity` and the default `urn` sort for an exact export. |
 | `GET /ciem/identity?urn=` | `{identity}` — the Identity 360 single-identity rollup for one principal URN: its grants, reachable sensitive resources, access levels, and escalation paths. |
-| `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `provider`, `account`, `region`, `q`, paging. |
+| `GET /inventory` | `{resources, next_cursor}`. Filters: `type`, `provider`, `account`, `region`, `q`, `account_unscoped` (drop the account scoping and walk the whole estate), `sort` (`urn`, the default and the safe order for a full walk or export; `risk` with `type=Identity`; `last_seen` with `type=ThirdPartyAsset`), paging. With `type=Identity`, `provider`/`source`, `account`, and `region` become repeatable and the identity cross-filter applies: `kind`, `criticality`, `risk_band`, `mfa` (`on`/`off`/`unknown`), and the tri-state `admin`, `external`, `public`, `disabled`, `crown_jewel`, `can_escalate`, `dormant_90d`, `with_sensitive`. Pages served from the materialized view also carry `served_from` and `data_as_of` (the snapshot's build time) so a client can render "as of" instead of implying live. |
 | `GET /inventory/facets` | Inventory facet counts by type/account/region. |
 | `GET /data-security/facets` | `{facets}` — DSPM data-store rollup. |
+| `GET /data-security/stores` | `{stores, next_cursor}` — the filtered, paginated data-store list, under the same selectors as `data-security/facets`: `provider`, `account`, `region`, `store_kind`, `tier`, and the tri-state `sensitivity` / `exposure`. Served from the materialized graph, so the list stays exact at any estate size. |
 | `GET /resource?urn=` | `{resource}` — the canonical record for any URN (null when unknown). |
 | `GET /graph/neighbors?urn=` | `{graph: {nodes, edges}}` — 1-hop expansion; `limit` default 200, cap 500; `truncated` flag. |
-| `GET /topology` | `{scopes, edges, available}` — the server-side estate aggregate behind the Topology diagram (scope nodes + the edges between them). The `available` flag is `false` when the estate is too large to aggregate inline. |
-| `GET /policy/vocabulary` | `{vocabulary}` — the classification-policy vocabulary: the per-surface matcher-capability table, closed vocabularies (resource types, content classes), and the org's in-use value histograms. |
-| `GET /providers/manifest?type=` | `{manifest}` — the per-provider coverage manifest ("what you get"): the resource kinds, edges, and checks a given `provider_type` produces. |
+| `GET /topology` | `{scopes, edges, available, generated_at}` — the server-side estate aggregate behind the Topology diagram (scope nodes + the edges between them), with the unix time the aggregate was built. `available` is `false` only when the aggregate has not been materialized for this organization yet (the client should fall back to its own walk); a genuinely empty estate answers `available: true` with empty `scopes` and `edges`. |
+| `GET /policy/vocabulary` | The classification-policy vocabulary, as a flat object: `surfaces` (the per-surface matcher-capability table), `resource_types` (`data_stores`, `compute`, `identities`), `content_classes`, `providers`, `tiers`, `suggested_classes`, and `in_use` — the org's in-use value histograms. |
+| `GET /providers/manifest?type=` | `{manifest}` — the per-provider coverage manifest ("what you get"): the resource kinds, edges, and checks a given `provider_type` produces. Omit `type` to get `{manifests}`, the manifest for every supported provider. |
 | `GET /queries` | `{queries}` — the named query pack (name, title, description, query). |
-| `POST /query` | `{rows}` — run a graph query. Body: exactly one of `named` / `text` / `query` (DSL object), optional `project`. |
+| `POST /query` | `{rows}` — run a graph query. Body: exactly one of `named` / `text` / `query` (DSL object), optional `project`. With `project: "graph"` the response also carries `graph: {nodes, edges}`, the subgraph induced over the matched URNs — or `truncated: true` in its place when the result spans more than 500 nodes (the rows are complete either way; only the drawing is capped). A shortest-path query answers `{paths: [{anchor, target, hops, path}]}` instead of `rows`, and its `project: "graph"` draws the whole kill chain, adding `graph_partial` when only some paths are drawn and `graph_unavailable` when none can be. |
 | `GET /compliance` | `{report}` — per-control assessment. Params: `framework` (default `cis-gcp`) or `assignment` (overrides `framework`). |
 | `GET /compliance/frameworks` | `{frameworks}` — id, name, version, control counts. |
 | `GET /compliance/assignments` | `{assignments}` — scoped assignments with per-assignment scores. |
-| `GET /overview` | Composed risk overview (`score`, distributions, top paths, coverage, trend, changes, and the per-tenant `usage` metering block). Param: `trend_days` (default 30). |
-| `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50). |
+| `GET /overview` | Composed risk overview in one round-trip: `score`, `severity_counts`, `open_count`, `reachable_open`, `reachable_criticals`, `top_paths`, `coverage`, `trend`, `recent_changes`, the per-tenant `usage` metering block, and `top_issue` when there is one. Also carries `estate_shape` (`cloud` \| `identity` \| `hybrid`) and, for an identity or hybrid estate, an `identity_summary` posture headline — both best-effort and omitted on a read failure. Param: `trend_days` (default 30). |
+| `GET /changes` | `{changes}` — created/closed feed, newest first. Param: `limit` (default 50, clamped to 1000). |
 | `GET /risk-trend` | `{trend}` — score history, oldest first. Param: `trend_days`. |
-| `GET /scan-status` | `{status}` — collection run state. Param: `provider` (default `gcp`; ids are lowercase — the lookup is case-sensitive and an unknown/miscased id reads as never-scanned). |
+| `GET /scan-status` | Collection run state. With `provider` set: `{status}` for that provider — ids are lowercase and the lookup is case-sensitive, so an unknown or miscased id reads as never-scanned. With `provider` omitted: `{coverage, workload, status}` — per-provider run state for every connected cloud provider, the agentless workload-scan state separately (it is a different pass, not cloud-inventory coverage), and `status` as the first cloud provider's state for backward compatibility. There is no default provider. |
 | `GET /resolve/sensors?sid=…` | `{resolved, unresolved}` — sensor → cloud asset, bulk via repeated `sid` (server cap 500/request; keep URLs under ~8KB — the CLI/SDK chunks automatically). |
 | `GET /resolve/assets?urn=…` | `{resolved, unresolved}` — cloud asset → sensors, bulk via repeated `urn` (same caps and chunking). |
-| `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, paging. |
+| `GET /caasm/assets` | `{resources, next_cursor}` — the merged third-party asset inventory. Params: `q`, `kind[]`, `source[]` (which observing tool reported the asset), the four repeatable device-posture filters `posture_encryption`, `posture_screen_lock`, `posture_compromised`, `posture_managed`, `sort` (`urn` default, or `last_seen`), paging. Pass an **empty** value to a posture filter to select the assets no source reported that fact for — unreported is not the same as compliant. Also carries `served_from` / `data_as_of` when the page came from the materialized merged view. |
 | `GET /caasm/coverage` | `{findings, next_cursor}` — coverage-gap findings. Params: `status[]`, `severity[]`, `q`, `sort`, `order`, paging. |
 | `GET /caasm/policy` | Resource-list shape: zero rows (no policy) or one row whose `props` is the policy. |
+| `GET /free-tier` | `{is_free_tier, sensor_quota, max_providers, enabled_providers}` — the org's free-tier standing and the limits that apply, for surfacing an upgrade prompt before a limit is hit. Descriptive only: it is not a gate, the collector enforces the limits, and reads keep working after a trial expires. |
 
 !!! note "`ciem/*` and `providers/*` families"
-    `ciem/*` now has three members — `public-access`, `facets`, and
-    `identity`. `providers/*` has two — `test` (`POST`, below) and `manifest`
-    (`GET`, above). Creating, editing, and deleting provider *records* is not
-    a `/cloudsec` route: it goes through the `cloudsec_provider` Hive.
+    `ciem/*` has four members — `public-access`, `facets`, `identities`, and
+    `identity` (singular: one principal). `providers/*` has two — `test`
+    (`POST`, below) and `manifest` (`GET`, above). Creating, editing, and
+    deleting provider *records* is not a `/cloudsec` route: it goes through the
+    `cloudsec_provider` Hive.
 
 ## Fleet (multi-org)
 
@@ -81,7 +94,7 @@ One route sits outside the `{oid}` path — the MSSP cross-tenant board:
 
 | Route | Returns |
 |---|---|
-| `GET /cloudsec/fleet/overview` | `{orgs, rollups, total_orgs, skipped, next_cursor}` — risk posture rolled up across many organizations, with the tenants that could not be included counted in `skipped`. Params: `oids[]` (repeat to select tenants), `group` (a saved fleet group), `trend_days`, `cursor`, `limit`. Requires `cloudsec.get` on each tenant in scope. |
+| `GET /cloudsec/fleet/overview` | `{orgs, rollups, total_orgs, skipped, next_cursor}` — risk posture rolled up across many organizations. `skipped` splits the tenants that could not be included into `not_enabled` (no `ext-cloud-security` subscription) and `lookup_failed` (a transient check failure, so one bad tenant never fails the whole call). Params: `oids[]` (repeat to select tenants), `group` (a saved fleet group), `trend_days`, `cursor`, `limit` (default 25, cap 100). Requires `cloudsec.get` on each tenant in scope — organizations you lack it on are simply left out, not reported as skipped. A single call may resolve to at most 500 organizations (past that, narrow with explicit `oids` or a smaller group), and the route carries its own quota of 120 calls per hour. |
 
 ## Writes
 
@@ -90,14 +103,14 @@ All writes are `POST` with a JSON body and require `cloudsec.set`.
 | Route | Body | Returns |
 |---|---|---|
 | `/findings/{finding_id}/status` | `{resolution: {kind, reason, expires_at}}` — `kind` is `mitigated` \| `accepted` \| `false_positive`, or `open` to clear the disposition and reopen. `expires_at` is unix seconds (meaningful with `accepted`). | `{ok}` |
-| `/findings/bulk/status` | `{finding_ids: [...], resolution: {...}}` — one resolution applied to many findings. Unlike the single-finding route, `kind` must be `mitigated` \| `accepted` \| `false_positive` — the bulk route does **not** accept `open` (reopen findings one at a time). | `{updated}` |
+| `/findings/bulk/status` | `{finding_ids: [...], resolution: {...}}` — one resolution applied to many findings. Unlike the single-finding route, `kind` must be `mitigated` \| `accepted` \| `false_positive` — the bulk route does **not** accept `open` (reopen findings one at a time). At most 500 ids per call: an over-cap batch is **rejected**, not truncated, so split larger sets yourself rather than have a prefix dispositioned silently. | `{ok, updated}` |
 | `/findings/{finding_id}/owner` | `{owner}` — empty string clears. | `{ok}` |
 | `/findings/{finding_id}/ticket` | `{ticket}` — empty string clears. | `{ok}` |
 | `/chokepoints/dismiss` | `{urn, reason?}` | `{ok}` |
 | `/chokepoints/restore` | `{urn}` | `{ok}` |
 | `/caasm/policy` | `{policy: {expect: [{label, capability, kinds}]}}` — validated before storing. | `{ok}` |
-| `/caasm/ingest` | `{source, records?: [...], record?: {...}, policy?: {...}}` — `source` required; a single `record` is treated as a one-element batch. Body capped at 1 MiB; ingestion is idempotent. | `{result: {received, normalized, skipped, assets, created, updated, deleted}}` |
-| `/providers/test` | `{provider: <cloudsec_provider record>}` — credential inline (ephemeral, never stored) or a `hive://secret/<name>` reference. | `{supported, report: {provider, ok, checks: [{id, name, required, ok, detail}]}}` |
+| `/caasm/ingest` | `{source, records?: [...], record?: {...}, policy?: {...}}` — `source` required; a single `record` is treated as a one-element batch. Body capped at 1 MiB; ingestion is idempotent. | `{result: {received, normalized, skipped, assets, created, updated, deleted, policy_set}}` |
+| `/providers/test` | `{provider: <cloudsec_provider record>}` — credential inline (ephemeral, never stored) or a `hive://secret/<name>` reference. | `{supported, report: {provider, ok, checks: [{id, name, required, ok, detail}]}}`. A provider type with no preflight implemented answers `{supported: false, report: null}` rather than an error — treat it as "cannot verify", not "credential bad". |
 
 Example — disposition a finding:
 
@@ -117,9 +130,13 @@ and `limacharlie cloudsec policy vocabulary`.
 
 | Route | Body | Returns |
 |---|---|---|
-| `POST /simulate/resources` | `{rules, target, resource_types?, sample_limit?}` — `rules` is a list of matcher rules, `target` scopes the walked surface (`data_store`, `compute`, `identity`, or `any` — the default). | `{evaluated, matched, indeterminate, truncated, sample}` — preview a classification / coverage / exclusion matcher against stored inventory. |
-| `POST /simulate/findings` | `{match, sample_limit?}` — a suppression matcher. | `{evaluated, matched, indeterminate, truncated, sample}` — preview it against currently-open findings. |
-| `POST /policy/suggest` | `{dimension, q, target, limit?}` — `dimension` is `name` or `account`. | `{suggestions}` — live matcher-value autocomplete drawn from the tenant estate. |
+| `POST /simulate/resources` | `{rules, target, resource_types?, sample_limit?}` — `rules` is a list of matcher rules, `target` scopes the walked surface (`data_store`, `compute`, `identity`, or `any` — the default). `sample_limit` defaults to 25, cap 100. | `{evaluated, matched, indeterminate, truncated, sample, indeterminate_sample}` — preview a classification / coverage / exclusion matcher against stored inventory, with a bounded sample per bucket. |
+| `POST /simulate/findings` | `{match, sample_limit?}` — a suppression matcher. An empty `match` is allowed: it matches everything up to the default severity ceiling, and showing that blast radius is the point of the preview. | `{evaluated, matched, partial, indeterminate, truncated, sample, partial_sample, indeterminate_sample}` — preview it against currently-open findings. `partial` counts vulnerability rollups the rule would *shrink* (some affected resources accepted, the finding stays open); `indeterminate` counts rollups whose bounded target sample cannot decide. |
+| `POST /policy/suggest` | `{dimension, q, target, limit?}` — `dimension` is `name` or `account`; `q` is required and at most 256 bytes (longer is a `400`); `target` takes the same surface enum as `simulate/resources`; `limit` defaults to 20, cap 50. | `{values: [{value, count}], truncated, evaluated}` — live matcher-value autocomplete drawn from the tenant estate. |
+
+Both simulations are bounded walks: they stop at 50,000 rows or 15 seconds and
+report `truncated: true` with the counts so far, so a preview on a large estate
+never turns into an unbounded scan.
 
 Pair these with `GET /policy/vocabulary` (the closed vocabularies and
 per-surface capability table) and `GET /findings/classes` (the
@@ -133,23 +150,31 @@ carry the same shape) — key fields:
 | Field | Meaning |
 |---|---|
 | `finding_id`, `fingerprint` | Stable identity of the condition (`fnd_` + fingerprint prefix). |
-| `rule_id`, `finding_class`, `classification` | What detected it and its class — one of: `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `coverage_gap`, `device_posture`. |
+| `rule_id`, `finding_class`, `classification` | What detected it and its class. The canonical enum, in picker order (paths → identity → posture → workload scan → coverage), is `toxic_combination`, `public_exposure`, `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`, `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`. Of those, `malware`, `secret`, and `scan_finding` come from the agentless snapshot scanner. `workload_coverage_gap`, the cloud-workload flavor of a coverage gap, can additionally appear on a finding even though it is not one of the 11 picker values. |
 | `severity`, `lc_risk`, `risk_breakdown` | `CRITICAL`–`INFO`, the 0–1000 composite, and its explanation. |
 | `title`, `resource_urn`, `resource_name`, `resource_type`, `account`, `region` | The affected resource. |
 | `related_urns`, `path`, `path_kind` | Related resources; the hop list for path findings and the kind of path it represents. |
-| `source_scope`, `target_scope` | For attack-path / toxic findings, the durable workload group at each end (GKE/EKS/AKS node pool, MIG, ASG, VMSS) — `group_urn`, `group_kind`, `member_count`, `affected_count`, `members` — so the finding headlines the shared-fix group, not a churny ephemeral node. |
+| `source_scope`, `target_scope` | For attack-path / toxic findings, the durable workload group at each end (GKE/EKS/AKS node pool, MIG, ASG, VMSS) — `group_urn`, `group_kind`, `group_name` (the human label), `member_count` (the group's full size), `affected_count` (the members actually on paths), and `members`, a sample of those affected members bounded at 20 — so the finding headlines the shared-fix group, not a churny ephemeral node. |
+| `cause` | The mutable object that actually gets edited to fix the finding — `kind`, `urn`, `name`. The shared-fix grouping key behind `GET /findings/causes`. |
 | `reachable`, `in_kev`, `vulns`, `epss`, `epss_percentile` | Exposure and exploit intelligence; `vulns` entries carry `cve`, `package`, `package_version`, `fix_version`, `cvss_score`. |
+| `pivot_targets`, `target_count` | For rollup findings, a bounded sample (20) of the affected targets and the true total, so a rollup states its own blast radius without carrying every row. |
 | `evidence`, `remediation` | The offending configuration and the fix. |
-| `ciem_access` | For identity findings: role, identity kind, public/external/privileged flags, grant path, and the classified data-plane **access level** / capability (`data_admin` > `data_write` > `data_read` > `metadata` > `none`) the grant confers. |
+| `ciem_access` | For identity findings: role, identity kind, public/external/privileged flags, grant path, and the classified data-plane **access level** / capability (`data_admin` > `data_write` > `data_read` > `metadata` > `none`) the grant confers. A sixth value, `unknown`, is the unverified escape hatch: it ranks below `none` and deliberately fails every "at least" threshold, so handle it explicitly rather than by ordinal comparison. It still counts as potential data access for the "reaches sensitive data" gate, flagged `unverified` instead of silently dropped. |
+| `ciem_escalation` | For privilege-escalation findings, the escalation detail: `from_urn`, `admin_urn`, and the ordered identity `path`. |
+| `business_criticality`, `environment`, `tags` | Business context carried from the resource, for routing and prioritization. |
 | `runtime_sids` | Sensors resolved onto the affected asset. |
 | `status`, `resolution`, `resolved_by`, `resolution_expires_at`, `owner`, `ticket` | The triage overlay. |
 | `first_seen`, `last_seen` | Lifecycle timestamps. |
 
 ## Events
 
-With finding/resource emission enabled (see the
-[`emission` policy](configuration.md#emission-the-event-feed)), the
-platform emits into the organization's event stream.
+The platform emits lifecycle events into the organization's event stream. With
+no [`emission` policy](configuration.md#emission-the-event-feed) record, finding
+events are **on** and resource + operational events are **off** — an org gets
+the finding feed without configuring anything, and opts in to the noisier
+families. The policy also takes a `severity_floor` that drops finding events
+below a given severity (the created/updated/closed feed only — the first-sync
+summary still counts the whole estate).
 
 **Detection-truth lifecycle** (from the projector):
 
@@ -160,13 +185,29 @@ platform emits into the organization's event stream.
   changed, old_severity, new_severity, finding}`.
 - `cloud_finding.closed` — `{finding_id, fingerprint, finding_class}`.
 - `cloud_finding.still_open` — re-asserted at most once a day for open
-  findings with a linked ticket (the case-sync verb).
+  findings with a linked ticket (the case-sync verb); the payload carries the
+  `ticket` alongside the identity fields.
 
-**Operator disposition** (from the triage write handlers) — flat payload
-`{finding_id, fingerprint, finding_class, actor, note?}`:
+**Disposition** — flat payload
+`{finding_id, fingerprint, finding_class, actor, note?}`, plus the finding's
+post-disposition `status` and `resolution` on the operator-written ones:
 
 - `cloud_finding.resolved`, `cloud_finding.dismissed`,
   `cloud_finding.reopened`, `cloud_finding.assigned`.
+
+Two things emit these verbs, and `actor` is what tells them apart: an operator
+triage write carries the user, while a
+[`suppression` policy](configuration.md#suppression-finding-disposition-policy)
+applying automatically carries `policy:<rule name>` (and plain `policy` when a
+rule stops matching and releases its findings). A broad first application is
+capped per pass, so a very large policy rollout summarizes rather than emitting
+one event per finding.
+
+The verb alone is deliberately coarse: **both** a `mitigated` and an `accepted`
+disposition emit `cloud_finding.resolved`, because minting a new verb would
+break consumers filtering on a known set. Branch on `resolution` — not on
+`event_type` — to tell a risk somebody signed off on carrying from one that was
+actually fixed.
 
 **Summary & inventory:**
 
@@ -175,6 +216,16 @@ platform emits into the organization's event stream.
   `{total, by_class, by_severity}`.
 - `cloud_resource.created`, `cloud_resource.updated`,
   `cloud_resource.deleted` — inventory change events (off by default).
+
+**Scheduled queries:** a `cloudsec_query` record with `schedule.scheduled` set
+emits `cloud_query.match` once per new anchor entering its result set and
+`cloud_query.resolved` once per anchor leaving — the same lifecycle symmetry as
+findings — plus `cloud_query.overbudget` once on each transition into the
+over-budget state (rather than a match flood).
+
+**Operational:** `cloudsec.sweep_failed` and `cloudsec.scan_failed` report a
+collection or scan pass that failed. Off by default; opt in with the emission
+policy's `ops_events`.
 
 Every payload also carries `event_type` and `oid`.
 

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -254,9 +254,9 @@ operator/policy disposition).
       feed: a saved graph query becomes a detection source, emitting per anchor
       entering and leaving its match set (and one `.overbudget` instead of a
       flood when the match set blows its cap).
-    - `cloudsec.sweep_failed` / `cloudsec.scan_failed` — operational events for
-      alerting on collection and scanner health, gated by the `emission`
-      policy's `ops_events` flag (**off by default**).
+    - `cloudsec.sweep_failed` — the operational event for alerting on
+      collection health, gated by the `emission` policy's `ops_events` flag
+      (**off by default**).
 
 !!! warning "Drive automation from events, read state from the API"
     Event emission is best-effort and at-most-once: events queue in a bounded

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -119,10 +119,8 @@ shape.
 ## CSV export
 
 Add `?format=csv` to `findings`, `inventory`, `compliance`, or `query` to
-stream the result as a CSV attachment instead of JSON. The server walks the
-full filtered set itself (filter parameters apply; paging parameters are
-ignored), capped at 100,000 rows with a trailing `#`-comment row as the
-truncation notice:
+stream the result as a CSV attachment instead of JSON. Filter parameters apply;
+paging parameters are ignored, because the export owns its own walk:
 
 ```bash
 curl -H "Authorization: Bearer $JWT" \
@@ -130,8 +128,15 @@ curl -H "Authorization: Bearer $JWT" \
   -o findings.csv
 ```
 
+**`findings` and `inventory`** are multi-page sets, so the server pages through
+the whole filtered set for you, capped at 100,000 rows with a trailing
+`#`-comment row as the truncation notice. **`compliance` and `query`** are
+single-shot: one evaluation or one query execution produces the whole result, so
+there is nothing to walk and the CSV is exactly that result in row form.
+
 The compliance CSV carries one row per control including the proving finding
-ids — the auditor-facing evidence export.
+ids — the auditor-facing evidence export, with a higher per-control evidence cap
+than the JSON report (see [Compliance](compliance.md#auditor-export)).
 
 !!! note "CLI `--output csv` is per-page"
     The CLI's global `--output csv` formats the rows the command returned —
@@ -149,6 +154,13 @@ stream (see the [`emission` policy](configuration.md#emission-the-event-feed)):
 `cloud_finding.still_open` (re-asserted at most once per day for open
 findings with a linked ticket). D&R rules match these like any event; the
 Cases extension actions close the loop.
+
+!!! tip "You do not have to paste these by hand"
+    All three rules below ship as an installable recipe: the Cases toggle in
+    Cloud Security's settings writes them into your general D&R rule set for
+    you, byte-for-byte identical to what follows. Use the toggle for the
+    standard loop, and the YAML here when you want to review what it installs or
+    fork it into something org-specific.
 
 **Auto-case on high/critical findings** (async, grouped, storm-safe — one
 case per rule category per window, and first-sync floods are summarized
@@ -215,15 +227,20 @@ operator/policy disposition).
     The `created` / `closed` / `still_open` verbs above are the Cases loop,
     but D&R rules can key off more of the finding lifecycle:
 
-    - `cloud_finding.updated` — an **open** finding's content materially
-      changed (a severity flip or a change to its vuln set) without re-firing
-      on every sweep. Payload carries `changed[]` (the fields that moved),
+    - `cloud_finding.updated` — an **open** finding changed materially, on a
+      deliberately short list so it does not re-fire every sweep: the severity
+      moved (either direction), the finding became reachable, or one of its CVEs
+      entered KEV. Payload carries `changed[]` (the fields that moved),
       `old_severity`, `new_severity`, and the full `finding` — the hook for
       reacting to escalation (e.g. re-notify only when a finding crosses into
       CRITICAL).
     - `cloud_finding.resolved` / `.dismissed` / `.reopened` / `.assigned` —
-      the operator-disposition verbs, flat payload with an `actor` field, for
-      auditing human triage decisions (who accepted/muted/reopened what).
+      the disposition verbs, flat payload carrying `actor`, `status`, and
+      `resolution`, for auditing triage decisions. Note that **`mitigated` and
+      `accepted` both arrive as `.resolved`** — branch on `resolution`, not on
+      the verb, to tell "fixed" from "accepted". These are not only human
+      actions: a `suppression` policy emits the same verbs with `actor` set to
+      `policy:<rule-name>`.
     - `cloudsec.sync_completed` — the first-sync summary
       (`{total, by_class, by_severity}`) emitted once instead of a
       per-finding `created` flood, so onboarding a large estate is one event,
@@ -232,6 +249,22 @@ operator/policy disposition).
       change events, gated by the [`emission`
       policy](configuration.md#emission-the-event-feed)'s `resource_events`
       flag (**off by default**).
+    - `cloud_query.match` / `.resolved` / `.overbudget` — the
+      [scheduled-query](configuration.md#scheduled-queries-any-saved-query-as-a-detection-source)
+      feed: a saved graph query becomes a detection source, emitting per anchor
+      entering and leaving its match set (and one `.overbudget` instead of a
+      flood when the match set blows its cap).
+    - `cloudsec.sweep_failed` / `cloudsec.scan_failed` — operational events for
+      alerting on collection and scanner health, gated by the `emission`
+      policy's `ops_events` flag (**off by default**).
+
+!!! warning "Drive automation from events, read state from the API"
+    Event emission is best-effort and at-most-once: events queue in a bounded
+    buffer and the oldest batch is dropped under sustained pressure rather than
+    stalling the sweep. That is the right trade for triggering work, but it means
+    the feed is not a replayable ledger. Whenever correctness matters — a
+    reconciliation job, a nightly audit, "is this really still open?" — read the
+    findings API rather than replaying events.
 
 **Non-Cases shops:** route the same `cloud_finding.*` events to
 Jira/ServiceNow via an Output and key your tickets on `fingerprint` the same

--- a/docs/cloud-security/caasm.md
+++ b/docs/cloud-security/caasm.md
@@ -9,29 +9,56 @@ Your tools already know what you own: the EDR sees devices, the identity
 provider sees users and their devices, MDM and scanners see more. CAASM
 merges those third-party views into one entity-resolved asset inventory and
 evaluates your *expected-coverage* policy over it — surfacing the assets a
-required tool does **not** see.
+required tool does **not** see. The same policy also covers your cloud
+workloads, so "which of my VMs has no agent on it" is answered the same way.
 
 ## The merged asset inventory
 
-Records from connected sources are normalized and entity-resolved
-(**merge-on-read**) into one canonical asset per real device. Resolution is a
-union-find that joins records sharing a strong identifier, in priority order —
-serial, then MAC address, then cloud id, then hostname, then email — so the
-same laptop seen by the EDR, the IdP, and MDM collapses to a single row with
-per-source provenance retained:
+Records from connected sources are normalized and entity-resolved into one
+canonical asset per real device or person. Resolution is deterministic — a
+union-find over a ladder of match keys, strongest first, with explicit ambiguity
+handling instead of fuzzy scoring:
+
+| Match key | Strength |
+|---|---|
+| `serial` | Strong — always links |
+| `mac` | Strong — always links |
+| `cloud_id` | Strong — always links |
+| `hostname` | Weak — links only under the guards below |
+| `email` | Strong for identities; the owner key on devices |
+| `source_id` | Last resort — the asset stands alone under the reporting tool's own id |
+
+Hostname is the key that over-merges — two laptops both called
+`DESKTOP-1234` — so it links only under guards: a hostname one tool reports for
+two distinct assets never links anything, and two records that *conflict* on a
+stronger key (different non-empty serials or cloud ids) never merge on hostname
+alone. The merged asset's identity derives from its strongest key, so which
+source reported first never changes the outcome: same records in, in any order,
+same assets out. The same laptop seen by the EDR, the IdP, and MDM collapses to a
+single row with per-source provenance retained:
 
 ```bash
 limacharlie cloudsec caasm assets -q laptop --limit 50
 ```
 
+The merge is normally served from a **materialized merged view**, kept current
+as records arrive; when that view is not ready for an organization the same
+resolution runs **on read**, so the answer is the same either way.
+
 Supported sources: `sentinelone`, `crowdstrike`, `defender`, `okta`,
 `entraid`, `ms_graph`, `wiz`, plus two **native** sources — `limacharlie`
-(your own LimaCharlie sensors, capability `edr`) and `google_workspace`
+(your own LimaCharlie endpoint sensors, capability `edr`) and `google_workspace`
 (managed devices from the Workspace directory, capability `mdm`). The native
-sources feed automatically once the corresponding provider or sensor telemetry
-is connected — no ingest needed. Other telemetry the organization already
-pulls through USP adapters also feeds the inventory automatically; anything
-else can be pushed through the ingest endpoint below.
+sources feed automatically once the corresponding provider is connected — no
+ingest needed. On the LimaCharlie side that means the provider's own sweep of
+your sensors, and only real endpoints become assets: USP adapters and the
+cloud/SaaS log-ingestion platforms are inventory noise here and are skipped.
+
+Telemetry the organization pulls through USP adapters does **not** flow into
+CAASM on its own. To feed a source that has no first-class collector, push its
+records in — either as a batch, or continuously with a D&R feeder rule. Both are
+in [Pushing records in](#pushing-records-in) below, and both are a deliberate
+choice: nothing is auto-provisioned.
 
 ### Managed devices and device posture
 
@@ -45,13 +72,24 @@ asset, CAASM raises a `device_posture` finding:
 | `encryption` off | Medium |
 | `screen_lock` off | Low |
 | `developer_mode` on | Low |
-| `auto_update` off / OS past end-of-life | Medium |
+| Past its auto-update expiration (no longer receives OS updates) | Medium |
 
 Posture checks fire only on a positive assertion — an asset that simply never
-reported a field is not flagged. A device owned by a privileged identity
-raises the finding rather than swallowing it, and `owns-device` edges
-(identity → device) join owners to their devices in the
-[security graph](graph.md), so "who owns this at-risk laptop" is one hop away.
+reported a field is not flagged.
+
+When a failing device's owner is a **privileged** identity — one holding admin
+roles in any connected directory — that raises an *additional* HIGH
+`toxic_combination` finding, anchored on the identity rather than the device, and
+carrying both the admin roles and the failing checks as evidence. The
+device-posture finding still stands on its own; the join adds the "compromise of
+this laptop is a direct path to privileged directory access" reading rather than
+swallowing either half.
+
+The `owns_device` edge (identity → device) is what joins owners to their devices
+in the [security graph](graph.md), so "who owns this at-risk laptop" is one hop
+away. It is emitted only when the device's owner email resolves to an identity
+already in the inventory — an owner outside your directory (a contractor's
+personal account, a typo'd device annotation) never invents an identity node.
 
 ## Declare expected coverage
 
@@ -82,26 +120,59 @@ The policy shape is `{expect: [ ... ]}`, and each expectation rule takes:
 
 - `label` **(required)** — names the expectation; it anchors the resulting
   finding.
-- `kinds` — asset kinds the rule applies to; defaults to `["device"]`.
+- `kinds` — what the rule applies to; defaults to `["device"]`. See
+  [the three kinds](#the-three-kinds) below.
 - `capability` **or** `sources` **(one required)** — either a required
   capability (`edr`, `idp`, `mdm`, `vuln_scanner`, or `cloud_scanner`) or an
   explicit list of source names that must see the asset.
 - `severity` — severity of the gap finding; defaults to `MEDIUM`.
-- `max_age_days` / `source_max_age_days` — staleness gates: an asset (or a
-  source's view of it) older than the window is treated as no longer covered,
-  so a stale sensor does not silently count as coverage.
+- `max_age_days` — an **exemption** window, not a coverage gate. An asset whose
+  own last-seen is older than this (or absent) is skipped entirely: no finding
+  either way. Use it to stop retired kit from sitting in the worklist forever.
+- `source_max_age_days` — the actual **staleness gate on coverage**. A source
+  only satisfies the expectation if *that source's* sighting of the asset falls
+  inside the window, so an EDR that last saw the laptop a quarter ago is a gap,
+  not coverage — even though its name is still on the asset. A sighting with no
+  timestamp can never prove freshness.
 
 With no policy set, there are **no gap findings** — coverage expectations are
 entirely user-declared. The policy is validated on write; an invalid policy is
 rejected loudly rather than silently ignored.
 
-!!! note "Distinct from the `coverage` cloudsec_policy"
-    This CAASM expected-coverage policy evaluates **third-party assets** (the
-    merged device inventory: "seen by the IdP, no EDR"). It is separate from
-    the `coverage`-typed `cloudsec_policy`, which declares an EDR expectation
-    over **cloud workloads** — see
-    [Coverage — workload coverage expectations](configuration.md#coverage-workload-coverage-expectations).
-    The two are not synced.
+!!! warning "`vuln_scanner` has no supplying source yet"
+    Of the five capabilities, `vuln_scanner` is accepted by validation but no
+    connected source currently attests it. An expectation gating on it therefore
+    flags every asset in scope, permanently. Declare `edr`, `idp`, `mdm`,
+    `cloud_scanner`, or an explicit `sources` list instead.
+
+### The three kinds
+
+The three kinds span two very different populations, which is why what can
+satisfy an expectation differs by kind:
+
+| Kind | Population | Satisfied by |
+|---|---|---|
+| `device` | Merged third-party devices | An observation from a source with the required capability (or in `sources`) |
+| `identity` | Merged third-party identities | Same |
+| `cloud_instance` | Cloud compute workloads from your provider sweeps | The live sensor ↔ instance runtime join — *not* third-party observations |
+
+`cloud_instance` is the "unprotected workload" expectation: a VM that your cloud
+inventory holds but that no live sensor resolves onto. Because its only evidence
+is that runtime join, the expectation must be declared with the `edr` capability
+or the `limacharlie` source explicitly — anything else is rejected on write
+rather than silently flagging every workload forever. Two exemptions are built
+in: a workload whose provider reports it stopped, terminated, deallocated or
+suspended is never flagged, and nothing is evaluated at all while the resolver is
+unavailable (an outage must not read as "no agents"). The gaps land as
+`workload_coverage_gap` findings, distinct from the `coverage_gap` class the
+merged kinds produce.
+
+!!! note "Related policy surfaces"
+    Expected coverage is set through the CAASM policy shown above, for all three
+    kinds. There is also a `coverage`-typed `cloudsec_policy` record —
+    see [Configuration](configuration.md#coverage-workload-coverage-expectations)
+    for its current status. The two are separate records and are not synced;
+    the CAASM policy is the one the commands on this page read and write.
 
 ## Coverage gaps
 
@@ -116,6 +187,11 @@ limacharlie cloudsec caasm coverage --status open --severity HIGH
 "Seen by Okta, no EDR" is the canonical example: the asset exists, a human
 uses it, and your endpoint tooling is blind to it.
 
+This view is pinned to the `coverage_gap` class, so it covers the `device` and
+`identity` kinds. Unprotected cloud workloads carry the separate
+`workload_coverage_gap` class — filter for it in the main worklist
+(`limacharlie cloudsec finding list --class workload_coverage_gap`).
+
 ## Pushing records in
 
 For sources without a live adapter, push raw vendor-shaped records directly.
@@ -129,9 +205,50 @@ limacharlie cloudsec caasm ingest --source okta --records-file users.json
 limacharlie cloudsec caasm ingest --source crowdstrike --record-json '{...}'
 ```
 
+The two native sources are **not** push-ingestable: their own collector is their
+single writer, so a raw push under their name is rejected rather than
+mis-normalized into a phantom asset.
+
 The response carries the reconcile counters — `received`, `normalized`,
-`skipped`, `assets`, `created`, `updated`, `deleted` — so a feeder can
-observe exactly what its batch changed.
+`skipped`, `assets`, `created`, `updated`, `deleted`, plus `policy_set` (true
+when the same call also rewrote the coverage policy) — so a feeder can observe
+exactly what its batch changed.
+
+### A continuous feeder
+
+To keep a source current instead of importing it once, forward its events to the
+same ingest action from a D&R rule — the way anything else in the platform is
+automated (see [Automation](automation.md)):
+
+```yaml
+detect:
+  event: <the adapter event that carries a user or device sighting>
+  op: exists
+  path: event/actor/id
+respond:
+  - action: extension request
+    extension name: ext-cloud-security
+    extension action: caasm_ingest
+    extension request:
+      source: okta
+      record: "{{ .event }}"
+    suppression:
+      keys:
+        - caasm-okta
+        - '{{ .event.actor.id }}'
+      max_count: 1
+      period: 24h
+```
+
+The action takes `source` plus either one `record` or a `records` batch, and the
+record is the raw vendor event — the same shape the CLI sends, which is why the
+detect side just forwards `.event` untouched. Substitute the field the source
+identifies its records by: for `okta` that is `actor.id` (or `id` on the users
+inventory shape), for `crowdstrike` the agent id, for `ms_graph` the device id.
+
+Ingestion is idempotent, so a re-sent record is harmless; the suppression block
+is about volume, not correctness. One forward per asset per day keeps freshness
+comfortably inside any sane `source_max_age_days`.
 
 !!! info "Permissions"
     Reading assets and coverage requires `cloudsec.get`; setting the policy

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -5,13 +5,18 @@
     configuration formats described here may change before general
     availability. Contact us if you would like access.
 
-The `limacharlie cloudsec` command group (Python SDK/CLI v2) covers the full
-Cloud Security API surface. Every command supports the global options
-(`--oid`, `--output json|yaml|csv|table`, `--filter <jmespath>`), and every
-command and subgroup answers `--ai-help` with task-oriented guidance.
+The `limacharlie cloudsec` command group (Python SDK/CLI v2) covers most of
+the Cloud Security API surface: the posture and inventory reads, findings
+triage, graph queries, policy previews, CSV exports, and the fleet roll-up.
+Commands take the global options (`--oid`,
+`--output json|yaml|toon|csv|table|jsonl`, `--filter <jmespath>`,
+`--fields <names>`), and every command and subgroup answers `--ai-help` with
+task-oriented guidance. The `export` subgroup is the one exception: it writes
+a server-rendered CSV straight through, so the output, filter, and field
+options do not apply to it.
 
 ```bash
-pip install limacharlie
+pip install 'limacharlie>=5.5.3'   # Python 3.10 or newer
 limacharlie cloudsec --help
 ```
 
@@ -55,6 +60,7 @@ limacharlie cloudsec data-security facets
 
 # Inventory & graph
 limacharlie cloudsec inventory list --type <resource-type> --provider gcp -q prod --limit 50
+limacharlie cloudsec inventory list --all-accounts --limit 50   # drop per-account scoping
 limacharlie cloudsec inventory facets
 limacharlie cloudsec resource get "lcrn:..."
 limacharlie cloudsec graph neighbors "lcrn:..." --limit 200
@@ -74,7 +80,7 @@ limacharlie cloudsec resolve assets "lcrn:..."
 
 # CAASM
 limacharlie cloudsec caasm assets -q laptop
-limacharlie cloudsec caasm coverage --status open
+limacharlie cloudsec caasm coverage --status open --sort lc_risk --order desc
 limacharlie cloudsec caasm policy get
 limacharlie cloudsec caasm policy set --input-file coverage.json
 limacharlie cloudsec caasm ingest --source okta --records-file users.json
@@ -85,9 +91,10 @@ limacharlie cloudsec provider manifest --type gcp        # "what you get" for a 
 
 # Policy authoring aids + read-only matcher previews
 limacharlie cloudsec policy vocabulary
-limacharlie cloudsec policy suggest --dimension name -q prod
-limacharlie cloudsec simulate resources --input-file rules.json --target data_store
-limacharlie cloudsec simulate findings --input-file match.json
+limacharlie cloudsec policy suggest --dimension name -q prod --limit 10
+limacharlie cloudsec simulate resources --input-file rules.yaml --target data_store
+limacharlie cloudsec simulate resources --rules-json '[{"name_glob":"prod-*"}]' --resource-type gcp_bucket
+limacharlie cloudsec simulate findings --match-json '{"finding_class":"misconfig","max_severity":"LOW"}'
 
 # Full-set CSV export (server-side walk of the entire filtered set)
 limacharlie cloudsec export findings -o findings.csv
@@ -97,7 +104,7 @@ limacharlie cloudsec export query --named public_data_stores -o data-stores.csv
 
 # Fleet — cross-tenant (MSSP) roll-up, no single --oid
 limacharlie cloudsec fleet overview --oid $OID1 --oid $OID2 --trend-days 30
-limacharlie cloudsec fleet overview --group prod --limit 100
+limacharlie cloudsec fleet overview --group <GROUP_ID> --limit 100
 ```
 
 The `export` subgroup streams the **entire** filtered set as a CSV
@@ -109,23 +116,34 @@ only the current page of a normal list command. `export findings`,
 `export query` takes the same `--named` / `--text` / `--query-json`
 selectors as `query run`.
 
-`fleet overview` is the multi-org board for MSSPs: pass `--oid` repeatedly
-(or `--group` to select a saved fleet group) to roll risk posture up across
-tenants. It carries `--trend-days`, `--limit`, and `--cursor` for paging the
-tenant list, and is the one command that does not resolve a single `--oid`.
+`fleet overview` is the multi-org board for MSSPs: pass `--oid` repeatedly,
+or `--group <GROUP_ID>` — the opaque id of an org group you own or belong to,
+not its display name — to roll risk posture up across tenants. Given neither,
+it spans every organization your credentials can see. It carries
+`--trend-days`, `--limit`, and `--cursor` for paging the tenant list, and is
+the one command that does not resolve a single `--oid`.
 
-!!! note "CLI is the query & triage surface"
-    Scheduled queries and workload-group views are **console + REST-API**
-    features with no CLI command — everything else (reads, findings triage,
-    graph queries, Topology, Identity 360, policy simulation and
-    autocomplete, exports, and fleet roll-up) is covered. Provider and
-    policy *records* are managed with `limacharlie hive` (see
-    [Configuration](configuration.md)).
+!!! note "What lives outside this command group"
+    Three read routes have no `cloudsec` command of their own: the shared-fix
+    cause rollup (`GET /findings/causes`), the filtered identity list behind
+    the Access page (`GET /ciem/identities`), and the paginated data-store
+    list (`GET /data-security/stores`). Call them over the REST API, or with
+    the generic `limacharlie api <path>` escape hatch — see the
+    [API Reference](api-reference.md).
+
+    Two things that look like missing commands are really something else.
+    **Scheduled queries** are not a separate feature: a scheduled query is a
+    `cloudsec_query` Hive record carrying a `schedule` block, authored with
+    `limacharlie hive set --hive-name cloudsec_query` (see
+    [Configuration](configuration.md#cloudsec_query)). **Workload groups**
+    are not a view of their own either: they arrive on findings as
+    `source_scope` / `target_scope` in `finding list`, and as the
+    `ComputeGroup` node type in graph queries.
 
 ## Filtering and pagination
 
-List commands accept repeatable filters (OR within a key, AND across keys),
-free-text search, sorting, and keyset pagination:
+`finding list` carries the full vocabulary — repeatable filters (OR within a
+key, AND across keys), free-text search, sorting, and keyset pagination:
 
 ```bash
 limacharlie cloudsec finding list \
@@ -139,6 +157,34 @@ limacharlie cloudsec finding list --cursor "<next_cursor>" --limit 50
 
 Boolean tri-state flags (`--kev/--no-kev`, `--reachable/--no-reachable`)
 send the filter only when given, so the server default applies otherwise.
+
+The other lists carry a subset, so check `--help` before assuming a flag is
+there. `caasm coverage` behaves like `finding list` (repeatable filters,
+`--sort`/`--order`, paging). `inventory list` and `caasm assets` page but do
+not sort, and inventory's `--type` / `--provider` / `--account` / `--region`
+each take a single value rather than repeating. `attack-path list` returns
+the headline set in one shot: repeatable filters and `-q`, but no sorting and
+no paging.
+
+## Records, files, and stdin
+
+The commands that take a record — `provider test`, `caasm policy set`, and
+both `simulate` commands — accept it three ways: `--input-file` (JSON *or*
+YAML), an inline-JSON flag (`--provider-json`, `--policy-json`,
+`--rules-json`, `--match-json`), or piped on stdin:
+
+```bash
+cat provider.yaml | limacharlie cloudsec provider test
+limacharlie cloudsec caasm policy set --policy-json '{"expect":[...]}'
+```
+
+`caasm ingest` has its own pair: `--records-file` for a JSON or YAML array of
+vendor records, `--record-json` for a single inline record.
+
+Both `simulate` commands take `--sample-limit` (default 25, cap 100) to size
+the returned sample, and `simulate resources` takes a repeatable
+`--resource-type` to narrow the walked types the way an exclusions rule does.
+`policy suggest` takes `--limit` (default 20, cap 50).
 
 ## Scripting
 

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -35,16 +35,49 @@ The report is per-control, and each control lands in one of four states:
 - **PASS** — no open finding proves a violation of the control.
 - **FAIL** — one or more open findings prove it; their `finding_id`s are
   attached as evidence.
-- **NOT_ASSESSED** — the control has no mapped rule yet, so nothing was
-  evaluated.
-- **NOT_APPLICABLE** — the control maps to resource types that are not in
-  scope for this assessment.
+- **NOT_ASSESSED** — the control cannot be evaluated automatically. These are
+  the manual / attestation controls (policy documents, board sign-off,
+  interview evidence): the framework marks them as not auto-assessable, so no
+  rule is run and no verdict is invented.
+- **NOT_APPLICABLE** — the control has nothing to assess in *this* estate:
+  either the framework's cloud has no resources connected, or the control
+  declares no resource types to apply to.
 
 A framework scoped to a single cloud assesses only that cloud's findings —
 `cis-aws` looks at AWS findings, `cis-gcp` at GCP. A framework with no
 in-scope resource types comes back **NOT_APPLICABLE** rather than a vacuous
-PASS, so an empty estate never reads as compliant. Alongside the controls the
-report carries a summary score.
+PASS, so an empty estate never reads as compliant.
+
+### How the score is computed
+
+The report's summary carries `passed`, `failed`, `not_assessed`,
+`not_applicable`, `total`, `score`, and `applicable`. The score is the share of
+**assessable** controls that pass:
+
+```text
+score = passed / (passed + failed) × 100
+```
+
+Only PASS and FAIL are assessable. NOT_ASSESSED and NOT_APPLICABLE controls are
+excluded from the denominator entirely, so a manual control you have not
+attested does not drag the number down, and a framework you are only partly in
+scope for is not penalized for the parts that do not apply.
+
+!!! warning "No assessable controls means `applicable: false`, not 100%"
+    When nothing in the framework is assessable against your estate, the report
+    comes back with `applicable: false` and a `score` of **0** — never a
+    vacuous 100. Read `applicable` before reading `score`: a 0 with
+    `applicable: false` means "we could not assess this", not "you failed
+    everything".
+
+!!! note "FAIL evidence is capped per control"
+    A failing control attaches at most **25** proving `finding_id`s in the JSON
+    report, while `evidence_count` reports the true total — so a control with
+    900 violations shows 25 examples and `evidence_count: 900`. The CSV export
+    raises the cap to 2,000 ids per control for auditors who need the fuller
+    list; use the [findings API](findings.md) itself when you need all of them.
+
+### Auditor export
 
 For auditors, the same report exports as CSV — one row per control including
 the evidence finding ids — via the API's `?format=csv`

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -13,7 +13,7 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 | Hive | Records | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per cloud / IdP / SaaS / AI connection | what to collect and with which credential |
-| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, scanning, emission, exclusions, suppression, compliance assignments |
+| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, emission, exclusions, suppression, compliance assignments |
 | `cloudsec_query` | one per saved query | shared saved graph queries |
 
 !!! info "Permissions"
@@ -135,7 +135,7 @@ not accept is **rejected when you save** rather than silently ignored:
 
 | Dimension | Where it is honored |
 |---|---|
-| `tag` | compute resources only. Within `classification` that means the `compute` section; the dimension is also accepted on `coverage`, `scanning` scopes, and `exclusions`. |
+| `tag` | compute resources only. Within `classification` that means the `compute` section; the dimension is also accepted on `coverage` and `exclusions`. |
 | `public` | data stores **and** compute. |
 | `content_class` | data stores only — and not yet populated, see the caveat above. |
 | `label` / `label_key_present` | resources carrying cloud labels. Not honored on `classification.identities`. |
@@ -218,46 +218,6 @@ covered; `exempt` wins.
     documented for records that already exist and for the shape it will take
     when evaluation lands; it is not synced with the CAASM policy.
 
-### `scanning` — what the agentless scanner looks for
-
-Declares what the agentless snapshot scanner looks for inside cloud workloads.
-There is **no built-in scanning**: with no `scanning` policy the scanner runs no
-content rules at all. Creating the policy *is* the opt-in — the same
-user-declared-only stance as `classification`.
-
-```json
-{
-  "policy_type": "scanning",
-  "scanning": {
-    "rules": [
-      {"yara_rule": "known-implants", "classification": "malware"},
-      {"yara_rule": "cloud-credentials", "classification": "secret"}
-    ],
-    "scope": [
-      {"account_glob": ["proj-prod-*"]}
-    ]
-  }
-}
-```
-
-`rules` is required and non-empty. Each entry is a binding of a YARA ruleset to
-a classification:
-
-| Field | Meaning |
-|---|---|
-| `yara_rule` | The **name of a record in your org's `yara` hive**, not inline YARA source. Every `rule` block inside that record is compiled and run. |
-| `classification` | How every hit from that ruleset is labeled. `malware` and `secret` are the built-in classes and produce `malware` / `secret` findings; any other value is preserved as a custom label that scan findings are grouped by. |
-
-`scope` is optional and applies to the whole policy, as cost control over which
-compute is snapshot-scanned: empty means **all** compute is in scope, and when
-non-empty only compute matching a scope rule is scanned. Scope rules match
-compute, so they follow the compute matcher rules (`tag` allowed, `classes`
-rejected).
-
-Scanning also has its own exclusion list, and an **exclusion beats the include
-scope**: a workload matching a scanning exclusion is never scanned even if a
-scope rule selects it.
-
 ### `emission` — the event feed
 
 Controls which Cloud Security events reach the organization's event stream:
@@ -266,7 +226,7 @@ Controls which Cloud Security events reach the organization's event stream:
 |---|---|---|
 | `resource_events` | `cloud_resource.*` inventory change events | off |
 | `finding_events` | `cloud_finding.*` lifecycle events | on |
-| `ops_events` | operational events — `cloudsec.sweep_failed` and `cloudsec.scan_failed` | off |
+| `ops_events` | operational events — `cloudsec.sweep_failed` | off |
 | `severity_floor` | drop finding events below this severity (`CRITICAL` … `INFO`); the first-sync summary still counts the whole estate | none |
 | `suppress_first_sync` | emit one summary instead of a per-finding flood on the first / rebuild sweep | on |
 
@@ -276,15 +236,13 @@ event taxonomy.
 ### `exclusions` — the escape hatch
 
 The per-org escape hatch for whales and noise: the account with hundreds of
-thousands of buckets, the workload too expensive to scan, the account whose
-events should never reach your stream. It has **three independent rule lists**,
-one per surface, and a rule on one surface has no effect on the others. At least
-one list must be non-empty:
+thousands of buckets, the account whose events should never reach your stream.
+It has **independent rule lists**, one per surface, and a rule on one surface
+has no effect on the others. At least one list must be non-empty:
 
 | List | Effect |
 |---|---|
 | `collection` | Matching scopes are skipped by the collection sweep. Only this list may add the `services` and `resource_types` narrowers on top of the shared resource matchers — an account-only rule excludes the whole account, while adding `services`/`resource_types` narrows the exclusion to those collector services or resource types inside the matched scope. |
-| `scanning` | Matching workloads are never snapshot-scanned. This **beats** the include scope of the `scanning` policy above. |
 | `emission` | Matching events are dropped before delivery to the event stream. Only account/name/provider matchers are honored here — an emission rule constrained on labels or tags can never be satisfied by a lean event and so never drops one. |
 
 !!! warning "A collection exclusion deletes the inventory it excludes"

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -13,7 +13,7 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 | Hive | Records | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per cloud / IdP / SaaS / AI connection | what to collect and with which credential |
-| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, emission, exclusions, suppression, compliance assignments |
+| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, scanning, emission, exclusions, suppression, compliance assignments |
 | `cloudsec_query` | one per saved query | shared saved graph queries |
 
 !!! info "Permissions"
@@ -37,7 +37,7 @@ Common fields (all provider types):
 | `compliance_credentials` | Optional second `hive://secret/<name>` reference for providers with a second credential plane (today: Anthropic's compliance/analytics key). |
 | `internal_domains` | Your own email domains (bare domains, no `@`) beyond the discoverable primary — human identities outside this set are classified external. |
 | `sync_now` | Opaque nonce; change its value to trigger an on-demand sweep. |
-| `refresh` | Periodic re-enumeration cadence as a duration string (e.g. `"6h"`); empty uses the service default. |
+| `refresh` | Periodic re-enumeration cadence as a duration string (e.g. `"6h"`); empty uses the service default of **6h**. |
 | `feed_subscription` | Optional fully-qualified Pub/Sub subscription carrying a cloud change feed, for event-driven freshness between full sweeps. |
 
 Per-provider scope fields:
@@ -82,7 +82,7 @@ the same matcher grammar:
 | `label_key_present` | a set of label keys — **all** must be present |
 | `tag` | a set of tags (compute only) — **all** must be present |
 | `public` | tri-state exposure (`true` / `false`) |
-| `content_class` | detected sensitive-content classes on a data store (`pii`, `pci`, `phi`, `financial`) |
+| `content_class` | detected sensitive-content classes on a data store (`pii`, `pci`, `phi`, `financial`) — accepted and validated, but see the caveat below |
 
 !!! warning "Matchers within a rule are ANDed"
     A rule matches a resource only when **every populated dimension matches**.
@@ -95,6 +95,14 @@ the same matcher grammar:
 
     (This is a change from earlier behavior, where dimensions within a rule were
     ORed. The `store_kind` matcher has been folded into `resource_type`.)
+
+!!! warning "`content_class` rules do not match anything yet"
+    The `content_class` dimension is accepted and validated wherever it appears,
+    but the content-detection pipeline that populates detected content classes on
+    resources is **not live in the current release**. Until it ships, a rule
+    matching on `content_class` saves cleanly and matches zero resources. Express
+    sensitivity you need enforced today with the other dimensions (`name_glob`,
+    `label`, `tag`, `account_glob`, …).
 
 #### Glob syntax
 
@@ -113,25 +121,37 @@ Every glob dimension (`account_glob`, `name_glob`, `region`, and suppression
 A pattern whose **first character is `!` is a negation**: within one list the
 positive patterns OR together as before, and any matching negation **vetoes**
 the whole list. A list containing only negations matches everything it doesn't
-exclude — `account_glob: ["!legion-*"]` means "every account **without** the
-`legion-` prefix". `\!` matches a literal leading `!`. Case-insensitive
+exclude — `account_glob: ["!sandbox-*"]` means "every account **without** the
+`sandbox-` prefix". `\!` matches a literal leading `!`. Case-insensitive
 dimensions stay case-insensitive under negation.
 
 ```yaml
-account_glob: ["*-prod", "!legion-*"]   # every -prod account except legion ones
+account_glob: ["*-prod", "!sandbox-*"]  # every -prod account except sandbox ones
 region: ["!eu-*"]                        # everywhere outside the EU
 ```
 
-Not every dimension is honored on every surface — `tag` is compute-only,
-`content_class`/`public`/`classes` apply to data stores, and the `exclusions`
-emission list honors only account/name/provider. The console's policy editors
-enforce this per surface and offer live value **autocomplete** from your actual
-estate, plus a **Simulate** preview that shows which resources a rule matches
-before you save (see [Previewing policies](#previewing-policies)).
+Not every dimension is honored on every surface, and a dimension a surface does
+not accept is **rejected when you save** rather than silently ignored:
 
-Assign-side fields (not matchers): `name` (provenance), `classes` (the classes a
-`classification` data-store rule assigns), and `tier`
-(`critical`/`high`/`medium`/`low`).
+| Dimension | Where it is honored |
+|---|---|
+| `tag` | compute resources only. Within `classification` that means the `compute` section; the dimension is also accepted on `coverage`, `scanning` scopes, and `exclusions`. |
+| `public` | data stores **and** compute. |
+| `content_class` | data stores only — and not yet populated, see the caveat above. |
+| `label` / `label_key_present` | resources carrying cloud labels. Not honored on `classification.identities`. |
+| `services` / `resource_types` | collection exclusions only. |
+| account / name / provider matchers | every surface, including the `exclusions` emission list — which honors *only* these. |
+
+The console's policy editors enforce this per surface and offer live value
+**autocomplete** from your actual estate, plus a **Simulate** preview that shows
+which resources a rule matches before you save (see
+[Previewing policies](#previewing-policies)).
+
+Assign-side fields (not matchers): `name` carries provenance and is accepted
+anywhere, but the two that assign meaning are surface-bound and rejected at save
+elsewhere — `classes` (the classes a rule assigns) is accepted on
+`classification` **data-store** rules only, and `tier`
+(`critical`/`high`/`medium`/`low`) on `classification` rules only.
 
 ### `classification` — crown jewels
 
@@ -154,32 +174,89 @@ match resources and assign classes and/or a criticality tier, in three sections
 }
 ```
 
-Content-based sensitivity is expressed with `content_class` rules: the agentless
-scanner samples data stores and surfaces detected content classes (`pii`, `pci`,
-`phi`, `financial`) as facts on the resource, and a `content_class` rule is what
-turns a detection into a sensitivity claim. Your explicit policy always remains
-authoritative.
+Content-based sensitivity is expressed with `content_class` rules: detected
+content classes (`pii`, `pci`, `phi`, `financial`) become facts on a data store,
+and a `content_class` rule is what turns such a detection into a sensitivity
+claim. Your explicit policy always remains authoritative.
 
-!!! note "auto_classify has been replaced"
-    Earlier versions accepted an `auto_classify: true` boolean. It has been
-    retired in favor of explicit, previewable `content_class` rules — the same
-    detection, but visible in the policy and testable with Simulate. Remove
-    `auto_classify` from any existing record.
+!!! warning "Content detection is not live yet"
+    `content_class` rules are accepted and validated today, but the pipeline
+    that populates detected content classes on resources has **not shipped in
+    the current release** — so the second rule in the example above currently
+    matches nothing. Classify by name, label, or tag for sensitivity you need
+    enforced now, and treat `content_class` rules as forward-looking.
+
+!!! note "auto_classify has been removed"
+    Earlier versions accepted an `auto_classify: true` boolean. It is gone, and
+    a record that still carries it is now **rejected at save** with an unknown-
+    field error rather than being ignored. Remove `auto_classify` from any
+    existing record before updating it. Explicit `content_class` rules are the
+    replacement: the same intent, but visible in the policy and testable with
+    Simulate.
 
 ### `coverage` — workload coverage expectations
 
 Declares which **cloud workloads** are expected to run a LimaCharlie sensor,
 with `required` and `exempt` resource-rule lists — the "EDR on production VMs"
-expectation, evaluated over the cloud inventory. An empty `required` means every
-compute resource is expected to be covered; `exempt` wins.
+expectation. An empty `required` means every compute resource is expected to be
+covered; `exempt` wins.
 
-!!! note "Distinct from the CAASM expected-coverage policy"
-    `limacharlie cloudsec caasm policy set` manages a **separate** policy with a
-    different shape (`{expect: [{label, capability, kinds}]}`) evaluated over the
-    merged *third-party asset* inventory ("seen by the IdP, no EDR") — see
-    [CAASM](caasm.md#declare-expected-coverage). The two are not synced: this
-    hive record drives cloud-workload coverage findings; the CAASM policy drives
-    `coverage_gap` findings over third-party assets.
+!!! warning "Accepted and validated, but not currently evaluated"
+    A `coverage`-typed record saves and validates, but **nothing evaluates it in
+    the current release** — it produces no findings. Use the **CAASM coverage
+    policy** instead, which is the live expected-coverage surface:
+
+    ```bash
+    limacharlie cloudsec caasm policy set --input-file coverage.json
+    ```
+
+    It has a different shape (`{expect: [{label, capability, kinds}]}`) and is
+    evaluated over the merged asset inventory, where a `cloud_instance` kind
+    covers cloud workloads as well as third-party assets — so the "EDR expected
+    on production VMs" expectation belongs there today. See
+    [CAASM](caasm.md#declare-expected-coverage). This `coverage` policy type is
+    documented for records that already exist and for the shape it will take
+    when evaluation lands; it is not synced with the CAASM policy.
+
+### `scanning` — what the agentless scanner looks for
+
+Declares what the agentless snapshot scanner looks for inside cloud workloads.
+There is **no built-in scanning**: with no `scanning` policy the scanner runs no
+content rules at all. Creating the policy *is* the opt-in — the same
+user-declared-only stance as `classification`.
+
+```json
+{
+  "policy_type": "scanning",
+  "scanning": {
+    "rules": [
+      {"yara_rule": "known-implants", "classification": "malware"},
+      {"yara_rule": "cloud-credentials", "classification": "secret"}
+    ],
+    "scope": [
+      {"account_glob": ["proj-prod-*"]}
+    ]
+  }
+}
+```
+
+`rules` is required and non-empty. Each entry is a binding of a YARA ruleset to
+a classification:
+
+| Field | Meaning |
+|---|---|
+| `yara_rule` | The **name of a record in your org's `yara` hive**, not inline YARA source. Every `rule` block inside that record is compiled and run. |
+| `classification` | How every hit from that ruleset is labeled. `malware` and `secret` are the built-in classes and produce `malware` / `secret` findings; any other value is preserved as a custom label that scan findings are grouped by. |
+
+`scope` is optional and applies to the whole policy, as cost control over which
+compute is snapshot-scanned: empty means **all** compute is in scope, and when
+non-empty only compute matching a scope rule is scanned. Scope rules match
+compute, so they follow the compute matcher rules (`tag` allowed, `classes`
+rejected).
+
+Scanning also has its own exclusion list, and an **exclusion beats the include
+scope**: a workload matching a scanning exclusion is never scanned even if a
+scope rule selects it.
 
 ### `emission` — the event feed
 
@@ -189,8 +266,8 @@ Controls which Cloud Security events reach the organization's event stream:
 |---|---|---|
 | `resource_events` | `cloud_resource.*` inventory change events | off |
 | `finding_events` | `cloud_finding.*` lifecycle events | on |
-| `ops_events` | operational events (sweep failures) | off |
-| `severity_floor` | drop finding events below this severity | none |
+| `ops_events` | operational events — `cloudsec.sweep_failed` and `cloudsec.scan_failed` | off |
+| `severity_floor` | drop finding events below this severity (`CRITICAL` … `INFO`); the first-sync summary still counts the whole estate | none |
 | `suppress_first_sync` | emit one summary instead of a per-finding flood on the first / rebuild sweep | on |
 
 See [Findings are events too](findings.md#findings-are-events-too) for the full
@@ -198,11 +275,30 @@ event taxonomy.
 
 ### `exclusions` — the escape hatch
 
-Excludes matching resources from `collection` or `emission` (two
-independent rule lists; collection rules add `services` and `resource_types`
-matchers on top of the shared resource matchers). Use it for the million-object
-bucket that should not be enumerated, or the noisy account that should not emit
-events. Removal takes effect on the next sweep.
+The per-org escape hatch for whales and noise: the account with hundreds of
+thousands of buckets, the workload too expensive to scan, the account whose
+events should never reach your stream. It has **three independent rule lists**,
+one per surface, and a rule on one surface has no effect on the others. At least
+one list must be non-empty:
+
+| List | Effect |
+|---|---|
+| `collection` | Matching scopes are skipped by the collection sweep. Only this list may add the `services` and `resource_types` narrowers on top of the shared resource matchers — an account-only rule excludes the whole account, while adding `services`/`resource_types` narrows the exclusion to those collector services or resource types inside the matched scope. |
+| `scanning` | Matching workloads are never snapshot-scanned. This **beats** the include scope of the `scanning` policy above. |
+| `emission` | Matching events are dropped before delivery to the event stream. Only account/name/provider matchers are honored here — an emission rule constrained on labels or tags can never be satisfied by a lean event and so never drops one. |
+
+!!! warning "A collection exclusion deletes the inventory it excludes"
+    Collection exclusion is not just "stop collecting from here". On the next
+    sweep the excluded scope is reported as *covered with zero rows*, so the
+    authoritative diff **deletes the scope's existing inventory rows** (the
+    resulting delete storm is kept out of the event feed). This is deliberate —
+    an excluded scope disappears instead of lingering as stale rows — but it
+    means excluding a scope you still want recorded loses that inventory until
+    you remove the exclusion and let a sweep repopulate it.
+
+Exclusions are captured when a sweep starts, so an edit lands on the *next*
+sweep. Change the provider's `sync_now` nonce to apply it immediately instead of
+waiting for the refresh cadence.
 
 ### `suppression` — finding disposition policy
 
@@ -233,12 +329,55 @@ A saved graph query, shared org-wide:
 }
 ```
 
-`query` takes one of `named` (a query-pack reference), `text`, or `ast` (the raw
-DSL). Optional `ui` hints (view, columns) shape how the console renders results;
-the query appears in the [Query console and as an Explore lens](graph.md#graph-queries).
-`schedule` and `detection` blocks are accepted for forward-compatibility;
-turning a saved query into a scheduled detection source (emitting `cloud_query.*`
-events) is an emerging capability.
+`query` takes **exactly one** of `named` (a query-pack reference), `text`, or
+`ast` (the raw DSL) — setting none or more than one is rejected. The other
+fields draw on closed sets: `version` accepts `0` (unset) or `1`, both meaning
+the shape documented here; `project` is `rows` (table) or `graph` (canvas),
+defaulting to `rows`; the optional `ui` hint takes `view` (`table` or `graph`)
+and `columns`. The query appears in the
+[Query console and as a pinnable lens on the Attack Surface page](graph.md#graph-queries).
+
+### Scheduled queries — any saved query as a detection source
+
+The `schedule` block turns a saved query into a live detection source, with no
+new rule syntax:
+
+```json
+{
+  "version": 1,
+  "name": "Exposed VMs reaching sensitive data",
+  "query": {"text": "..."},
+  "schedule": {"scheduled": true, "interval": "1h"}
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `scheduled` | Activates evaluation. The record must also be **enabled** — a disabled record is never a live detection source. |
+| `interval` | Cadence as a Go duration (`"1h"`, `"24h"`); minimum **5m**. |
+| `cron` | A 5-field cron expression, with optional `timezone` (IANA name). |
+| `emit_suppressed` | Emit matches for anchors your `suppression` policy suppressed. Default `false` (suppressed anchors stay silent). Only meaningful with `scheduled: true`. |
+
+Set **at most one** of `interval` or `cron`. With neither, the query is evaluated
+after each projection cycle — the default and usually the right choice, since it
+fires as soon as the estate actually changes.
+
+Evaluation follows the same lifecycle symmetry as findings: `cloud_query.match`
+is emitted once per **new** anchor entering the match set, `cloud_query.resolved`
+once per anchor leaving it — so a re-evaluation that changed nothing emits
+nothing. These events flow through the same `emission` policy gate as every
+other Cloud Security event.
+
+!!! note "Two budgets protect the loop"
+    An org runs at most **25** scheduled queries per pass (excess is skipped in
+    deterministic query-name order, not silently dropped). A single query whose
+    match set exceeds **1,000** anchors is *over budget*: it emits one
+    `cloud_query.overbudget` instead of a match flood, and per-anchor tracking
+    pauses until it comes back under the cap. Scope a scheduled query so its
+    result set is a worklist, not a table dump.
+
+The `detection` block is still **reserved**: it is validated for shape so
+infrastructure-as-code written today keeps working, but nothing consumes it yet.
 
 ## Previewing policies
 

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -48,9 +48,9 @@ Each finding carries:
   same fingerprint across sweeps.
 - `finding_class` — one of `toxic_combination`, `public_exposure`,
   `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
-  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`.
-  `malware`, `secret`, and `scan_finding` come from the agentless snapshot
-  scanner. Cloud-workload coverage findings additionally carry
+  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`
+  (`malware`, `secret`, and `scan_finding` are reserved for capabilities not
+  yet enabled). Cloud-workload coverage findings additionally carry
   `workload_coverage_gap`, which is not part of the class list offered by the
   suppression rule picker.
 - `severity` (`CRITICAL` … `INFO`), `lc_risk`, and the `risk_breakdown`

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -18,18 +18,43 @@ verbs, and the same automation events.
 
 ## The worklist
 
-Findings are ordered by `lc_risk` — a 0–1000 composite that weighs severity,
-exposure, reachability, exploit intelligence (KEV / EPSS), and whether the
-resource is sensitive. Each finding carries:
+Findings are ordered by `lc_risk` — a 0–1000 composite built from the severity
+of the condition and the exploit intelligence around it, amplified by how much
+the affected resource matters:
+
+- a **severity** base term, plus an **EPSS** term (the exploit-probability of
+  the finding's CVEs) and a **KEV** term (a bonus when a CVE is on CISA's Known
+  Exploited Vulnerabilities list);
+- multiplied by the **criticality** of the affected resource — the tier your
+  [`classification` policy](configuration.md#classification-crown-jewels)
+  assigned it (nothing is critical by default);
+- multiplied by a **blast-radius** factor taken from the graph: how many
+  sensitive nodes are reachable from the affected resource.
+
+Every finding carries a `risk_breakdown` that decomposes its score into those
+terms, so a position in the worklist is always explainable rather than an
+opaque number.
+
+!!! note "Runtime state never moves the score"
+    `lc_risk` is a property of the condition and of the resource's importance.
+    Whether a LimaCharlie sensor happens to be running on the affected asset is
+    context (`runtime_sids`) and can drive its own coverage findings, but it
+    never raises or lowers `lc_risk`.
+
+Each finding carries:
 
 - `finding_id` (stable, prefixed `fnd_`) and `fingerprint` — the identity of
   the *condition*; the same misconfiguration on the same resource keeps the
   same fingerprint across sweeps.
 - `finding_class` — one of `toxic_combination`, `public_exposure`,
   `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
-  `coverage_gap`, `device_posture`.
-- `severity` (`CRITICAL` … `INFO`), `lc_risk`, and a `risk_breakdown`
-  explaining the score.
+  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`.
+  `malware`, `secret`, and `scan_finding` come from the agentless snapshot
+  scanner. Cloud-workload coverage findings additionally carry
+  `workload_coverage_gap`, which is not part of the class list offered by the
+  suppression rule picker.
+- `severity` (`CRITICAL` … `INFO`), `lc_risk`, and the `risk_breakdown`
+  above.
 - The affected resource (`resource_urn`, `resource_name`, `resource_type`,
   `account`, `region`), related resources, and — for path findings — the
   full `path` of hops.
@@ -51,6 +76,10 @@ confers — `data_admin` › `data_write` › `data_read` › `metadata` › `no
 not by the mere existence of the grant. "Reaches sensitive data" gates on
 `data_read`-or-higher; `metadata`/`none` grants surface as a lower-severity
 reconnaissance signal, not a top data-access risk.
+
+A grant whose effective capability cannot be resolved is `unknown`. It is not
+assumed harmless: it counts as *potentially* data-capable and surfaces as
+unverified access to review, but it is never treated as proven `data_read`.
 
 List, filter, and paginate server-side:
 
@@ -82,7 +111,8 @@ close) or an operator dispositions it:
 ```bash
 # Accept a known risk for 90 days.
 limacharlie cloudsec finding resolve fnd_0a1b... --kind accepted \
-  --reason "sandbox accepted risk (SEC-123)" --expires-at 1767225600
+  --reason "sandbox accepted risk (SEC-123)" \
+  --expires-at "$(date -d '+90 days' +%s)"
 
 # Reopen it.
 limacharlie cloudsec finding resolve fnd_0a1b... --kind open
@@ -95,7 +125,9 @@ limacharlie cloudsec finding bulk-resolve \
 
 The `bulk-resolve` route applies one disposition to many findings at once, but
 it does **not** accept `open` — reopen findings one at a time with
-`finding resolve <id> --kind open`.
+`finding resolve <id> --kind open`. A single call takes at most **500** finding
+ids; a larger batch is rejected outright rather than silently truncated, so
+split long lists into chunks of 500 yourself.
 
 In the console, the same dispositions are one-click buttons on a finding, plus
 the workflow actions built on top of them:
@@ -173,23 +205,43 @@ the world):
 - `cloud_finding.created` — a new finding; the full finding object rides under
   `event/finding` (including `runtime_sids`).
 - `cloud_finding.updated` — the content of an already-open finding materially
-  changed (a severity flip, a changed vuln set); payload names the
-  `changed` fields, `old_severity`/`new_severity`, and carries the current
-  `finding`.
+  changed. "Material" is a deliberately short list, so the event does not
+  re-fire on every sweep: the **severity** moved (in either direction), the
+  finding became **reachable** (not reachable → reachable), or one of its CVEs
+  entered **KEV** (not in KEV → in KEV). The payload names the `changed`
+  fields, `old_severity`/`new_severity`, and carries the current `finding`.
 - `cloud_finding.closed` — the condition is gone; `{finding_id, fingerprint,
   finding_class}`.
 - `cloud_finding.still_open` — re-asserted at most once per day for open
   findings that carry a linked ticket, the heartbeat that keeps a Case honest
   when the cloud was never actually fixed.
 
-**Operator-disposition verbs** (emitted by the write handlers, flat payload
-`{finding_id, fingerprint, finding_class, actor, note?}`):
+**Operator-disposition verbs** (flat payload
+`{finding_id, fingerprint, finding_class, actor, status, resolution, note?}`):
 `cloud_finding.resolved`, `cloud_finding.dismissed`, `cloud_finding.reopened`,
-`cloud_finding.assigned`.
+`cloud_finding.assigned`. `status` is the finding's new status and `resolution`
+the disposition kind that produced it — note that **both `mitigated` and
+`accepted` emit `cloud_finding.resolved`**, and `resolution` is what tells them
+apart. Key on `resolution` (not on the verb) if "fixed" and "accepted" should
+drive different automation.
+
+These verbs are not exclusively human: when a `suppression` policy
+auto-dispositions a finding it emits the same events, with `actor` set to
+`policy:<rule-name>` — and plain `policy` on the `reopened` event when a rule
+is removed or stops matching and releases its findings. Policy and human
+triage are therefore auditable through one stream, and the `actor` field is
+how you separate them.
 
 **Summary:** on the first-ever projection (or a rebuild) the platform emits a
 single `cloudsec.sync_completed` (`{total, by_class, by_severity}`) instead of
 a per-finding `created` flood — first-sync suppression.
+
+!!! warning "The event feed is best-effort"
+    Emission is at-most-once: events queue in a bounded buffer and the oldest
+    batch is dropped under sustained pressure rather than stalling the sweep.
+    Use the feed to *drive* automation, but treat the read API
+    (`finding list` / `finding get`) as the authoritative state of a finding —
+    it is not a replayable ledger of every transition.
 
 See [Automation & IaC](automation.md#findings-cases-automation) for the
 ready-made Cases loop that keys on `fingerprint`, and the

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -14,18 +14,39 @@ both are shown.
 
 Cloud Security is enabled per organization by subscribing to the
 `ext-cloud-security` extension — the subscription is both the enable gate and
-the billing hook. In the web console, open the extension from the Add-Ons
-marketplace and click **Subscribe**, or from the CLI:
+the billing hook.
+
+!!! info "Private Beta: contact us to enable"
+    While Cloud Security is in Private Beta, `ext-cloud-security` is not
+    publicly subscribable — you cannot turn it on yourself. Contact us and we
+    will enable it for your organization. Enabling it requires the
+    `billing.ctrl` and `user.ctrl` permissions and an active billing
+    subscription on the organization.
+
+Confirm the organization is enabled:
+
+```bash
+limacharlie extension list --oid $OID
+```
+
+Once the extension is publicly subscribable, the same enable is a single
+command (and a **Subscribe** button on **Extensions → Cloud Security** in the
+console):
 
 ```bash
 limacharlie extension subscribe --name ext-cloud-security --oid $OID
 ```
 
-Until the organization is subscribed, every Cloud Security API route and
-console view returns `403`.
+Until the organization is subscribed, every Cloud Security API route returns
+`403`. The **Cloud Security** workspace is always listed in the organization
+sidebar, but its pages show an "enable Cloud Security" screen — with a link to
+**Extensions** — rather than the product.
 
-Once enabled, **Cloud Security** appears as a workspace in the organization
-sidebar.
+!!! tip "The workspace opens gradually"
+    Before the first provider is connected there is nothing to show, so the
+    workspace deliberately exposes only **Settings** (and **Give Feedback**);
+    the other pages redirect there. The full set of pages appears once a
+    provider exists and its first sweep has data.
 
 ## 2. Connect a provider
 
@@ -36,20 +57,32 @@ steps below use Google Cloud as the worked example.
 
 ### In the console
 
-1. Open **Cloud Security → Settings → Providers** and click **+ Add provider**.
-2. Give the connection a **name**, pick the **provider type**, and fill the
-   type-specific connection fields (for GCP, the scope — a project, folder, or
-   organization).
-3. Supply the **credential**: either reference an existing
-   [secret](../7-administration/config-hive/secrets.md) by
-   `hive://secret/<name>`, or paste the credential to have the console store it
-   as a new secret for you. Credentials are always stored as a secret and
-   referenced — never inlined into the provider record.
-4. Click **Test Provider** to run the read-only preflight (see below), then
-   save. Saving an enabled connection starts collection.
+Open **Cloud Security → Settings → Providers** and click **+ Add provider**.
+The wizard has five steps:
 
-The provider row then shows its sync status, resource count, and per-row actions
-(**What you get**, **Sync now**, **Edit**, **Delete**).
+1. **Name & type** — name the connection and pick the provider type.
+2. **Configuration** — the type-specific connection fields (for GCP, the
+   scope: a project, folder, or organization).
+3. **Permissions** — the credential, plus the list of grants the collector
+   needs and per-OS command-line tabs that create them in the target platform.
+   Reference an existing [secret](../7-administration/config-hive/secrets.md)
+   by `hive://secret/<name>`, or paste the credential to have the console store
+   it as a new secret for you. Credentials are always stored as a secret and
+   referenced — never inlined into the provider record.
+4. **Sync cadence** — how often to re-enumerate, from 30 minutes to daily, or
+   a custom interval.
+5. **Summary** — review, then click **Add provider**. Saving an enabled
+   connection starts collection, and the closing screen reports the status of
+   that first scan.
+
+**Test Provider** sits in the wizard footer on every step, so you can run the
+read-only preflight (see below) as soon as the credential is in place rather
+than waiting until the end.
+
+The provider list then shows one row per connection with its **Source**,
+**Connection**, **Scope**, **Status**, **Resources**, and **Last sync**, plus
+per-row actions: **Sync now**, **Edit**, **Delete**, and — once the connection
+has reported what it can collect — **What you're getting**.
 
 ### As code
 
@@ -153,15 +186,12 @@ Sensitivity drives the attack-path and CIEM analytics: "exposed workload that
 can reach *sensitive* data" and "external identity with access to *sensitive*
 store" both need to know what sensitive means in your estate.
 
-!!! tip "Content-based classification"
-    Beyond declaring crown jewels by name/label, you can add `content_class`
-    rules so that data stores where the agentless scanner samples sensitive
-    content (`pii`, `pci`, `phi`, `financial`) are treated as sensitive. Detected
-    content classes are always surfaced as facts on a resource; a `content_class`
-    rule is what turns a detection into a sensitivity claim. See
-    [Configuration](configuration.md#classification-crown-jewels). (The former
-    `auto_classify` boolean has been replaced by these explicit, previewable
-    rules.)
+!!! note "Content-based classification is not yet available"
+    Classification rules accept a `content_class` dimension, intended to let
+    detected data content drive sensitivity, but content detection is not live
+    in the current release — declare your crown jewels by account, name,
+    resource type, label, or tag. (The former `auto_classify` boolean has been
+    retired in favour of these explicit, previewable rules.)
 
 In the console, the same policy is authored on **Cloud Security → Policies →
 Data classification**, where a live **Simulate** panel shows exactly which

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -48,6 +48,22 @@ sidebar, but its pages show an "enable Cloud Security" screen — with a link to
     the other pages redirect there. The full set of pages appears once a
     provider exists and its first sweep has data.
 
+### Free tier and trial
+
+Organizations on the free tier (a configured sensor quota of 2 or fewer) can
+trial Cloud Security without upgrading: up to **2 provider connections**, with
+collection running for **14 days** from the day Cloud Security was enabled.
+The Overview page shows the trial banner, and
+[`GET /free-tier`](api-reference.md) reports the standing and limits.
+
+When the trial ends (or a third provider is added), the affected collection
+pauses rather than erroring: the reason appears as the provider's status in
+**Settings → Providers** and in `scan-status`. Nothing is deleted immediately
+and none of your configuration is touched — provider records, credentials, and
+policies all survive — so upgrading resumes collection where it left off within
+minutes. Trial data does age out eventually if the organization stays on the
+free tier.
+
 ## 2. Connect a provider
 
 A provider connection is one `cloudsec_provider` record. Each provider needs a

--- a/docs/cloud-security/graph.md
+++ b/docs/cloud-security/graph.md
@@ -13,22 +13,29 @@ facts into one critical finding — and it is directly explorable.
 ## The graph model
 
 Nodes are addressed by URN (the same `lcrn:` identifiers used across the
-API) and carry type-specific properties: exposure (`is_public`), sensitivity
-(`is_sensitive`), vulnerability context (`cve`, `severity`, `in_kev`,
-`cvss_score`), and identity insight (human/service kind, external flag, MFA
-posture, dormancy, escalation potential, least-privilege suggestions).
+API — canonically `lcrn:1:<oid>:<provider>:<type>:<rest>`, e.g. a VM's type
+segment is `compute_instance`) and carry type-specific properties: exposure
+(`is_public`), sensitivity (`is_sensitive`), vulnerability context (`cve`,
+`severity`, `in_kev`, `cvss_score`), and identity insight (human/service kind,
+external flag, MFA posture, dormancy, escalation potential, least-privilege
+suggestions).
 
 Edges carry the relationship semantics:
 
 | Edge | Meaning |
 |---|---|
-| `can_reach` | Network reachability between workloads |
-| `exposed_to` | Exposure to the internet / an external boundary |
+| `exposed_to` | Workload / AI endpoint → the internet (or another external boundary); carries the `via` mechanism |
+| `can_reach` | An internet-exposed workload → a **sensitive** workload or data store it can reach on the network. Not a general reachability index: the edge is materialized only from exposed sources to sensitive sinks, collapsed transitively, and carries the `hops` count and `protocol` of the path it stands for |
+| `reachable_from` | An internal entry point → the discovered external asset it is reachable from (the outside-in view) |
 | `has_vulnerability` | Workload → CVE (with package and fix version) |
-| `has_permission_on` | Identity → resource; carries the classified **access level** (the capability the grant confers — `data_admin` › `data_write` › `data_read` › `metadata` › `none`), which is the edge verb the UI shows |
+| `has_permission_on` | Identity → resource; carries the classified **access level** (the capability the grant confers — `data_admin` › `data_write` › `data_read` › `metadata` › `none`, plus `unknown`), which is the edge verb the UI shows |
 | `can_assume` | Identity → identity (role assumption / impersonation) |
-| `is_member_of` | Identity → group / account membership |
+| `is_member_of` | Identity → **group** identity (group membership; account containment is not this edge) |
 | `has_app_access` | Identity → application assignment (IdP surfaces) |
+| `runs_as` | AI service → the identity it runs as (its service-identity pivot) |
+| `runs_on` | Sensor — or a merged third-party asset — → the cloud workload it runs on (the runtime ↔ posture join) |
+| `owns_device` | Identity → a merged third-party device it owns (see [CAASM](caasm.md)) |
+| `member_of_group` | Workload → its workload group (cluster, node pool, scale set) |
 
 ## Attack paths
 
@@ -40,13 +47,21 @@ surfaced both as a `toxic_combination` finding and in the dedicated view:
 limacharlie cloudsec attack-path list --severity CRITICAL
 ```
 
+That list is the whole `toxic_combination` class, not only the network paths —
+it also carries the exposed foothold (an internet-facing workload with an
+exploitable vulnerability, even when nothing sensitive is reachable
+downstream), the identity path (a weakly-held identity — dormant admin, stale
+key, external or third-party principal — that can reach sensitive or
+privileged resources), and the CAASM hybrid (a privileged directory identity
+whose device fails a posture check; see [CAASM](caasm.md)).
+
 ## Exploring the graph
 
 Expand outward from any resource, one hop at a time — the API behind
-click-to-expand on the console's graph canvas:
+click-to-expand on the graph canvas of the **Attack Surface** page:
 
 ```bash
-limacharlie cloudsec graph neighbors "lcrn:gcp:...instance/web-1" --limit 200
+limacharlie cloudsec graph neighbors "lcrn:...:compute_instance:..." --limit 200
 ```
 
 The result is an induced subgraph (`nodes` + `edges`), ranked so sensitive
@@ -55,18 +70,22 @@ more neighbors than the cap (hard cap 500).
 
 ## Topology
 
-The interactive **Security graph** above (the Explore page canvas) is for
-traversal — expanding one hop at a time from a starting node. **Topology** is
-the other view: an aggregated, explorable diagram of the whole estate,
-laid out Provider → Account → Region → Resource. A node-type declutter filter
-hides the classes you don't care about, and the current view (filters,
-expansion) is captured in a shareable URL so a colleague opens exactly what
-you're looking at.
+The graph canvas above (on the **Attack Surface** page) is for traversal —
+expanding one hop at a time from a starting node. **Topology** is the other
+view: an aggregated, explorable diagram of the whole estate, laid out
+Provider → Account → Region → Resource. It is the landing view of the
+**Inventory** page, alongside **Resources**, **Third-party assets** and
+**Sensor coverage**. A node-type declutter filter hides the classes you don't
+care about, and the current view (filters, expansion) is captured in a
+shareable URL so a colleague opens exactly what you're looking at.
 
-Because it is backed by **server-side aggregates**, the counts on every node
-are exact at any scale — Topology never walks a capped page and then guesses.
-It is served by `GET /topology` (see [API Reference](api-reference.md)) and by
-`limacharlie cloudsec topology` on the CLI.
+It is backed by **server-side aggregates**, so the counts on every node are
+exact at any scale — no capped page, no guessing. The response says whether the
+aggregate is available for the organization yet; until it has been built the
+console falls back to a bounded client-side walk, which is the one case where
+counts reflect only what was walked. Topology is served by `GET /topology` (see
+[API Reference](api-reference.md)) and by `limacharlie cloudsec topology` on the
+CLI.
 
 ## Graph queries
 
@@ -81,7 +100,7 @@ limacharlie cloudsec query run --named public_data_stores
 limacharlie cloudsec query run --text 'MATCH (d:DataStore {is_sensitive: true})<-[:has_permission_on]-(i:Identity {is_external: true}) RETURN i, d'
 
 # The raw query DSL:
-limacharlie cloudsec query run --query-json '{...}' --project a,b
+limacharlie cloudsec query run --query-json '{...}'
 ```
 
 The text form is a compact graph-pattern grammar, not natural language:
@@ -90,20 +109,64 @@ nodes are `(alias:Label {prop: value, ...})`, edges are `<-[:edge_name]-`
 use underscores, and the query ends with `RETURN alias, alias...`. Inline
 predicates are AND-ed equalities.
 
-The first node is the **anchor**, and every query must anchor on a
-*selective* set and traverse inward. Bounded node types (data stores,
-vulnerabilities, public endpoints, applications, accounts) anchor as-is;
-dense types (workloads, identities) must be narrowed by a selective
-predicate — `is_sensitive: true`, `is_public: true`, `is_external: true`,
-`in_kev: true`, or an exact `email` / `sid`. A query that fans out from the
-dense fabric is rejected by design: restructure it to start from the
-selective end (the sensitive store, the known-exploited vulnerability, the
-specific identity) and walk toward the dense side.
+Any of the three forms can also be asked to return the result as something
+drawable: `project: "graph"` on the API call (see
+[API Reference](api-reference.md)) adds an induced subgraph — `nodes` + `edges`
+over the matched URNs — next to the rows. That is what the **Query console** tab
+of the **Attack Surface** page renders. `graph` is the only projection there is;
+the rows are always complete, and only the drawing is capped.
 
-Results are rows of alias → URN bindings; use
-`limacharlie cloudsec resource get <urn>` to hydrate any URN into its full
-canonical record (this also works for derived nodes — vulnerabilities,
-identities — that have no inventory row).
+!!! note "Edge names: underscores in the text form, hyphens in the DSL"
+    The text form uses the underscore spelling shown in the edge table above
+    (`has_permission_on`). The raw JSON DSL uses the hyphen spelling
+    (`has-permission-on`) — `{"in": "has_permission_on"}` is rejected as an
+    unknown edge. Node type names (`DataStore`, `ComputeInstance`, …) are
+    identical in both.
+
+The first node is the **anchor**, and every query must anchor on a
+*selective* set and traverse inward. Bounded node types anchor as-is; dense
+types must be narrowed by a selective predicate. A query that fans out from the
+dense fabric is rejected by design: restructure it to start from the selective
+end (the sensitive store, the known-exploited vulnerability, the specific
+identity) and walk toward the dense side.
+
+| | Node types | Anchoring |
+|---|---|---|
+| **Bounded** | `DataStore`, `Vulnerability`, `PublicEndpoint`, `Application`, `ExternalAsset`, `AIService`, `Account`, `ComputeGroup` | Anchor as-is |
+| **Dense** | `ComputeInstance`, `Identity`, `Endpoint`, `ThirdPartyAsset` | Need a selective predicate: `is_sensitive: true`, `is_public: true`, `is_external: true`, `in_kev: true`, or an exact `email` / `sid`. The booleans only count when `true` — `{is_sensitive: false}` matches nearly everything and is refused |
+
+Predicates draw from a per-type allow-list that is narrower than the properties
+a node *displays*: `ComputeInstance` admits `name` / `is_public` /
+`is_sensitive`; `Identity` admits `kind`, `is_human`, `is_public`,
+`is_external`, `email`, `mfa_enabled`, `status`; `DataStore` adds `store_kind`;
+`Vulnerability` admits `cve` / `severity` / `in_kev` — but *not* `cvss_score`,
+which is shown on the node and is not filterable. `ThirdPartyAsset` admits only
+`name` / `asset_kind`, neither of which is selective, so a merged third-party
+asset is reachable by traversal but can never be the anchor. An off-list field
+fails validation with a clear message rather than returning odd results. Edge
+predicates work the same way: `has_permission_on` filters on `effect`, `role`,
+`granted_via`, `privileged`; `can_reach` on `protocol`; `has_vulnerability` on
+`severity`; `runs_on` on `confidence`; `owns_device`, `member_of_group`,
+`is_member_of` and `runs_as` carry no filterable properties.
+
+Results are bounded: 1000 rows by default and 10000 at most, raised with the
+DSL's `limit` field — the text grammar has no limit clause, so it always takes
+the default. Rows are alias → URN
+bindings; use `limacharlie cloudsec resource get <urn>` to hydrate any URN into
+its full canonical record (this also works for derived nodes —
+vulnerabilities, identities — that have no inventory row).
+
+### Shortest-path queries
+
+Instead of a fixed chain of edges, the JSON DSL can ask a variable-length
+question — "is there a *short* path from this principal to a crown jewel?" —
+with a `path` block in place of `match`: a direction, the edge labels each hop
+may use, a hop bound (`max`, up to 12), and the target node. The answer is
+ordered paths rather than alias rows, and the graph projection draws the whole
+kill chain. `shortest_access_path_external_to_sensitive_data` in the built-in
+pack is the worked example: the shortest chain of grants and assume-role hops by
+which an identity outside the organization reaches a sensitive data store. This
+form is DSL-only — the text grammar expresses fixed chains.
 
 Queries worth keeping become `cloudsec_query` Hive records — shared,
 versioned, and IaC-manageable (see
@@ -111,7 +174,7 @@ versioned, and IaC-manageable (see
 
 ## Identity: CIEM views
 
-The console calls this area **Identity & Access**. Two dedicated identity
+The console calls this area **Identity & Access**. Three dedicated identity
 reads sit on top of the graph:
 
 ```bash
@@ -120,6 +183,9 @@ limacharlie cloudsec ciem public-access
 
 # Identity facet counts (kinds, external/public splits).
 limacharlie cloudsec ciem facets
+
+# Everything one principal can reach — the Identity 360 rollup (below).
+limacharlie cloudsec ciem identity "lcrn:...:identity:..."
 ```
 
 Access is scored by the **capability** a grant confers, not the mere existence
@@ -129,19 +195,32 @@ sensitive data" gates on `data_read`-or-higher; `metadata`/`none` grants are a
 lower-severity reconnaissance signal rather than a top data-access risk. That
 level is stamped on the `has_permission_on` edge and is the verb the UI shows.
 
+There is a sixth level, `unknown`: the grant's effective action set could not be
+verified (a role that could not be expanded, so only its verbatim name is
+known). It counts as *potential* data access — it passes the sensitive-data gate
+rather than being silently dropped, and what it produces is flagged as
+unverified so an unexpanded owner-class grant is never mistaken for a clean
+result. It deliberately satisfies no "at least this level" comparison, so it can
+never be ranked as if it were confirmed.
+
 Identity findings (dormant privileged identities, escalation edges, unused
 privileges) surface in the main worklist under the `ciem_risk` and
-`privilege_escalation` classes. External-vs-internal classification is
-driven by the provider record's `internal_domains` — keep it complete.
+`privilege_escalation` classes. External-vs-internal classification is driven by
+the provider record's `internal_domains`, unioned with the primary domain the
+provider discovers on its own (a single primary is not enough — the
+organization's own users on secondary or verified domains would be classified
+external), so declare every additional domain you own.
 
 ### Identity 360
 
 For a single identity, **Identity 360** is the one-screen view of everything
 it can reach — direct grants, group-inherited permissions, identities it can
-assume, and application assignments — plus a **devices** lane pulling in the
-endpoints associated with that identity. Each reach edge carries its classified
-access level, so the whole effective blast radius is visible in one place. It
-is the console's Identity & Access → *(an identity)* drill-down, served by
+assume, and application assignments — plus a **devices** lane listing the merged
+third-party devices the identity owns (the `owns_device` edge from
+[CAASM](caasm.md), not the sensors reporting into the organization). Each reach
+edge carries its classified access level, so the whole effective blast radius is
+visible in one place. It is the console's Identity & Access → *(an identity)*
+drill-down, served by
 `GET /cloudsec/{oid}/ciem/identity?urn=<identity-urn>` (see
 [API Reference](api-reference.md)) and by
 `limacharlie cloudsec ciem identity "<identity-urn>"` on the CLI.
@@ -153,12 +232,16 @@ limacharlie cloudsec data-security facets
 ```
 
 Returns the data-store posture rollup: total stores, sensitive, public, and
-public-*and*-sensitive counts, plus store-kind / sensitivity / exposure
-histograms. Sensitivity is your declaration: `classification`-policy
-`content_class` and name/`resource_type` rules decide what counts as sensitive
-(the retired `auto_classify` boolean is gone). The agentless scanner still
-detects content classes and surfaces them as facts on a resource, but only a
-matching `content_class` rule turns a detection into a sensitivity claim — see
+public-*and*-sensitive counts, plus seven facet dimensions — `store_kind`,
+`sensitivity`, `exposure`, `criticality` (the crown-jewel tier),
+`provider`, `account`, and `data_class` (the classifier labels a store
+carries). The facets are cross-filtered: each dimension is counted under every
+*other* selector but not its own, so a value's number tells you how many stores
+you would see if you added it. Sensitivity is your declaration:
+`classification`-policy rules matching on account, name, resource type, label,
+or tag decide what counts as sensitive (the retired `auto_classify` boolean is
+gone, and the `content_class` dimension is accepted but content detection is
+not live in the current release) — see
 [Configuration](configuration.md#classification-crown-jewels).
 
 ## Inventory
@@ -172,10 +255,22 @@ limacharlie cloudsec inventory list \
 limacharlie cloudsec inventory facets
 ```
 
-This is the first-party cloud inventory. **Third-party (CAASM) assets** — the
-entity-resolved devices and identities merged from EDR, IdP, MDM, and scanner
-sources — live in their own inventory tab and have their own reads; see
-[CAASM](caasm.md).
+This is the whole system-of-record, cloud resources and third-party assets
+alike. Two of the types are served *merged* rather than raw, because their
+underlying rows are per-observing-source:
+
+- `--type ThirdPartyAsset` returns the entity-resolved CAASM assets — one row
+  per real device or identity, with per-source provenance retained. The
+  provider / account / region filters don't apply to a cross-source merged
+  asset; the type is the scope selector. The console shows these in the
+  **Third-party assets** view of the **Inventory** page, which appears once the
+  organization has any.
+- `--type Identity` likewise returns one entity per human rather than one row
+  per observing sweep, stamped with the providers that saw it. Here the scope
+  filters keep their meaning and match any producing observation.
+
+See [CAASM](caasm.md) for the merge itself and the dedicated third-party
+asset reads.
 
 ## Sensors ↔ cloud assets
 
@@ -187,8 +282,12 @@ posture (cloud assets), in bulk:
 limacharlie cloudsec resolve sensors $SID1 $SID2
 
 # Which sensors run on this asset?
-limacharlie cloudsec resolve assets "lcrn:...instance/web-1"
+limacharlie cloudsec resolve assets "lcrn:...:compute_instance:..."
 ```
 
 Each response splits `resolved` and `unresolved`, so a pivot from a cloud
-finding to live endpoint telemetry (or the reverse) is one call.
+finding to live endpoint telemetry (or the reverse) is one call. It also carries
+`resolver_ready`. When that is `false` the resolver is not available for the
+organization and *everything* comes back unresolved regardless of what you
+asked — which is a different answer from "the resolver ran and matched
+nothing". Check it before concluding that a sensor has no cloud asset.

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -25,7 +25,7 @@ rules, Cases, and Outputs you already use.
 | **Inventory (CSPM)** | A continuously refreshed system-of-record of your cloud resources — compute, storage, networking, identities — with misconfiguration findings per resource. |
 | **Attack paths** | Toxic combinations across resources: an internet-exposed workload with a known-exploited vulnerability that can reach sensitive data is one finding, not three disconnected ones. |
 | **Identity (CIEM)** | Who — human or service — can access what: public/external access to sensitive resources, privilege-escalation edges, dormant privileged identities. Access is scored by the *capability* a grant actually confers, not by the mere existence of a grant. |
-| **Data security (DSPM)** | Which data stores exist, which are sensitive (you declare it by policy, optionally augmented by content-based classification rules), and which sensitive stores are exposed. |
+| **Data security (DSPM)** | Which data stores exist, which are sensitive (you declare it by policy), and which sensitive stores are exposed. |
 | **AI security (AISPM)** | Your OpenAI and Anthropic organizations as first-class estate: members, API keys, projects, and posture — with the same findings and compliance lenses (`nist-ai-rmf`, `owasp-llm`). |
 | **Compliance** | Per-control pass/fail assessment of frameworks over the live estate, whole-estate or scoped to named assignments. |
 | **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources, including LimaCharlie's own sensors) with coverage-gap and device-posture findings — "seen by the identity provider, no EDR". |
@@ -54,8 +54,10 @@ demand, or continuously from a change feed. See
 
 ## How it works
 
-1. **Subscribe** the organization to the `ext-cloud-security` extension —
-   this is the product's enable (and billing) gate.
+1. **Enable** the organization for the `ext-cloud-security` extension — the
+   subscription is the product's enable (and billing) gate. While Cloud
+   Security is in Private Beta, contact us to have it enabled for your
+   organization.
 2. **Connect providers**: one `cloudsec_provider` Hive record per cloud
    account / IdP tenant / AI org. A pre-save credential test probes every
    permission the collector needs and reports which are missing.
@@ -67,10 +69,11 @@ demand, or continuously from a change feed. See
    chokepoint analysis, and full automation through `cloud_finding.*`
    events.
 
-Everything the console shows is also available through the
+Nearly everything the console shows is also available through the
 [REST API](api-reference.md), the [CLI](cli.md), and — for configuration —
 plain [Hive records](configuration.md), so a fleet of tenants can be
-onboarded and governed as code.
+onboarded and governed as code. (A few surfaces are console-only, notably the
+printable posture report.)
 
 ## In the console
 
@@ -80,14 +83,13 @@ map onto the capabilities above:
 | Page | What it is |
 |---|---|
 | **Overview** | The risk overview: score, severity distribution, top attack paths and the marquee chokepoint. |
-| **Risks** | The findings worklist, with lenses (Public exposure & misconfig / Identity / Workload / Vulnerabilities / Data) and per-finding triage. |
-| **Attack Paths** | The toxic-combination paths, grouped by shared fix. |
-| **Identity & Access** | CIEM — who can reach what, with a single-identity "Identity 360" view. |
+| **Risks** | The findings worklist, with lenses (All risks / Public exposure & misconfig / Identity / Vulnerabilities / Data) and per-finding triage. |
+| **Attack Surface** | The toxic-combination paths, grouped by shared fix, on an interactive graph canvas — plus a **Query console** tab for ad-hoc graph queries and saved queries. |
+| **Identity & Access** | CIEM — who can reach what, with a per-identity drill-down (**Grants** and **Access map** tabs). |
 | **Data Security** | DSPM — data-store posture and exposure. |
-| **Inventory** | The resource system-of-record, plus Third-party assets and Sensor coverage (CAASM) tabs. |
-| **Topology** | An aggregated, explorable diagram of the estate. |
+| **Inventory** | The estate itself, in four views: **Topology** (the landing view — an aggregated diagram of the estate), **Resources** (the resource system-of-record), **Third-party assets**, and **Sensor coverage** (CAASM). |
 | **Compliance** | Per-control framework assessment and scoped assignments. |
-| **Explore** | The interactive Security graph and the Query console. |
+| **Report** | A print-optimized posture report over the current estate, also reachable from **Overview → View report**. |
 | **Policies** | Data classification (crown jewels), coverage, asset coverage, exclusions, and suppression. |
 | **Settings** | Provider connections and the Cases integration. |
 
@@ -105,14 +107,18 @@ organization you manage.
       credential tests).
     - `cloudsec_provider.get` / `.set` / `.del` — manage provider
       connection records in the Hive.
+    - `cloudsec_provider.get.mtd` / `.set.mtd` — read and write the records'
+      user metadata (tags, comments, enabled state).
 
     Every route additionally requires the organization to be subscribed to
-    `ext-cloud-security`; unsubscribed organizations receive `403`.
+    `ext-cloud-security`. API calls from an unsubscribed organization return
+    `403`; in the console the Cloud Security pages render an "enable Cloud
+    Security" screen instead of the product.
 
 ## Documentation
 
-- [Getting Started](getting-started.md) — subscribe, connect a provider, run
-  your first sweep.
+- [Getting Started](getting-started.md) — enable the product, connect a
+  provider, run your first sweep.
 - [Connecting Providers](providers.md) — the thirteen connectors, their
   credentials, and what each collects.
 - [Provider Setup](provider-setup/index.md) — onboarding walkthrough for every

--- a/docs/cloud-security/provider-setup/anthropic.md
+++ b/docs/cloud-security/provider-setup/anthropic.md
@@ -6,7 +6,8 @@
     availability. Contact us if you would like access.
 
 Collects your Anthropic organization as an AI-security surface: the member
-directory, workspaces, and API keys from the Console plane, plus — for Claude
+directory (including pending invites — staged seats that have never logged in),
+workspaces, and API keys from the Console plane, plus — for Claude
 Enterprise organizations — enforced security settings and a per-key/per-user
 activity feed that powers dormancy findings.
 
@@ -66,19 +67,24 @@ Compliance scopes only, restricted to their own organization.
 |---|---|
 | `read:compliance_org_data` | Enforced organization security settings |
 | `read:compliance_activities` | The activity feed — per-key and per-user last-used, which drives dormancy findings |
-| `read:analytics` | Usage analytics |
 
-!!! tip "One scope covers it"
-    Anthropic also offers `read:org_audit` — a single read-only scope covering
-    the Admin API read endpoints plus every Compliance API read endpoint,
-    intended for security-audit integrations. It is the simplest choice for
-    this connector. Note it does **not** include the Analytics API, so add
-    `read:analytics` alongside it if you want usage analytics.
+Those two are the whole ask. Anthropic's `read:analytics` scope is **not used by
+this connector today** — no usage-analytics endpoint is called, so adding it
+unlocks nothing here.
+
+!!! tip "The broad audit scope also works"
+    Anthropic offers `read:org_audit`, a single read-only scope covering the
+    Admin API read endpoints plus every Compliance API read endpoint, intended
+    for security-audit integrations. A Compliance key carrying it works fine
+    here. Be aware that only its *Compliance* coverage is exercised: this
+    connector reaches the Console plane exclusively through the Admin key on
+    `credentials`, so `read:org_audit` on a Compliance key is not a substitute
+    for connecting the Console plane.
 
 !!! warning "Scopes are fixed at creation"
-    To add a scope later you must create a new key. The Compliance and
-    Analytics APIs must also be **enabled for your organization** before keys
-    carrying those scopes will work.
+    To add a scope later you must create a new key. The Compliance API must
+    also be **enabled for your organization** before a key carrying Compliance
+    scopes will work.
 
 You will also need the **organization UUID** (8-4-4-4-12 hex), which addresses
 the Compliance API.
@@ -98,15 +104,22 @@ the Compliance API.
 ```
 
 Bare key strings are accepted for both and wrapped into these shapes
-automatically. Keep the two in separate secrets — the provider record
-references them independently and they are merged at runtime.
+automatically, so the simplest path is to store the key verbatim:
 
 ```bash
-limacharlie hive set --hive-name secret --key anthropic-admin \
-    --input-file anthropic-admin.json --enabled
-limacharlie hive set --hive-name secret --key anthropic-compliance \
-    --input-file anthropic-compliance.json --enabled
+limacharlie secret set --key anthropic-admin \
+    --value 'sk-ant-admin01-...' --enabled
+limacharlie secret set --key anthropic-compliance \
+    --value 'sk-ant-api01-...' --enabled
 ```
+
+`secret set` wraps whatever you pass in `--value` into the secret record's
+`{"secret": "..."}` shape for you. Pass the JSON object above instead of a bare
+key when the secret needs a second field — see
+[workload identity federation](#optional-workload-identity-federation-inventory).
+
+Keep the two planes in separate secrets — the provider record references them
+independently and they are merged at runtime.
 
 ## Create the provider record
 
@@ -153,7 +166,7 @@ limacharlie cloudsec provider test --input-file provider.yaml
 
 | Check | Required | Meaning if it fails |
 |---|:--:|---|
-| `auth` | ✅ | Neither plane's key authenticated. |
+| `auth` | ✅ *(Console)* | The Console Admin key was rejected, or it belongs to a different organization than the `anthropic_org_uuid` you set. This check covers the **Console plane only** and appears only when a Console key is configured — the rest of the Console plane is not probed after it fails. A Compliance-only connection has no `auth` row; `compliance_settings` is its gate. |
 | `directory` | ✅ *(Console)* | Member directory unreadable. |
 | `workspaces` | ✅ *(Console)* | Workspace inventory unreadable. |
 | `api_keys` | ✅ *(Console)* | API-key inventory unreadable. |

--- a/docs/cloud-security/provider-setup/auth0.md
+++ b/docs/cloud-security/provider-setup/auth0.md
@@ -14,6 +14,13 @@ policy, attack protection, and session lifetimes.
 **Auth model:** a **Machine-to-Machine application** authorized against the
 **Auth0 Management API** with read-only scopes, using client credentials.
 
+!!! info "Auth0 Organizations are not collected"
+    **Auth0 Organizations (B2B)** — organizations, their members, and
+    organization-scoped role assignments — are outside the current coverage. On
+    a tenant that uses them, users, roles and applications are still
+    inventoried tenant-wide; what is missing is the per-organization
+    membership and role scoping. Granting extra scopes does not change this.
+
 ## Prerequisites
 
 - Auth0 tenant admin access.
@@ -82,9 +89,12 @@ checkboxes → **Update**.
 ```
 
 ```bash
-limacharlie hive set --hive-name secret --key auth0-m2m \
-    --input-file auth0-secret.json --enabled
+limacharlie secret set --key auth0-m2m \
+    --value "$(cat auth0-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you.
 
 ## Create the provider record
 

--- a/docs/cloud-security/provider-setup/aws.md
+++ b/docs/cloud-security/provider-setup/aws.md
@@ -11,7 +11,10 @@ Two topologies:
 - **Single account** (below): one IAM user plus one role in that account.
 - **AWS Organization:** deploy the same role to every account via a
   service-managed CloudFormation StackSet and set `aws_member_role_name`; the
-  base user additionally needs `organizations:List*` / `Describe*`.
+  **management-account role** named by `aws_role_arn` additionally needs
+  `organizations:List*` / `Describe*`. The base IAM user still needs nothing
+  beyond `sts:AssumeRole` — member-account discovery is performed with the
+  assumed role, not with the user's own credentials.
 
 ## Architecture (least-privilege)
 
@@ -70,17 +73,24 @@ aws iam create-access-key --user-name lc-cloudsec   # capture AccessKeyId + Secr
 {"access_key_id": "AKIA...", "secret_access_key": "..."}
 ```
 
-!!! warning "No `aws_` prefix"
+!!! warning "No `aws_` prefix, and no other keys"
     `aws_access_key_id` / `aws_secret_access_key` are silently ignored — the
     SDK then falls back to the default credential chain and the auth check
     fails with `no EC2 IMDS role found`. Use the bare `access_key_id` /
-    `secret_access_key` keys. (Optional third key: `session_token` for
-    temporary credentials.)
+    `secret_access_key` keys. Those two are the only keys read: a
+    `session_token` is **not** supported, so temporary/session credentials
+    cannot be used here (they are dropped, and the assume then fails with
+    `InvalidClientTokenId`). Use the long-lived access key of the dedicated IAM
+    user — the role it assumes is where the read permissions live.
 
 ```bash
-limacharlie hive set --hive-name secret --key aws-credentials \
-    --input-file aws-secret.json
+limacharlie secret set --key aws-credentials \
+    --value "$(cat aws-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record for you — the equivalent of
+`limacharlie hive set --hive-name secret` with `{"secret": "<the credential JSON
+as a string>"}`.
 
 ## Create the provider record
 
@@ -101,13 +111,17 @@ credentials: hive://secret/aws-credentials
 limacharlie cloudsec provider test --input-file provider.yaml
 ```
 
+The report opens with the `config` and `credential` checks common to every
+provider, [documented once in Provider Setup](index.md#the-two-checks-every-provider-reports-first);
+the AWS-specific checks follow.
+
 | Check | Required | Meaning if it fails |
 |---|:--:|---|
 | `auth` | ✅ | `sts:AssumeRole` failed — wrong external ID, trust policy, or credentials. Nothing else is probed. |
 | `ec2` | ✅ | Compute inventory unavailable. |
 | `iam` | ✅ | IAM inventory unavailable — the CIEM access graph cannot be built. |
 | `s3` | ✅ | Storage inventory unavailable. |
-| `regions` | — | Enabled-region enumeration unavailable; the sweep falls back to `aws_regions` or defaults. |
+| `regions` | — | Only meaningful when `aws_regions` is **unset** (with it set the check is skipped as unnecessary, and still counts as passing). Enabled-region enumeration was denied, so the sweep falls back to `us-east-1` alone — list the regions you want in `aws_regions`. |
 | `organizations` | — | Member-account discovery unavailable; only the connected account is swept. |
 | `inspector` | — | Workload vulnerability findings unavailable. |
 | `secrets_manager` | — | Secret-store inventory unavailable. |

--- a/docs/cloud-security/provider-setup/azure.md
+++ b/docs/cloud-security/provider-setup/azure.md
@@ -40,7 +40,7 @@ licensed, Conditional Access and sign-in activity.
 | Grant | Unlocks | Preflight check |
 |---|---|---|
 | **Policy.Read.All** (application) | Conditional Access policy posture | *(collected during the sweep)* |
-| **AuditLog.Read.All** (application) | Last-sign-in / dormancy enrichment on identities. **Requires an Entra ID P1 or P2 licence** — without the licence the report is unavailable regardless of consent | `signin_activity` |
+| **AuditLog.Read.All** (application) | Two things: last-sign-in / dormancy enrichment on identities, and each identity's **MFA-registration state** (whether the user is MFA-registered / MFA-capable, from the authentication-methods registration report). **Requires an Entra ID P1 or P2 licence** — without the licence the reports are unavailable regardless of consent | `signin_activity` covers the sign-in half only |
 | **RoleManagement.Read.Directory** (application) | Directory role assignments and PIM eligibility | *(collected during the sweep)* |
 | **Application.Read.All** (application) | Fuller app-registration / service-principal credential detail | *(collected during the sweep)* |
 | **AdministrativeUnit.Read.All** (application) | Administrative-unit scoping | *(collected during the sweep)* |
@@ -49,6 +49,12 @@ licensed, Conditional Access and sign-in activity.
 
 A denied Graph permission 403s only its own collector — that surface goes
 unobserved while everything else still collects.
+
+!!! note "MFA-registration state has no preflight check of its own"
+    The `signin_activity` check probes the sign-in report only. MFA-registration
+    state is read during the sweep, so if that particular report is denied or
+    unlicensed the provider test still passes and the symptom is identities with
+    **no MFA-registration information** rather than a failing check.
 
 ## Create the app registration
 
@@ -108,9 +114,13 @@ az ad app permission admin-consent --id "$APP_ID"
 ```
 
 ```bash
-limacharlie hive set --hive-name secret --key azure-sp \
-    --input-file azure-secret.json --enabled
+limacharlie secret set --key azure-sp \
+    --value "$(cat azure-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record for you — the equivalent of
+`limacharlie hive set --hive-name secret` with `{"secret": "<the credential JSON
+as a string>"}`.
 
 ## Create the provider record
 
@@ -134,13 +144,18 @@ refresh: 6h
     back to the single configured subscription.
 
 In the web app: **Add provider → Azure**, then set **Tenant ID**, **Client
-ID**, **Subscription ID**, **Credentials**, and **Refresh interval**.
+ID**, **Subscription ID**, **Credentials**, and the **Sync cadence** (pick a
+preset, or **Custom interval** for a duration of your own).
 
 ## Verify
 
 ```bash
 limacharlie cloudsec provider test --input-file provider.yaml
 ```
+
+The report opens with the `config` and `credential` checks common to every
+provider, [documented once in Provider Setup](index.md#the-two-checks-every-provider-reports-first);
+the Azure-specific checks follow.
 
 | Check | Required | Meaning if it fails |
 |---|:--:|---|

--- a/docs/cloud-security/provider-setup/cloudflare.md
+++ b/docs/cloud-security/provider-setup/cloudflare.md
@@ -20,8 +20,9 @@ Custom Token.**
 !!! note "User tokens live elsewhere"
     Tokens created under **My Profile → API Tokens** are *user*-owned. One
     scoped to the account also works for the surfaces below, but it is tied to
-    an individual. A user token is only strictly needed for the optional
-    [account-members and API-token surfaces](#optional-account-members-and-api-tokens).
+    an individual. A user token is only needed to enumerate *user*-owned API
+    tokens, and as a fallback for account membership — see
+    [account members and user-owned API tokens](#optional-account-members-and-user-owned-api-tokens).
 
 **Minimum permissions** (the required checks — authenticate plus the
 zones/DNS inventory):
@@ -30,6 +31,13 @@ zones/DNS inventory):
 |---|---|---|
 | Account | Account Settings | Read |
 | Zone | Zone | Read |
+| Zone | DNS | Read |
+
+!!! warning "DNS: Read is not covered by the preflight check"
+    The `zones` check reads the zone *list*, which needs only **Zone: Read** — so
+    a token without **DNS: Read** passes preflight and then collects zero DNS
+    records. Every check that depends on record-level data, such as unproxied
+    origin IPs published in public DNS, then silently never fires. Grant both.
 
 **Optional permissions** — each lights up an additional inventory surface
 (skip any you do not want):
@@ -45,13 +53,21 @@ Scope the token's resources:
 - **Account Resources:** Include → your account.
 - **Zone Resources:** Include → All zones.
 
-Copy the token (it is shown once). You can confirm it independently:
+Copy the token (it is shown once). You can confirm it independently — an
+account-owned token introspects under the account:
 
 ```bash
 curl -s -H "Authorization: Bearer <TOKEN>" \
-  https://api.cloudflare.com/client/v4/user/tokens/verify
+  https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/tokens/verify
 # "status":"active" confirms it is valid
 ```
+
+!!! note "Each token kind has its own verify endpoint"
+    `/accounts/<ACCOUNT_ID>/tokens/verify` introspects **account-owned** tokens
+    only; the equivalent for a *user*-owned token is `/user/tokens/verify`. A
+    token that verifies under the wrong one returns 401 even though it works
+    fine. `provider test` sidesteps this entirely: it authenticates by reading
+    the account itself, which works for either kind.
 
 ## Get the account ID
 
@@ -60,14 +76,19 @@ dashboard URL.
 
 ## Create the credentials secret
 
+Save the credential JSON as `cf-secret.json`:
+
 ```json
 {"api_token": "<the-scoped-read-only-token>"}
 ```
 
 ```bash
-limacharlie hive set --hive-name secret --key cloudflare-credentials \
-    --input-file cf-secret.json
+limacharlie secret set --key cloudflare-credentials \
+    --value "$(cat cf-secret.json)" --enabled
 ```
+
+`secret set` wraps whatever you pass in `--value` into the secret record's
+`{"secret": "..."}` shape for you.
 
 ## Create the provider record
 
@@ -90,23 +111,34 @@ limacharlie cloudsec provider test --input-file provider.yaml
 
 | Check | Required | Meaning if it fails |
 |---|:--:|---|
-| `auth` | ✅ | The token was rejected, or it cannot see the configured account. |
-| `zones` | ✅ | Zone and DNS inventory unavailable. |
-| `access` | — | Zero Trust Access apps, identity providers, and service tokens unavailable. |
-| `security_center` | — | Security Center findings unavailable. |
-| `r2` | — | R2 storage inventory unavailable. |
-| `user_scoped` | — | Account members and API-token enumeration unavailable — these are user-scoped endpoints and need `user_api_token` in the secret. |
+| `auth` | ✅ | The token was rejected (401), or it is valid but missing **Account Settings: Read** (403), or it cannot see the configured account. A failure here stops the run — nothing else is probed. |
+| `zones` | ✅ | Zone inventory unavailable. Note this reads the zone list only; see the DNS caveat above. |
+| `access` | — | Zero Trust Access apps, identity providers, and service tokens unavailable. Passes with a note when Zero Trust Access is not enabled on the account. |
+| `security_center` | — | Security Center findings unavailable. Passes with a note when Security Center is not available on the account's plan. |
+| `r2` | — | R2 storage inventory unavailable. Passes with a note when R2 is not enabled on the account. |
+| `user_scoped` | — | The configured `user_api_token` could not read account members and/or user-owned API tokens. Passes with a note when no `user_api_token` is configured at all. |
 
-The optional checks pass only if you added the matching token permissions.
+Each optional check passes when the matching token permission is present. It
+**also passes, with a note**, when the product itself is not enabled on the
+account or plan — there is genuinely nothing to collect, which is a true empty
+rather than a coverage gap. An optional check fails only on a real permission
+denial or a connectivity problem.
 
-### Optional: account members and API tokens
+### Optional: account members and user-owned API tokens
 
-Account membership and API-token enumeration are served by **user-scoped**
-endpoints that an account-owned token cannot reach. To cover them, create a
-second token under **My Profile → API Tokens** and add it to the same secret:
+Two surfaces may want a *user*-owned token:
+
+- **Account members** — read with the account token first, falling back to the
+  user token, so on many accounts the account token alone is enough.
+- **API tokens** — account-owned tokens are enumerated with the account token;
+  **user**-owned tokens can only be enumerated with a user token.
+
+To cover both regardless, create a second token under **My Profile → API
+Tokens** and add it to the same secret:
 
 ```json
 {"api_token": "<account-scoped-token>", "user_api_token": "<user-owned-token>"}
 ```
 
-Without it those two surfaces are simply unobserved.
+Without it, account members are collected only if the account token can read
+them, and user-owned tokens are simply unobserved.

--- a/docs/cloud-security/provider-setup/entra.md
+++ b/docs/cloud-security/provider-setup/entra.md
@@ -10,7 +10,9 @@ Microsoft 365 but have no Azure infrastructure to enumerate. It collects the
 tenant-global identity surface over Microsoft Graph: users, groups and
 membership, service principals and app registrations (with their long-lived
 credentials), directory roles and PIM eligibility, Conditional Access policies,
-and administrative units.
+administrative units, and the tenant's **federated domains** — the external
+identity providers (ADFS and other SAML/WS-Fed trusts) that can assert
+identities into the tenant.
 
 **Auth model:** an **Entra ID app registration** (service principal) with a
 **client secret** and **Microsoft Graph application permissions**. There is no
@@ -37,7 +39,7 @@ ARM/subscription setup at all.
 
 | Grant | Type | Why | Preflight check |
 |---|---|---|---|
-| **Directory.Read.All** | Microsoft Graph — **Application** | Users, groups, service principals, app registrations, domains, directory roles | `graph_directory` |
+| **Directory.Read.All** | Microsoft Graph — **Application** | Users, groups, service principals, app registrations, domains (including federated-domain / external-IdP posture), directory roles and their active assignments | `graph_directory` |
 
 ## Optional permissions
 
@@ -45,10 +47,16 @@ ARM/subscription setup at all.
 |---|---|---|
 | **AuditLog.Read.All** | Last-sign-in / dormancy enrichment. **Requires Entra ID P1 or P2** | `signin_activity` |
 | **Policy.Read.All** | Conditional Access policy posture | *(collected during the sweep)* |
-| **RoleManagement.Read.Directory** | Directory role assignments and PIM eligibility | *(collected during the sweep)* |
+| **RoleManagement.Read.Directory** | PIM *eligibility* — who can activate a privileged role just-in-time. **Also requires Entra ID P1 or P2**: without the licence the PIM endpoints refuse the call no matter what is consented | *(collected during the sweep)* |
 | **Application.Read.All** | Fuller app-registration / service-principal credential detail | *(collected during the sweep)* |
 | **AdministrativeUnit.Read.All** | Administrative-unit scoping | *(collected during the sweep)* |
 | **AgentIdentity.Read.All** | Source-asserted AI-agent identities in the directory | *(collected during the sweep)* |
+
+!!! info "Skipping the PIM grant is safe"
+    Without `RoleManagement.Read.Directory` (or without the P1/P2 licence) the
+    directory-role graph is still collected from **active** assignments, which
+    ride `Directory.Read.All`. You lose just-in-time *eligibility* edges, not
+    the roles themselves.
 
 ## Create the app registration
 
@@ -95,9 +103,12 @@ az ad app permission admin-consent --id "$APP_ID"
 ```
 
 ```bash
-limacharlie hive set --hive-name secret --key entra-sp \
-    --input-file entra-secret.json --enabled
+limacharlie secret set --key entra-sp \
+    --value "$(cat entra-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you.
 
 ## Create the provider record
 
@@ -134,7 +145,7 @@ limacharlie cloudsec provider test --input-file provider.yaml
 
 | `provider test` result | Cause | Fix |
 |---|---|---|
-| `auth` fails with `invalid_client` | Stored the secret **ID** instead of its **Value**, or the secret expired | Re-mint the secret and update the hive secret |
+| `auth` fails with `invalid_client` | Stored the secret **ID** instead of its **Value**, or the secret expired | Re-mint the secret and update the secret record |
 | `graph_directory` fails after consent | Permissions added as *Delegated*, or consent not actually granted | Add them under *Application permissions* and grant tenant-wide admin consent |
 | `signin_activity` fails with a licence error | Sign-in activity needs Entra ID P1/P2 | Accept the degrade, or add the licence |
 | Renewal reminder | Client secrets expire; when one does, every check fails at `auth` | Re-mint before expiry and update the secret record — nothing else changes |

--- a/docs/cloud-security/provider-setup/gcp.md
+++ b/docs/cloud-security/provider-setup/gcp.md
@@ -20,18 +20,25 @@ discovers every active project underneath that node by itself.
    does not have to be one being scanned).
 2. Permission to grant IAM roles at the scope you intend to connect
    (Organization Admin / Folder Admin / Project IAM Admin).
-3. The **APIs enabled** on the service account's own project — these are the
-   client APIs the collector calls:
+3. The **APIs enabled** on the service account's own project — the client APIs
+   the collector calls:
 
     ```bash
     gcloud services enable \
       cloudresourcemanager.googleapis.com \
+      serviceusage.googleapis.com \
       iam.googleapis.com \
       compute.googleapis.com \
       storage.googleapis.com \
       secretmanager.googleapis.com \
+      cloudkms.googleapis.com \
+      bigquery.googleapis.com \
+      sqladmin.googleapis.com \
+      pubsub.googleapis.com \
+      apikeys.googleapis.com \
       osconfig.googleapis.com \
       aiplatform.googleapis.com \
+      notebooks.googleapis.com \
       recommender.googleapis.com \
       policyanalyzer.googleapis.com \
       cloudidentity.googleapis.com \
@@ -44,6 +51,14 @@ discovers every active project underneath that node by itself.
     That is usually what you want. `provider test` reports a disabled API as a
     passing check with an explanatory note, precisely so you do not mistake it
     for a missing grant.
+
+!!! warning "Only some of these surfaces have a preflight check"
+    The preflight probes the surfaces listed in the
+    [check table](#verify) below. The rest — KMS, BigQuery, Cloud SQL, Pub/Sub,
+    API keys, Workbench notebooks — are exercised only during the sweep. If one
+    of their APIs is disabled, that inventory type simply comes back **empty**
+    while the provider test stays green, so enable the full list above rather
+    than trimming it to what the test covers.
 
 ## Required roles
 
@@ -71,11 +86,25 @@ Each adds one inventory or analysis surface. Skipping one leaves that surface
 |---|---|---|
 | `roles/secretmanager.viewer` | Secret **metadata** inventory (names/rotation posture — never secret values) | `secret_manager` |
 | `roles/osconfig.vulnerabilityReportViewer` | Agentless workload vulnerabilities from VM Manager | `osconfig_vuln` |
-| `roles/osconfig.inventoryViewer` | The OS-inventory join that attaches package name + installed/fixed version to each CVE | `osconfig_vuln` |
+| `roles/osconfig.inventoryViewer` | The OS-inventory join that attaches package name + installed/fixed version to each CVE | *(not probed — exercised during the sweep)* |
 | `roles/recommender.iamViewer` | Unused-privilege findings (activity-based CIEM) | `activity_ciem` |
 | `roles/policyanalyzer.activityAnalysisViewer` | Dormant-identity / last-authentication findings | `activity_ciem` |
-| `roles/aiplatform.viewer` | Vertex AI endpoint, model, and notebook inventory | `vertex_ai` |
+| `roles/aiplatform.viewer` | Vertex AI endpoint and model inventory | `vertex_ai` |
 | `roles/cloudidentity.groups.readonly` | Google-group **membership expansion**, so `group:` IAM bindings resolve to real people | `cloud_identity` |
+
+!!! note "`osconfig_vuln` does not prove the inventory join"
+    The `osconfig_vuln` check probes the vulnerability-report read only, so it
+    passes with `roles/osconfig.vulnerabilityReportViewer` alone. If
+    `roles/osconfig.inventoryViewer` is missing, the sweep still records the
+    CVEs but skips the OS-inventory join and moves on — the symptom is
+    vulnerability rows with **no package name and no fixed version**, not a
+    failing check.
+
+!!! note "Workbench notebooks are a separate API"
+    Vertex AI Workbench notebook inventory comes from the Notebooks API
+    (`notebooks.googleapis.com`), not from the Vertex AI API, and it is not
+    covered by the `vertex_ai` check. Enable that API too if you want notebooks
+    inventoried.
 
 !!! note "Recommender needs only the list permission"
     Google's own walkthrough for *reviewing* role recommendations in the
@@ -114,7 +143,8 @@ for ROLE in roles/secretmanager.viewer \
             roles/osconfig.vulnerabilityReportViewer \
             roles/osconfig.inventoryViewer \
             roles/recommender.iamViewer \
-            roles/policyanalyzer.activityAnalysisViewer; do
+            roles/policyanalyzer.activityAnalysisViewer \
+            roles/aiplatform.viewer; do
   gcloud organizations add-iam-policy-binding "$ORG_ID" \
     --member "serviceAccount:${SA}" --role "$ROLE"
 done
@@ -165,8 +195,9 @@ refresh: 6h
 | `gcp_scope` | The node to enumerate: `organizations/{id}`, `folders/{id}`, or `projects/{id}`. Every **active** project underneath is swept. |
 | `gcp_project` | Alternative to `gcp_scope` for a single project. Supply one or the other. |
 
-In the web app: **Add provider → Google Cloud**, then set the **scope**,
-**Credentials**, and **Refresh interval**.
+In the web app: **Add provider → GCP**, then set the **scope**, **Credentials**,
+and the **Sync cadence** (pick a preset, or **Custom interval** for a duration of
+your own).
 
 ## Verify
 
@@ -174,10 +205,14 @@ In the web app: **Add provider → Google Cloud**, then set the **scope**,
 limacharlie cloudsec provider test --input-file provider.yaml
 ```
 
+The report opens with the `config` and `credential` checks common to every
+provider, [documented once in Provider Setup](index.md#the-two-checks-every-provider-reports-first);
+the GCP-specific checks follow.
+
 | Check | Required | Meaning if it fails |
 |---|:--:|---|
 | `auth` | ✅ | The key could not mint a token, or the scope node is unreachable. Nothing else can be probed. |
-| `projects` | ✅ | `resourcemanager.projects.list` denied — no project can be discovered under the scope. |
+| `projects` *(folder/org scope only)* | ✅ | `resourcemanager.projects.list` denied — no project can be discovered under the scope. A single-project scope has nothing to enumerate, so this check is not reported at all. |
 | `compute` | ✅ | `compute.instances.list` denied — no compute inventory. |
 | `storage` | ✅ | `storage.buckets.list` denied — no storage inventory. |
 | `iam` | ✅ | `getIamPolicy` and/or `serviceAccounts.list` denied — the CIEM access graph cannot be built. |

--- a/docs/cloud-security/provider-setup/github.md
+++ b/docs/cloud-security/provider-setup/github.md
@@ -5,10 +5,11 @@
     configuration formats described here may change before general
     availability. Contact us if you would like access.
 
-Collects a GitHub organization: org settings, members and teams (identities),
-repositories and their branch protection (data stores), installed GitHub Apps,
-webhooks, deploy keys and Actions secrets (machine identities), and the Actions
-OIDC subject configuration that lets workflows assume cloud roles.
+Collects a GitHub organization: org settings, members (including outside
+collaborators) and teams (identities), repositories and their branch protection
+(data stores), installed GitHub Apps, deploy keys and Actions secrets (machine
+identities), and the Actions OIDC subject configuration that lets workflows
+assume cloud roles.
 
 **Auth model:** a **GitHub App installed on the organization**, with a
 read-only permission set. The App's private key is used to mint short-lived
@@ -33,11 +34,18 @@ Create the App with **read-only** access on the following. All are
 
 | Permission | Scope | Unlocks | Preflight check |
 |---|---|---|---|
-| **Administration** | Organization | Installed-App inventory → over-privileged-app findings | `installed_apps` |
+| **Administration** | Organization | Installed-App inventory → over-privileged-app findings; the org's **MFA-required** posture; the per-member MFA-enrollment cross-check | `installed_apps` |
 | **Secrets** | Organization | Organization Actions-secret inventory (**names only**, never values) | `org_secrets` |
-| **Administration** | Repository | Branch-protection posture | *(collected during the sweep)* |
-| **Secrets** | Repository | Repository Actions-secret inventory (names only) | *(collected during the sweep)* |
-| **Webhooks** | Organization + Repository | Webhook inventory (data-egress surface) | *(collected during the sweep)* |
+| **Administration** | Repository | Branch-protection posture and deploy-key inventory (deploy keys are also the one activity signal — see [Known limitations](#known-limitations)) | *(collected during the sweep)* |
+| **Secrets** | Repository | Whether a repository has Actions secrets at all — an existence flag, not a name list (org-level secrets are the ones inventoried by name) | *(collected during the sweep)* |
+
+!!! note "The setup wizard asks for Administration as required"
+    The in-product **Add provider** wizard lists both Administration grants
+    (organization and repository) as required rather than optional. Collection
+    still succeeds without them — the required permissions above are what gate
+    the connection — but most of the useful posture depends on them (org MFA,
+    per-member MFA, branch protection, deploy keys, installed Apps), so the
+    wizard asks for them up front. Grant them unless you have a reason not to.
 
 ## Create the GitHub App
 
@@ -75,13 +83,18 @@ live on the provider record.
 {"private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n"}
 ```
 
-```bash
-python3 -c 'import json;print(json.dumps({"secret":json.dumps({"private_key":open("app.private-key.pem").read()})}))' \
-  > gh-secret.json
+The key is a multi-line PEM, so JSON-escape it rather than pasting it by hand:
 
-limacharlie hive set --hive-name secret --key github-app-key \
-    --input-file gh-secret.json --enabled
+```bash
+python3 -c 'import json;print(json.dumps({"private_key":open("app.private-key.pem").read()}))' \
+  > gh-key.json
+
+limacharlie secret set --key github-app-key \
+    --value "$(cat gh-key.json)" --enabled
 ```
+
+`secret set` wraps whatever you pass in `--value` into the secret record's
+`{"secret": "..."}` shape for you.
 
 ## Create the provider record
 
@@ -126,7 +139,7 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `auth` fails: `Bad credentials` / JWT rejected | Wrong App ID, or the private key does not belong to that App | Confirm the App ID on the App settings page and regenerate the key if unsure |
 | `auth` fails: `Not Found` on the org | The installation ID belongs to a different account, or the App is not installed on this org | Re-read the installation ID from the installation settings URL |
 | `repos` passes but repositories are missing | The installation was scoped to selected repositories | Re-install with **All repositories**, or accept partial coverage |
-| First sweep takes many minutes | Large orgs need per-repository calls for branch protection, deploy keys, secrets, and webhooks | Expected; subsequent sweeps are incremental |
+| First sweep takes many minutes | Large orgs need per-repository calls for branch protection, deploy keys and the Actions-secret check | Expected; subsequent sweeps are incremental |
 | A permission was added after installing | GitHub requires the installation to accept new permissions | Approve the permission request on the org's installation page |
 
 ## Known limitations
@@ -136,5 +149,12 @@ limacharlie cloudsec provider test --input-file provider.yaml
   analysis is unavailable.
 - **Fine-grained personal access tokens** cannot be enumerated org-wide by an
   App, so they are not inventoried.
+- **Webhooks are not inventoried.** Organization and repository webhooks are
+  out of scope for this connector, so webhook data-egress endpoints do not
+  appear in the graph.
+- **Enterprise-level SAML SSO is not readable.** App installation tokens cannot
+  read enterprise-level SAML identities (a documented GitHub limit), so members
+  of an enterprise-SSO or managed-user org resolve through verified-domain and
+  public-profile emails only. Organization-level SSO is read normally.
 - An **Actions OIDC trust** with no corresponding cloud-side role is reported
   as a dangling trust rather than a fabricated "can assume" edge.

--- a/docs/cloud-security/provider-setup/google-workspace.md
+++ b/docs/cloud-security/provider-setup/google-workspace.md
@@ -6,12 +6,17 @@
     availability. Contact us if you would like access.
 
 Collects identity posture from Google Workspace — users, groups and
-membership, admin roles, user security posture, devices, and inbound-SSO
-profiles — via the Admin SDK and Cloud Identity APIs.
+membership, admin roles, user security posture, devices, inbound-SSO profiles,
+and Gemini-in-Workspace usage — via the Admin SDK and Cloud Identity APIs.
 
-**Auth model:** a **Google Cloud service account** with **domain-wide
-delegation (DWD)** that **impersonates a Workspace super admin** to read
-directory data.
+**Auth model:** a **Google Cloud service account**, in one of two setups:
+
+- **Domain-wide delegation (DWD)** — the service account **impersonates a
+  Workspace super admin** to read directory data. This is the recommended
+  setup and the rest of this page assumes it.
+- **No delegation** — the service account calls the Admin SDK directly, and
+  must itself hold a Workspace admin role in the Admin console. See
+  [Alternative: no delegation](#alternative-no-delegation).
 
 ## Prerequisites
 
@@ -22,27 +27,39 @@ directory data.
     - **Cloud Identity API** (`cloudidentity.googleapis.com`) — needed for
       inbound-SSO and Cloud Identity device surfaces.
 3. A real **Workspace Super Admin** account to impersonate
-   (e.g. `admin@example.com`).
+   (e.g. `admin@example.com`) — DWD setup only.
 
-## Required OAuth scopes
+## OAuth scopes
 
-| Capability | Scope |
-|---|---|
-| Directory users (read) | `https://www.googleapis.com/auth/admin.directory.user.readonly` |
-| Groups & membership | `https://www.googleapis.com/auth/admin.directory.group.readonly` |
-| Group members | `https://www.googleapis.com/auth/admin.directory.group.member.readonly` |
-| User security posture | `https://www.googleapis.com/auth/admin.directory.user.security` |
-| Admin roles | `https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly` |
-| Inbound SSO profiles | `https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly` |
-| Mobile devices | `https://www.googleapis.com/auth/admin.directory.device.mobile.readonly` |
-| ChromeOS devices | `https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly` |
-| Cloud Identity devices | `https://www.googleapis.com/auth/cloud-identity.devices.readonly` |
+Only the user and group scopes are required. Each remaining scope unlocks one
+surface, and leaving it out degrades only that surface.
+
+| Capability | Required | Scope |
+|---|:--:|---|
+| Directory users (read) | ✅ | `https://www.googleapis.com/auth/admin.directory.user.readonly` |
+| Groups & membership | ✅ | `https://www.googleapis.com/auth/admin.directory.group.readonly` |
+| Group members | ✅ | `https://www.googleapis.com/auth/admin.directory.group.member.readonly` |
+| User security posture | — | `https://www.googleapis.com/auth/admin.directory.user.security` |
+| Admin roles | — | `https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly` |
+| Inbound SSO profiles | — | `https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly` |
+| Mobile devices | — | `https://www.googleapis.com/auth/admin.directory.device.mobile.readonly` |
+| ChromeOS devices | — | `https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly` |
+| Cloud Identity devices | — | `https://www.googleapis.com/auth/cloud-identity.devices.readonly` |
+| Gemini-in-Workspace usage | — | `https://www.googleapis.com/auth/admin.reports.audit.readonly` |
 
 Copy-paste block for the DWD scopes field (one comma-separated line):
 
 ```text
-https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.group.member.readonly,https://www.googleapis.com/auth/admin.directory.user.security,https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly,https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly,https://www.googleapis.com/auth/admin.directory.device.mobile.readonly,https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly,https://www.googleapis.com/auth/cloud-identity.devices.readonly
+https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.group.member.readonly,https://www.googleapis.com/auth/admin.directory.user.security,https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly,https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly,https://www.googleapis.com/auth/admin.directory.device.mobile.readonly,https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly,https://www.googleapis.com/auth/cloud-identity.devices.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly
 ```
+
+!!! info "Gemini usage has no preflight check"
+    `admin.reports.audit.readonly` reads the Admin SDK **Reports** audit stream
+    to land Gemini-in-Workspace usage as an application with per-user access
+    edges — only the set of users seen in the trailing window, never any
+    prompt or response content. It is the one surface `provider test` does not
+    probe: if the scope is missing (or the Admin SDK API is not enabled) the
+    connection still reports OK and Gemini usage is simply left uncollected.
 
 ## Register domain-wide delegation
 
@@ -76,31 +93,69 @@ service-account key:
 ```json
 {
   "service_account_json": { "type": "service_account", "project_id": "...", "private_key": "...", "client_email": "...", "...": "..." },
-  "admin_email": "admin@example.com",
-  "domain": "example.com"
+  "admin_email": "admin@example.com"
 }
 ```
 
 - `service_account_json` — the **entire raw Google service-account key JSON**,
   nested as this key's value.
-- `admin_email` — the Super Admin to impersonate.
-- `domain` — your primary Workspace domain.
+- `admin_email` — the Super Admin to impersonate. Omit it only for the
+  no-delegation setup below.
+- `domain` — **optional**, and a filter rather than a label. Most connections
+  should leave it out entirely.
+
+!!! warning "`domain` narrows what is collected"
+    Setting `domain` enumerates that **one** domain instead of the whole
+    customer. On a tenant with secondary or additional domains, every user and
+    group outside it is silently absent from the inventory — the sweep succeeds
+    and the connection looks healthy. Leave `domain` out unless you
+    deliberately want a single-domain inventory.
+
+    To declare which domains count as internal (for external-collaborator
+    detection), use the provider record's `internal_domains` instead. That is a
+    classification list and does not restrict collection.
 
 !!! danger "Do not flatten the wrapper"
     Do **not** place `admin_email` / `domain` at the top level next to the
-    service-account-key fields. LimaCharlie reads the key but finds no admin
-    to impersonate, mints a token with no subject, and Google returns
-    **`HTTP 400: Invalid Input`** on the first directory call.
+    service-account-key fields. A secret that looks like a bare service-account
+    key is read as the **no-delegation** form: the impersonation admin is
+    ignored, the token is minted with no subject, and Google returns
+    **`HTTP 400: Invalid Input`** on the first directory call — unless the
+    service account itself holds a Workspace admin role.
 
 Store it:
 
 ```bash
-limacharlie hive set --hive-name secret --key gw-credentials \
-    --input-file gw-secret.json
+limacharlie secret set --key gw-credentials \
+    --value "$(cat gw-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you.
 
 Or in the web app: **Organization Settings → Secrets Manager → Add**, name it
 `gw-credentials`, and paste the JSON.
+
+### Alternative: no delegation
+
+If you would rather not register domain-wide delegation, the **raw
+service-account key JSON** is accepted as the secret on its own — the file GCP
+hands you, stored verbatim with no wrapper and no `admin_email`:
+
+```bash
+limacharlie secret set --key gw-credentials \
+    --value "$(cat sa-key.json)" --enabled
+```
+
+In this form the service account calls the Admin SDK as itself instead of
+impersonating an admin, so it must **hold a Workspace admin role** granted in
+the Google Admin console — assign the service account a read-only or custom
+admin role covering the directory surfaces you want. No DWD registration is
+needed, and there is no way to set `domain`: the whole customer is enumerated.
+
+Everything else on this page is unchanged; `provider test` reports the same
+checks, and a surface the role does not cover fails exactly as an unregistered
+scope would.
 
 ## Create the provider record
 
@@ -124,7 +179,7 @@ limacharlie cloudsec provider test --input-file provider.yaml
 
 | Check | Required | Meaning if it fails |
 |---|:--:|---|
-| `core` | ✅ | Authentication plus the directory user read. A failure here means the delegation is wrong — nothing else can be probed meaningfully. |
+| `core` | ✅ | Authentication plus the directory user read. A failure here means the delegation (or, in the no-delegation setup, the service account's admin role) is wrong — nothing else can be probed meaningfully. |
 | `groups` | ✅ | Groups and membership unavailable — the group edges that complete the GCP IAM picture are missing. |
 | `security` | — | Per-user security posture (2SV enrolment/enforcement) unavailable. |
 | `roles` | — | Admin-role assignments unavailable. |
@@ -137,6 +192,7 @@ limacharlie cloudsec provider test --input-file provider.yaml
 
 | `provider test` error | Cause | Fix |
 |---|---|---|
-| `HTTP 400: Invalid input` on the user check | Secret is missing or mis-nested the impersonation admin → token has no subject → `my_customer` unresolvable | Use the **wrapper** envelope above: nest the key under `service_account_json`, with `admin_email` / `domain` as siblings |
+| `HTTP 400: Invalid input` on the user check | Secret is missing or mis-nested the impersonation admin → token has no subject → `my_customer` unresolvable | Use the **wrapper** envelope above: nest the key under `service_account_json`, with `admin_email` as a sibling. If you meant the no-delegation setup, grant the service account a Workspace admin role instead |
+| Users or groups from a secondary domain are missing | `domain` is set in the secret, narrowing collection to that one domain | Remove `domain` from the secret; declare internal domains with `internal_domains` on the record |
 | `token mint failed (HTTP 401): scope not granted to the delegated admin` | DWD missing scopes (all-or-nothing mint), a non-`.readonly` variant, or not yet propagated | Register the **full** scope list exactly; wait for propagation; confirm the service account's client ID matches |
 | `HTTP 403: … API has not been used in project …` | Admin SDK / Cloud Identity API not enabled | Enable the named API in the service account's project |

--- a/docs/cloud-security/provider-setup/index.md
+++ b/docs/cloud-security/provider-setup/index.md
@@ -59,6 +59,20 @@ limacharlie hive set --hive-name secret --key <name> \
 
 where `secret.json` is `{"secret": "<the credential JSON, as a string>"}`.
 
+The `secret set` shortcut does that wrapping for you, so you can hand it the
+credential itself — `credential.json` below is the provider's credential JSON,
+with no `{"secret": …}` envelope:
+
+```bash
+limacharlie secret set --key <name> --value "$(cat credential.json)" --enabled
+```
+
+!!! note "`--value` lands in your shell history"
+    Anything passed on the command line is visible in the process list and in
+    shell history. To avoid that, pipe the record on stdin instead —
+    `echo '{"secret": "…"}' | limacharlie secret set --key <name> --enabled` —
+    or use `--input-file`.
+
 !!! tip "Bare keys are accepted for single-key providers"
     For [OpenAI](openai.md), [Anthropic](anthropic.md), and
     [LimaCharlie](limacharlie.md) you may store the raw key string instead of a
@@ -80,7 +94,8 @@ over the required checks only.** A failed **optional** check means that surface
 degrades gracefully — an inventory type goes unobserved — rather than the
 connection failing, and its `detail` names exactly what you lose.
 
-Every provider page lists its check IDs and what each one means.
+Every provider page lists its platform-specific check IDs and what each one
+means, on top of the two common checks below.
 
 Once a record passes preflight, save it:
 
@@ -94,6 +109,30 @@ limacharlie hive set --hive-name cloudsec_provider --key <name> \
     Providers → Add provider**, with secrets managed under **Organization
     Settings → Secrets Manager**. The **Test Provider** button runs the same
     preflight.
+
+### The two checks every provider reports first
+
+Before any provider-specific probe runs, the report always contains these two
+**required** checks. They are identical for all thirteen connectors, which is
+why the per-provider tables in this section start at `auth`:
+
+| Check | Required | Meaning if it fails |
+|---|:--:|---|
+| `config` | ✅ | The provider record itself is malformed — a field required for this `provider_type` is missing or ill-formed (a scope that is not in the expected shape, an ARN that does not parse, and so on). Nothing is contacted. |
+| `credential` | ✅ | The `hive://secret/<name>` reference could not be resolved — no such secret, or it is disabled — or the secret's contents are not the JSON shape that provider documents. Nothing is contacted. |
+
+Only once both pass does `auth` actually reach the platform.
+
+!!! warning "Unknown fields on the provider record are rejected, not ignored"
+    The provider record is parsed **strictly**, both by `provider test` and on
+    the Hive write: an unrecognized key is an error rather than something
+    silently dropped. A misspelled field name therefore fails outright, with the
+    offending key named, instead of quietly leaving a setting unapplied — use the
+    exact names from [Configuration](../configuration.md#cloudsec_provider).
+    Credential secrets are **not** strict in the same way: an unrecognized key
+    there is dropped without complaint, which is why a mistyped credential field
+    surfaces later as an authentication failure instead. Each provider page
+    documents its exact credential keys.
 
 ## Fields every provider accepts
 
@@ -123,7 +162,7 @@ limacharlie hive set --hive-name cloudsec_provider --key <name> \
 | Provider | `secret` value |
 |---|---|
 | [Google Cloud](gcp.md) | The service-account key JSON |
-| [AWS](aws.md) | `{"access_key_id": "...", "secret_access_key": "..."}` *(optional `session_token`)* |
+| [AWS](aws.md) | `{"access_key_id": "...", "secret_access_key": "..."}` |
 | [Azure](azure.md) | `{"client_id": "...", "client_secret": "..."}` |
 | [Entra ID](entra.md) | `{"client_id": "...", "client_secret": "..."}` |
 | [Okta](okta.md) | `{"org_url": "...", "client_id": "...", "private_key": {…JWK…}}`, or `{"org_url": "...", "api_token": "..."}` |

--- a/docs/cloud-security/provider-setup/limacharlie.md
+++ b/docs/cloud-security/provider-setup/limacharlie.md
@@ -8,9 +8,10 @@
 Inventories your **own LimaCharlie tenancy** as an estate, like any other SaaS
 platform: org members as identities (with MFA state), API keys as machine
 identities, sensors as assets, installation keys, telemetry outputs, extension
-subscriptions, and configuration stores. Posture findings cover org MFA
-enforcement, unrestricted privileged API keys, insecure telemetry-output
-transports, stale enrollment keys, and non-expiring secrets.
+subscriptions, and configuration stores. Posture findings cover sign-in
+requirements, unrestricted privileged API keys, insecure telemetry-output
+transports, stale enrollment keys, config stores holding records that fail to
+apply, and non-expiring secrets.
 
 **Auth model:** a LimaCharlie **API key** — either an **org** key (one
 organization) or a **user** key (every organization that user can reach, which
@@ -23,8 +24,16 @@ is the MSSP fleet case).
 | **Org key** | `limacharlie_oid` | That one organization | You want a single tenant inventoried |
 | **User key** | `limacharlie_uid` | Every organization the user can reach, one account each | You run a fleet and want them all in one connection |
 
-Org-level MFA/SSO enforcement posture is observable **only in user-key mode** —
-the underlying endpoint rejects org identities.
+!!! note "What the MFA/SSO posture actually describes"
+    The sign-in posture on the Account node (required MFA, SSO-only sign-in) is
+    the policy attached to the **email domain of the user whose key is in
+    use** — the requirements that apply to everyone signing in with an address
+    in that domain. It is not a per-organization setting, so a user key reaching
+    several orgs reports the same posture on each of them.
+
+    It is therefore observable **only in user-key mode**: an org key has no user
+    identity behind it, so the posture is reported as unobserved rather than as
+    "not enforced".
 
 ## Required permissions
 
@@ -53,15 +62,52 @@ Set these on the API key. Each maps to a preflight check of the same name.
 |---|---|---|
 | `ext.conf.get` | Extension subscriptions as applications | `extensions` |
 | `replicant.get` | Extension configuration detail | `replicant` |
-| `billing.ctrl` | Org-level MFA/SSO enforcement posture *(user-key mode only)* | `billing` |
-| `secret.get.mtd` | The secret config store + non-expiring-secret findings | `secret_mtd` |
-| `lookup.get.mtd` | The lookup config store | `lookup_mtd` |
-| `yara.get.mtd` | The YARA config store | `yara_mtd` |
-| `query.get.mtd` | The query config store | `query_mtd` |
-| `playbook.get.mtd` | The playbook config store | `playbook_mtd` |
+| `billing.ctrl` | Sign-in requirement posture on the Account node *(user-key mode only)* | `billing` |
 
-All `*.get.mtd` permissions read **metadata only** — record names and
-attributes, never secret values or rule bodies.
+!!! info "Several permissions satisfy the extension read"
+    The extension-subscription read accepts **any** of `ext.conf.get`,
+    `ext.conf.get.mtd`, `ext.conf.set`, `ext.conf.set.mtd`, `ext.conf.del`,
+    `ext.request` or `billing.ctrl`, and the `extensions` check passes on any
+    one of them. `ext.conf.get` is simply the narrowest of the set.
+
+### Configuration stores
+
+Each configuration store is inventoried separately and needs its own
+metadata-read permission. Grant only the stores you want inventoried — a store
+whose permission is missing is left out, with no effect on the rest of the
+sweep.
+
+| Store | Permission | Preflight check |
+|---|---|---|
+| Secrets | `secret.get.mtd` | `secret_mtd` |
+| Lookups | `lookup.get.mtd` | `lookup_mtd` |
+| YARA | `yara.get.mtd` | `yara_mtd` |
+| Queries | `query.get.mtd` | `query_mtd` |
+| Playbooks | `playbook.get.mtd` | `playbook_mtd` |
+| D&R rules (general) | `dr.list` | — |
+| D&R rules (managed) | `dr.list.managed` | — |
+| False-positive rules | `fp.ctrl` | — |
+| Cloud sensors | `cloudsensor.get.mtd` | — |
+| External adapters | `externaladapter.get.mtd` | — |
+| AI agents | `ai_agent.get.mtd` | — |
+| Extension configuration | `ext.conf.get.mtd` (or `ext.conf.get` above) | — |
+
+!!! warning "Only the first five stores are preflighted"
+    `provider test` probes the secret, lookup, YARA, query and playbook stores
+    only. The stores below them have no check of their own: with the permission
+    missing, the test still reports the connection OK and those stores are
+    simply absent from the inventory. If you expected a store and do not see
+    it, compare the key's permissions against this table.
+
+    Note also that `fp.ctrl` is broader than read-only — LimaCharlie has no
+    read-only false-positive-rule permission, the same trade-off as `user.ctrl`
+    and `apikey.ctrl` above. It is used strictly for listing.
+
+All `*.get.mtd` and `*.list` permissions read **metadata only** — record names
+and attributes, never secret values or rule bodies. That metadata includes each
+store's count of records whose last apply failed, which is what raises the
+broken-records finding, and (for the secret store) which stored credentials
+carry no expiry.
 
 ## Create the API key
 
@@ -95,12 +141,17 @@ interface.
 {"api_key": "<the-api-key>"}
 ```
 
-A bare key string is also accepted and wrapped automatically.
+A bare key string is also accepted and wrapped automatically, so the key can go
+in directly:
 
 ```bash
-limacharlie hive set --hive-name secret --key limacharlie-collector \
-    --input-file lc-secret.json --enabled
+limacharlie secret set --key limacharlie-collector \
+    --value '<the-api-key>' --enabled
 ```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you. To store the JSON object form instead, pass
+`--value "$(cat lc-secret.json)"`.
 
 ## Create the provider record
 
@@ -155,5 +206,7 @@ it passes or fails.
 | `auth` fails | Key revoked, mistyped, or an org key used in user mode (or vice versa) | Re-copy the key; confirm the mode matches the field you set |
 | `scope` fails | `limacharlie_oid` is not the org the key belongs to, or the user ID is wrong | Confirm the org UUID / user ID; the user ID is case-sensitive |
 | A permission check fails after granting it | Permission changes need the key's effective permissions to refresh | Re-run the test; re-issue the key if it persists |
-| `billing` fails in org-key mode | Expected — org MFA/SSO posture is only observable with a user key | Use user-key mode if you want that posture |
+| `billing` fails in org-key mode | Expected — the sign-in posture is keyed on a user identity, so an org key cannot observe it | Use user-key mode if you want that posture |
+| `billing` reports the permission as missing, yet the sign-in posture is collected | The check looks for `billing.ctrl` on the key, while the underlying read is gated on the user identity rather than that permission | Grant `billing.ctrl` if you want the check to pass cleanly |
+| A configuration store is missing from the inventory | Its metadata-read permission is not on the key, and most stores have no preflight check | Grant the store's permission from the [Configuration stores](#configuration-stores) table |
 | Only some orgs appear in user-key mode | The user does not have the required permissions in the missing orgs | Grant the same permission set in each org you want inventoried |

--- a/docs/cloud-security/provider-setup/okta.md
+++ b/docs/cloud-security/provider-setup/okta.md
@@ -22,24 +22,27 @@ person, no password/MFA lifecycle, and no 30-day-inactivity expiry.
 - Your org base URL, e.g. `https://example.okta.com`. Use the URL you sign in
   to; note that an org's *name* and its *subdomain* can differ.
 
-## Required scopes
+## Scopes
 
-Granted on the app's **Okta API Scopes** tab:
+Granted on the app's **Okta API Scopes** tab. The collector requests all five
+of these by default; the first four are required for the connection to be
+usable.
 
-| Scope | Why | Preflight check |
-|---|---|---|
-| `okta.users.read` | The user directory — the core identity inventory | `users` |
-| `okta.groups.read` | Groups and membership | `groups` |
-| `okta.apps.read` | Application inventory and assignments | `apps` |
-| `okta.roles.read` | Admin-role enrichment on every user | `roles` |
-| `okta.idps.read` | External identity providers (federation/social trust) | `idps` |
+| Scope | Required | Why | Preflight check |
+|---|:--:|---|---|
+| `okta.users.read` | ✅ | The user directory — the core identity inventory | `users` |
+| `okta.groups.read` | ✅ | Groups and membership | `groups` |
+| `okta.apps.read` | ✅ | Application inventory and assignments | `apps` |
+| `okta.roles.read` | ✅ | Admin-role enrichment on every user | `roles` |
+| `okta.idps.read` | — | External identity providers (federation/social trust). Leave it ungranted and only that surface is skipped | `idps` |
 
 !!! danger "`okta.roles.read` is not optional"
     The user collector enriches every user with their admin roles inline and
     treats a roles denial as fatal. Without this scope **no users are
     inventoried at all** — not merely "users without roles".
 
-Optional scopes, requested only when you list them explicitly (see
+Two further scopes are outside the default set entirely — granting them is not
+enough, they are requested only when you list them explicitly (see
 [Requesting extra scopes](#requesting-extra-scopes)):
 
 | Scope | Unlocks | Preflight check |
@@ -55,8 +58,8 @@ Optional scopes, requested only when you list them explicitly (see
    **Public key / Private key**.
 3. Under **PUBLIC KEYS**, choose **Add key → Generate new key**, then copy the
    **private key in JWK format**. This is shown once — keep it.
-4. On the **Okta API Scopes** tab, **Grant** each of the five required scopes
-   (plus any optional ones you want).
+4. On the **Okta API Scopes** tab, **Grant** each of the five default scopes
+   above (plus any optional ones you want).
 5. On the app's **Admin roles** tab, **assign an admin role** — **Read-only
    Administrator** is sufficient for the required scope set.
 6. Copy the app's **Client ID** from the General tab.
@@ -102,17 +105,29 @@ with the key's `kid`.
 {"org_url": "https://example.okta.com", "api_token": "<SSWS-token>"}
 ```
 
+Either shape also accepts an optional `org_domain` — the org's primary email
+domain. It is treated as an internal domain on top of the record's
+`internal_domains`, so users outside it are flagged as external collaborators.
+
+!!! note "`org_url` in the secret wins"
+    The org URL can be carried on the provider record (`okta_org_url`) or in
+    the secret (`org_url`). When both are present the **secret's** value is
+    used; the record's is only a fallback.
+
 Store it:
 
 ```bash
-limacharlie hive set --hive-name secret --key okta-credentials \
-    --input-file okta-secret.json --enabled
+limacharlie secret set --key okta-credentials \
+    --value "$(cat okta-secret.json)" --enabled
 ```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you.
 
 ### Requesting extra scopes
 
-By default the collector requests exactly the five required scopes. To use an
-optional scope, grant it on the app **and** list the full scope set in the
+By default the collector requests exactly the five scopes listed above. To use
+an optional scope, grant it on the app **and** list the full scope set in the
 secret:
 
 ```json
@@ -125,10 +140,14 @@ secret:
 }
 ```
 
-!!! warning "`scopes` replaces the default set"
-    The list is used verbatim, and **every scope in it must be granted on the
-    app** or the token mint fails outright. Always include the five required
-    scopes alongside the optional ones.
+!!! warning "`scopes` replaces the default set — and misses fail silently"
+    The list is used verbatim; it does not add to the defaults. Always repeat
+    the five default scopes alongside the optional ones.
+
+    A scope in the list that is **not granted on the app** does not fail the
+    token mint: Okta's org authorization server quietly drops it and issues the
+    token without it. The gap only shows up later, as that one surface
+    returning 403 during the sweep. Grant every scope you list.
 
 ## Create the provider record
 
@@ -175,6 +194,6 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `auth` fails: *must use the private_key_jwt token_endpoint_auth_method* | App configured with a client secret | Switch the app to **Public key / Private key** and store the private JWK |
 | `groups` / `roles` 403 while `auth` passes | No admin role assigned to the app | Assign **Read-only Administrator** on the app's *Admin roles* tab |
 | A scope you granted still 403s | The org authorization server **silently drops ungranted scopes** at mint — the token simply lacks it | Re-check the *Okta API Scopes* tab; the 403's `WWW-Authenticate` header names the missing scope |
-| Token mint fails after adding `scopes` | A listed scope is not granted on the app | Grant it, or remove it from the list |
+| A surface 403s after you set `scopes` | The list omitted that scope, or it is listed but not granted on the app — either way the mint succeeds without it | List every scope you need and grant each one on the app |
 | `auth` fails: host unreachable | Wrong subdomain (org *name* ≠ org *subdomain*) | Use the exact URL you sign in to |
 | SSWS token stops working | SSWS tokens expire after 30 days of inactivity and die with their owner | Move to an API Services app |

--- a/docs/cloud-security/provider-setup/onepassword.md
+++ b/docs/cloud-security/provider-setup/onepassword.md
@@ -18,6 +18,11 @@ it read-only.
 - **1Password Business**, with **automated provisioning** set up (hosted
   provisioning or a self-hosted SCIM bridge).
 - The **SCIM base URL** and its **bearer token**.
+- The SCIM URL must be **`https://`** and its hostname must resolve on the
+  public internet. Plain `http://`, a private or loopback address literal, and
+  URLs with credentials embedded in them are rejected outright. The same applies
+  to a Connect URL. A self-hosted bridge behind a VPN or a private-only DNS name
+  cannot be collected.
 - *(Optional)* a running **1Password Connect** server plus a Connect token, if
   you want vault inventory.
 
@@ -32,9 +37,10 @@ it read-only.
 | Hosted provisioning | `https://provisioning.1password.com/scim/v2` |
 | Self-hosted SCIM bridge | Your bridge's own URL, e.g. `https://scim.example.com` |
 
-Do not include a trailing slash. Use exactly the URL your identity provider is
-configured with — the collector appends `/Users` and `/Groups` to it, so a
-wrong base path shows up immediately as a failed `scim_users` check.
+Use exactly the URL your identity provider is configured with — the collector
+appends `/Users` and `/Groups` to it, so a wrong base path shows up immediately
+as a failed `scim_users` check. A trailing slash is harmless (it is stripped),
+but the path before it must be right.
 
 !!! info "Why the two forms differ"
     Hosted provisioning serves SCIM under a `/scim/v2` path, while a
@@ -63,22 +69,32 @@ Connect configured, vault inventory is simply unobserved.
 
 ## Create the credentials secret
 
+Save the credential JSON as `op-secret.json`:
+
 ```json
 {
   "scim_url": "https://provisioning.1password.com/scim/v2",
   "scim_token": "<bearer-token>",
   "connect_url": "https://connect.example.com",
-  "connect_token": "<connect-token>"
+  "connect_token": "<connect-token>",
+  "org_domain": "example.com"
 }
 ```
 
-`connect_url` / `connect_token` are optional; omit both if you are not running
-Connect.
+| Field | Required | Meaning |
+|---|:--:|---|
+| `scim_url` | ✅ | The SCIM base URL |
+| `scim_token` | ✅ | The SCIM bearer token |
+| `connect_url` / `connect_token` | — | 1Password Connect, for vault inventory. Omit **both** if you are not running Connect. |
+| `org_domain` | — | The account's primary email domain. It is merged with the provider record's `internal_domains`, so directory members outside that set are classified as external collaborators. |
 
 ```bash
-limacharlie hive set --hive-name secret --key onepassword-scim \
-    --input-file op-secret.json --enabled
+limacharlie secret set --key onepassword-scim \
+    --value "$(cat op-secret.json)" --enabled
 ```
+
+`secret set` wraps whatever you pass in `--value` into the secret record's
+`{"secret": "..."}` shape for you.
 
 ## Create the provider record
 
@@ -114,4 +130,16 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `scim_users` fails with 404 | The base URL is missing (or wrongly carrying) the `/scim/v2` path | Copy the SCIM URL verbatim from the Integrations page |
 | `scim_users` fails with 401 | The bearer token is wrong, or credentials were regenerated | Copy the current token from the Integrations page |
 | `scim_users` fails to connect | The SCIM bridge is not reachable from the public internet, or is behind an allowlist | Self-hosted bridges must be reachable; confirm DNS and TLS |
+| The URL is rejected before any check runs | The URL is not `https://`, points at a private/loopback address, or embeds credentials | Use a public `https://` hostname (see [Prerequisites](#prerequisites)) |
 | `connect_vaults` fails | Connect URL/token wrong, or the Connect token has no vault access | Verify the Connect server is running and the token grants read on the vaults you want inventoried |
+
+## Known limitations
+
+- **No activity signal.** Neither SCIM nor Connect exposes last-used data, so
+  1Password identities carry no dormancy or used-vs-granted analysis. Absence of
+  activity is treated as unknown, never as "unused".
+- **Connect sees only its own vaults.** The Connect API returns the vaults its
+  token has been granted, so vault inventory is a partial view of the estate by
+  design — grant the token read access on every vault you want inventoried.
+- **No vault ACLs.** Connect does not expose who can open a vault, so
+  vault-access edges are not built from this provider.

--- a/docs/cloud-security/provider-setup/openai.md
+++ b/docs/cloud-security/provider-setup/openai.md
@@ -6,7 +6,8 @@
     availability. Contact us if you would like access.
 
 Collects your OpenAI platform organization as an AI-security surface: projects,
-members and service accounts, API keys (with last-used timestamps, so dormant
+members (including pending invites — staged seats that have never logged in)
+and service accounts, API keys (with last-used timestamps, so dormant
 and over-scoped keys surface), org Admin API keys, mTLS certificates, and
 audit-log availability posture.
 
@@ -45,17 +46,22 @@ configuration-change forensics — the `audit_logs` check reports that.
 
 ## Create the credentials secret
 
+The secret's shape is:
+
 ```json
 {"admin_api_key": "sk-admin-..."}
 ```
 
-You may also paste the bare key string; it is wrapped into this shape
-automatically.
+You may also store the bare key string; it is wrapped into this shape
+automatically, which makes it a one-liner:
 
 ```bash
-limacharlie hive set --hive-name secret --key openai-admin-key \
-    --input-file openai-secret.json --enabled
+limacharlie secret set --key openai-admin-key \
+    --value 'sk-admin-...' --enabled
 ```
+
+`secret set` wraps whatever you pass in `--value` into the secret record's
+`{"secret": "..."}` shape for you.
 
 ## Create the provider record
 
@@ -75,7 +81,9 @@ sweeping the wrong organization. Useful when one team manages several OpenAI
 orgs.
 
 In the web app: **Add provider → OpenAI**, then set **Credentials** and
-**Refresh interval**.
+**Refresh interval**. The optional **Organization ID** field is the same
+assertion as `openai_org_id`; leave it blank to have the organization
+discovered.
 
 ## Verify
 

--- a/docs/cloud-security/providers.md
+++ b/docs/cloud-security/providers.md
@@ -79,9 +79,11 @@ Azure infrastructure to enumerate, use the standalone `entra` provider instead.
 ## Identity providers
 
 Identity providers ingest a directory — users, groups, and app assignments —
-into the identity graph rather than cloud infrastructure. They unify with cloud
-IAM principals by email, which is what makes cross-surface CIEM ("this Workspace
-user has admin on that GCP bucket") possible.
+into the identity graph rather than cloud infrastructure. Most of them unify
+with cloud IAM principals **by email**, which is what makes cross-surface CIEM
+("this Workspace user has admin on that GCP bucket") possible. The exception is
+[Auth0](#auth0-auth0), which keys identities per connection instead — see its
+section below.
 
 ### Okta (`okta`)
 
@@ -132,6 +134,15 @@ the legacy `acme.auth0.com` — not a custom domain). The credential is a
 Machine-to-Machine application authorized for the Management API with read-only
 scopes: `{"client_id": "...", "client_secret": "..."}`. It collects users, roles,
 applications, and connections.
+
+!!! note "Auth0 identities are not unified by email"
+    Unlike the other identity providers, Auth0 users are kept **scoped to the
+    Auth0 tenant** and keyed on their stable Auth0 user id, which means one
+    record per connection — the same person signing in through both a database
+    connection and a social connection appears as two Auth0 identities. This is
+    deliberate: Auth0 emails are per-connection and not necessarily verified or
+    unique, so unifying on them would merge identities that are not the same
+    principal.
 
 ## SaaS
 


### PR DESCRIPTION
## What this is

A claim-by-claim accuracy audit of **every Cloud Security page** — the 11 pages under `docs/cloud-security/`, all 14 provider-setup pages, `docs/8-reference/cloud-security-api-iac.md`, and the cloud-security use-case page — verified against the current backend behavior, public API surface, CLI, and web console. 27 files, with every correction grounded in what the product actually does today.

## Highest-impact fixes

**Broken instructions a user would hit:**
- 11 provider pages stored the bare credential JSON into the `secret` hive in a shape the store rejects. All pages now use `limacharlie secret set`, which wraps the value correctly (GitHub/GCP pages already wrapped; now uniform).
- AWS: `session_token` is not supported (temporary credentials fail), and the AWS Organizations read permissions belong on the management-account role, not the base IAM user.
- Okta: `okta.idps.read` is optional (4 required scopes, not 5), and an ungranted scope does **not** fail the token mint — Okta silently drops it and the gap surfaces later as a 403.
- Google Workspace: `domain` in the secret is an optional **filter** that silently drops other domains' users on multi-domain tenants; also documented the no-DWD auth mode and the missing `admin.reports.audit.readonly` scope.
- GCP: the API-enablement list was missing 7 APIs the collectors call (KMS, BigQuery, Cloud SQL, Pub/Sub, API Keys, Notebooks, Service Usage) — surfaces that degrade silently with a green preflight.
- Cloudflare: the minimum-permission table was missing `Zone > DNS > Read`, and the token-verify command targeted the wrong endpoint for the token kind the page creates.
- `fleet overview --group` takes a group **id**, not a name; a findings example used an `--expires-at` epoch already in the past.

**API reference:**
- Corrected response shapes: `policy/vocabulary` (flat object, not `{vocabulary}`), `policy/suggest` (`{values, ...}`, not `{suggestions}`), `scan-status` (no `gcp` default; omitted provider returns per-provider coverage + workload state), `topology` `available:false` semantics.
- Documented four missing routes (`findings/causes`, `ciem/identities`, `data-security/stores`, `free-tier`), the full 11-value `finding_class` enum (+ `workload_coverage_gap`), disposition-event payloads (`status`/`resolution`; both `mitigated` and `accepted` arrive as `.resolved`; suppression policy emits the same verbs as `policy:<rule>`), the `cloud_query.*` and ops event families, emission defaults (finding events ON by default), and request caps/defaults (bulk 500-id reject, simulate walk bounds, fleet quotas).

**Features documented as inert that are live (and vice versa):**
- Scheduled saved queries are **live**: full documentation of the `schedule` block, cadence rules, budgets, and `cloud_query.*` events (was "accepted but inert").
- Content-based classification (`content_class`) and the `coverage`-typed policy record are accepted but **not evaluated in the current release** — now marked honestly everywhere.
- A collection exclusion **deletes** the excluded scope's existing inventory on the next sweep — now documented.

**Console reality:**
- Updated to the current IA: **Attack Surface** (canvas + Query console tab; Explore is gone), Topology as the landing view of **Inventory**, the **Report** page, the real five-step provider wizard (credential lives on the Permissions step), current lens names, and private-beta enablement (the extension is not self-subscribable — contact us).

**Also:** compliance scoring/evidence caps now defined; CAASM merge ladder (6 tiers, hostname guards), the three coverage kinds incl. `cloud_instance`, `max_age_days` vs `source_max_age_days` semantics, `vuln_scanner` has no supplying source yet; graph edge table completed (12 edges), query caps/allow-lists/shortest-path form, `unknown` access level; CLI version floor (`>=5.5.3`), output formats, per-command filter capabilities.

## Deploy-state pass (second commit)

After the code audit, everything newly documented was re-verified against **what is deployed and enabled in production**, not just master:

- Removed all agentless workload/snapshot scanner content (feature not enabled): no `scanning` policy docs, no scanner attribution on the finding-class enums (values stay, marked reserved — the API serves all 11).
- **Documented the free tier / 14-day trial** — the gates are now armed (enforce) fleet-wide, so silence was no longer correct. Semantics verified in the collector: 2-provider cap, pause-with-reason as provider status, config survives, upgrade resumes.
- Confirmed live: prod cloudsec host + graph images match master exactly, as do the API gateway and extension images; the current web release carries the documented console IA; the sensor↔asset resolver runs in all prod DCs; the documented CLI floor is on PyPI.

## Verification
- Every command line in the affected pages validated against the installed CLI (flags, choices, defaults).
- `markdownlint-cli2`: 0 issues across all 360 docs; list-numbering check: no new breaks (5 pre-existing on master, none in cloud-security).
- Swept all added text for internal repo names/paths — none (also replaced pre-existing internal-codename glob examples with neutral ones).

## Follow-ups (code, not docs — filed separately)
A handful of code-side inconsistencies were found during the audit (CLI `--project` sends an array the server ignores, stale CLI help examples, a dead `model` store entry in the LimaCharlie collector, the webapp exposure lens filtering on a nonexistent `posture` class, wizard/doc drift on a few permission lists, capability-table drift for `classification.identities` label and compliance scope dims). Happy to open issues/PRs for those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wAL18rVrkErdz8kBTkkRi
