### PR TITLE
docs: document the org_notes hive, refresh the SOP page, and drop Cloud Security's Private Beta framing

### DIFF
--- a/docs/7-administration/config-hive/index.md
+++ b/docs/7-administration/config-hive/index.md
@@ -11,6 +11,7 @@ The Config Hive is LimaCharlie's hierarchical configuration store. It provides a
 - [Cloud Sensors](cloud-sensors.md) - Cloud sensor configurations
 - [Apps](apps.md) - User-authored, AI-generated mini web applications
 - [SOPs](../../9-ai-sessions/sops.md) - Standard Operating Procedures that AI agents read and follow
+- [Organization Notes](../../9-ai-sessions/org-notes.md) - Free-form reference documents about the organization, read by analysts and AI agents
 
 ## Usage
 

--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -1,10 +1,5 @@
 # Cloud Security: API, Infrastructure-as-Code, and Case Automation
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 This page is the operator reference for automating LimaCharlie Cloud Security: the
 public REST API surface, the Hive records that ARE the Infrastructure-as-Code
 surface (providers, policies, saved queries), and the D&R recipes that close the

--- a/docs/8-reference/permissions.md
+++ b/docs/8-reference/permissions.md
@@ -173,6 +173,16 @@ LimaCharlie uses a granular permission system that controls access to all platfo
 | sop.get.mtd | View SOP metadata only |
 | sop.set.mtd | Modify SOP metadata only |
 
+### Organization Notes
+
+| Permission | Description |
+| --- | --- |
+| org_notes.get | Access organization notes |
+| org_notes.set | Create and modify organization notes |
+| org_notes.del | Delete organization notes |
+| org_notes.get.mtd | View organization note metadata only |
+| org_notes.set.mtd | Modify organization note metadata only |
+
 ### Apps
 
 | Permission | Description |

--- a/docs/9-ai-sessions/compliance/case-reviewer-agent.md
+++ b/docs/9-ai-sessions/compliance/case-reviewer-agent.md
@@ -66,7 +66,7 @@ The scoped LimaCharlie API key created by `compliance-deploy` is granted only th
 | `insight.evt.get` | Read historical events for context |
 | `investigation.get`, `investigation.set` | Read and update the case |
 | `ext.request`, `ext.list` | Communicate with the Cases extension and list subscribed extensions |
-| `org_notes.read` | Read organization-level notes for context |
+| `org_notes.get` | Read organization-level notes for context |
 | `sop.get`, `sop.get.mtd` | Read Standard Operating Procedures relevant to the case |
 | `ai_agent.operate` | Operate as an AI agent in the org |
 

--- a/docs/9-ai-sessions/compliance/skills.md
+++ b/docs/9-ai-sessions/compliance/skills.md
@@ -128,7 +128,7 @@ Guided deployment of a framework's case-reviewer agent to a LimaCharlie organiza
 The skill walks through these steps, asking for confirmation before each platform write:
 
 1. **Pre-flight checks** — verifies `ext-cases` is subscribed on the target org, that the framework's bundled assets are accessible, and that an Anthropic key is staged or available to stage.
-2. **API-key creation** — creates a scoped LimaCharlie API key for the reviewer agent, with the minimum permissions needed (typically `org.get`, `sensor.list`, `sensor.get`, `dr.list`, `insight.det.get`, `insight.evt.get`, `investigation.get`, `investigation.set`, `ext.request`, `ext.list`, `org_notes.read`, `sop.get`, `sop.get.mtd`, `ai_agent.operate`).
+2. **API-key creation** — creates a scoped LimaCharlie API key for the reviewer agent, with the minimum permissions needed (typically `org.get`, `sensor.list`, `sensor.get`, `dr.list`, `insight.det.get`, `insight.evt.get`, `investigation.get`, `investigation.set`, `ext.request`, `ext.list`, `org_notes.get`, `sop.get`, `sop.get.mtd`, `ai_agent.operate`).
 3. **Anthropic secret staging** — captures or stages the Anthropic key into a [Hive Secret](../../7-administration/config-hive/secrets.md).
 4. **Agent hive sync** — pushes the reviewer manifest (`ai_agent` record) and its trigger rule (`dr-general` record) into the org.
 5. **Verification** — reads the resulting hive records back to confirm the deploy succeeded and reports the agent identifier for follow-up.

--- a/docs/9-ai-sessions/org-notes.md
+++ b/docs/9-ai-sessions/org-notes.md
@@ -1,0 +1,202 @@
+# Organization Notes
+
+An Organization Note is a free-form document you store in your organization to
+record context that is true of the org itself: the network layout, which subnets
+are production, the naming convention for servers, who owns which business unit,
+the maintenance window, a link to the internal runbook.
+
+Where an [SOP](sops.md) says *how a job should be done* and [AI Memory](memory.md)
+holds *what an agent learned on its own*, an Organization Note is *reference
+material a human wrote down for whoever reads it next* — an analyst opening the
+web interface, or an AI agent gathering context before it acts.
+
+Organization Notes live in the `org_notes` [Config Hive](../7-administration/config-hive/index.md),
+scoped to a single organization. They are managed with the `limacharlie note`
+command group.
+
+!!! note "Not the same as case or investigation notes"
+    Organization Notes are org-wide and permanent. Notes attached to a case or an
+    investigation are scoped to that one incident and belong there instead.
+
+## Record format
+
+Each note is one Hive record. The key is the note name, and the payload has two
+fields — identical in shape to an [SOP](sops.md):
+
+| Field | Required | Purpose |
+|---|---|---|
+| `text` | Yes | The note itself. Free-form; markdown is the convention. |
+| `description` | No | A one-line summary used to decide whether the note is relevant. |
+
+```yaml
+data:
+  description: Production network layout and ownership
+  text: |
+    # Production Network
+
+    ## Subnets
+    - `10.10.0.0/16` — production application tier, owned by Platform.
+    - `10.20.0.0/16` — corporate VPN pool, dynamic, expect churn.
+    - `10.30.0.0/16` — lab; noisy by design, do not escalate on it.
+
+    ## Naming
+    - Hostnames `web-*` and `api-*` are internet-facing.
+    - Hostnames `db-*` are never internet-facing — treat exposure as an incident.
+
+    ## Maintenance window
+    - Sundays 02:00–06:00 UTC. Patch-related process churn is expected then.
+usr_mtd:
+  enabled: true
+  tags: [network, reference]
+```
+
+The only validation applied is that `text` must be non-empty — nothing about the
+content is enforced. Write for the reader, which increasingly means an LLM
+deciding whether this note changes what it is about to do.
+
+### Writing an effective `description`
+
+As with SOPs, the `description` is load-bearing. An agent lists the notes,
+reads names and descriptions, and fetches in full only the ones that look
+relevant. "Misc" gets skipped; "Production network layout and ownership" gets
+opened.
+
+### Limits
+
+- Maximum record size: 1 MB per note.
+
+Notes are meant to be read whole, so keep each one to a single subject. A dozen
+focused notes beat one `everything` document that no reader can pull selectively.
+
+!!! warning "New notes are created disabled"
+    Like every Hive record, a note is created **disabled** unless you pass
+    `--enabled` or set `usr_mtd.enabled: true`.
+
+## How agents use notes
+
+Nothing injects Organization Notes into an agent automatically. Agents that
+gather org context do it in two steps, the same lazy-loading pattern used for
+SOPs:
+
+1. **List** the notes and read the names and descriptions — `limacharlie note list --brief`
+   reduces each record to its `description` so the index costs almost no context.
+2. **Fetch by key** the notes whose description bears on the task, then use them
+   as ground truth about the environment.
+
+Notes are also the recommended place to park longer reference documents an agent
+should consult but that are not procedures — a compliance control mapping, an
+asset inventory summary, a customer-specific escalation matrix.
+
+!!! tip "Don't mirror notes into AI Memory"
+    [AI Memory](memory.md) is for what an agent discovered itself. Copying an
+    Organization Note into memory creates a second copy that silently goes stale;
+    have the agent read the note from the hive instead.
+
+## Permissions
+
+| Operation | Permission |
+|---|---|
+| List / read notes | `org_notes.get` |
+| Create / update a note | `org_notes.set` |
+| Delete a note | `org_notes.del` |
+| Read metadata | `org_notes.get.mtd` |
+| Update metadata | `org_notes.set.mtd` |
+
+An agent that only needs environment context should be issued `org_notes.get`
+(plus `org_notes.get.mtd` if it reads tags) — read-only. Grant `org_notes.set`
+only to agents expected to write documentation back, such as an agent that
+maintains an inventory note between runs.
+
+## Managing Organization Notes
+
+### Web interface
+
+Notes are managed under **Organization Settings → Organization Notes** in the
+organization view, where you can create, edit, tag, enable, and disable them. The
+editor takes markdown.
+
+### CLI
+
+The command group is `note` — the hive it writes to is `org_notes`.
+
+```bash
+# List every note in the organization, full bodies included.
+limacharlie note list --oid <oid> --output yaml
+
+# List just the index — each record reduced to its description.
+limacharlie note list --brief --oid <oid> --output yaml
+
+# Read one note.
+limacharlie note get --key prod-network --oid <oid> --output yaml
+
+# Create or update a note from a file, enabled in one shot.
+limacharlie note set --key prod-network \
+    --input-file prod-network.yaml --enabled --oid <oid>
+
+# Or pipe the record in.
+cat prod-network.yaml | limacharlie note set \
+    --key prod-network --enabled --oid <oid>
+
+# Toggle without touching the content.
+limacharlie note disable --key prod-network --oid <oid>
+limacharlie note enable --key prod-network --oid <oid>
+
+# Organize with tags.
+limacharlie note tag add --key prod-network -t reference --oid <oid>
+
+# Delete.
+limacharlie note delete --key prod-network --confirm --oid <oid>
+```
+
+The input file takes the same shape as the record above — a `data` block with
+`text` and `description`, plus an optional `usr_mtd` block.
+
+### REST API
+
+Notes use the standard Hive endpoints with a hive name of `org_notes` and the
+organization ID as the partition key:
+
+```bash
+# List all notes.
+curl -s "https://api.limacharlie.io/v1/hive/org_notes/$OID" \
+  -H "Authorization: Bearer $LC_JWT"
+
+# Read one note.
+curl -s "https://api.limacharlie.io/v1/hive/org_notes/$OID/prod-network/data" \
+  -H "Authorization: Bearer $LC_JWT"
+
+# Create or update.
+curl -s -X POST \
+  "https://api.limacharlie.io/v1/hive/org_notes/$OID/prod-network/data" \
+  -H "Authorization: Bearer $LC_JWT" \
+  --data-urlencode 'data={"text":"# Production Network\n- 10.10.0.0/16 is production.","description":"Production network layout and ownership"}' \
+  --data-urlencode 'usr_mtd={"enabled":true}'
+```
+
+### Python SDK
+
+```python
+--8<-- "snippets/python/org_note_create.py"
+```
+
+Reading works the same way as any other hive:
+
+```python
+--8<-- "snippets/python/org_note_list.py"
+```
+
+## Version control
+
+`org_notes` is one of the hives the [Git Sync](../5-integrations/extensions/limacharlie/git-sync.md)
+extension can handle: enable it under the extension's `sync_hives` (pull from the
+repository) or `export_hives` (push to the repository) selection and notes are
+versioned alongside the rest of your configuration. Reviewing notes like code is
+worth it — they are the assumptions your analysts and agents act on.
+
+## Related
+
+- [SOPs](sops.md) — the procedures agents follow, in the sibling `sop` hive.
+- [AI Memory](memory.md) — what an agent learned and should recall later.
+- [AI Skills](skills.md) — reusable instruction sets an agent invokes as capabilities.
+- [Config Hive](../7-administration/config-hive/index.md) — the store notes live in.
+- [Permissions](../8-reference/permissions.md) — the full permission reference.

--- a/docs/9-ai-sessions/sops.md
+++ b/docs/9-ai-sessions/sops.md
@@ -2,8 +2,9 @@
 
 A Standard Operating Procedure is a document you store in your organization that
 tells AI agents how *your* team wants a job done. Where [AI Skills](skills.md) are
-reusable capabilities an agent can invoke and [AI Memory](memory.md) is what an agent
-has learned, an SOP is organizational policy: the escalation path for a ransomware
+reusable capabilities an agent can invoke, [AI Memory](memory.md) is what an agent
+has learned, and [Organization Notes](org-notes.md) are reference material about the
+environment, an SOP is organizational policy: the escalation path for a ransomware
 detection, who must approve an endpoint isolation, which hosts are never to be
 touched during business hours.
 
@@ -85,7 +86,9 @@ described SOPs (`ransomware-response`, `after-hours-escalation`,
     `limacharlie sop list` and `GET /v1/hive/sop/{oid}` return every SOP in full,
     including `text`. Agents are instructed to read only the names and descriptions
     at that stage and re-fetch the body with `sop get`, but budget context
-    accordingly if you keep many large SOPs.
+    accordingly if you keep many large SOPs. `limacharlie sop list --brief` reduces
+    each record's data to its `description` — that is the index-only form to prefer
+    when all you need is to decide what to fetch.
 
 ## Permissions
 
@@ -105,9 +108,9 @@ author policy.
 
 ### Web interface
 
-SOPs are managed under **Automation → SOPs** in the organization view, where you can
-create, edit, tag, enable, and disable them. In an interactive AI session, the
-`/sops` [slash command](rich-cards.md) renders the same list inline.
+SOPs are managed under **Organization Settings → SOPs** in the organization view,
+where you can create, edit, tag, enable, and disable them. In an interactive AI
+session, the `/sops` [slash command](rich-cards.md) renders the same list inline.
 
 ### CLI
 
@@ -198,5 +201,7 @@ for name, rec in sops.list().items():
 
 - [AI Skills](skills.md) — reusable instruction sets an agent invokes as capabilities.
 - [AI Memory](memory.md) — what an agent has learned and should recall later.
+- [Organization Notes](org-notes.md) — free-form reference documents about the
+  organization itself, in the sibling `org_notes` hive.
 - [Config Hive](../7-administration/config-hive/index.md) — the store SOPs live in.
 - [Permissions](../8-reference/permissions.md) — the full permission reference.

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -1,10 +1,5 @@
 # API Reference
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 All Cloud Security routes live under
 `https://api.limacharlie.io/v1/cloudsec/{oid}/…` and appear in the public
 OpenAPI spec at [`/openapi`](https://api.limacharlie.io/openapi).

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -1,10 +1,5 @@
 # Automation & Infrastructure-as-Code
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Everything Cloud Security does is scriptable: configuration is Hive records,
 the query/triage surface is the [REST API](api-reference.md) and
 [CLI](cli.md), and findings flow through the standard event pipeline. This

--- a/docs/cloud-security/caasm.md
+++ b/docs/cloud-security/caasm.md
@@ -1,10 +1,5 @@
 # CAASM — Cyber Asset Attack Surface Management
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Your tools already know what you own: the EDR sees devices, the identity
 provider sees users and their devices, MDM and scanners see more. CAASM
 merges those third-party views into one entity-resolved asset inventory and

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -1,10 +1,5 @@
 # Command Line Interface
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 The `limacharlie cloudsec` command group (Python SDK/CLI v2) covers most of
 the Cloud Security API surface: the posture and inventory reads, findings
 triage, graph queries, policy previews, CSV exports, and the fleet roll-up.

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -1,10 +1,5 @@
 # Compliance
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Cloud Security evaluates compliance frameworks continuously against the live
 estate: each control maps to detection rules, and a control fails when open
 findings prove the violation — so the compliance report is always as fresh

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -1,10 +1,5 @@
 # Configuration Reference
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Cloud Security is configured entirely through three Hive types. Anything the
 console can configure, `limacharlie hive set` can configure — which makes
 tenant onboarding and fleet-wide policy a script, not a UI workflow (see

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -1,10 +1,5 @@
 # Findings & Triage
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Everything Cloud Security detects lands in one place: a merged, risk-ranked
 findings worklist. CSPM misconfigurations, graph-derived attack paths, and
 identity (CIEM) risks are all findings with the same shape, the same triage

--- a/docs/cloud-security/getting-started.md
+++ b/docs/cloud-security/getting-started.md
@@ -1,10 +1,5 @@
 # Getting Started with Cloud Security
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 This guide takes an organization from zero to a populated Cloud Security
 dashboard: enable the product, connect a provider, run the first sweep, and
 declare what matters. You can do all of it in the console or entirely as code —
@@ -16,25 +11,19 @@ Cloud Security is enabled per organization by subscribing to the
 `ext-cloud-security` extension — the subscription is both the enable gate and
 the billing hook.
 
-!!! info "Private Beta: contact us to enable"
-    While Cloud Security is in Private Beta, `ext-cloud-security` is not
-    publicly subscribable — you cannot turn it on yourself. Contact us and we
-    will enable it for your organization. Enabling it requires the
-    `billing.ctrl` and `user.ctrl` permissions and an active billing
-    subscription on the organization.
+Subscribe from the console with the **Subscribe** button on
+**Extensions → Cloud Security**, or in one command:
+
+```bash
+limacharlie extension subscribe --name ext-cloud-security --oid $OID
+```
+
+Subscribing requires the `billing.ctrl` and `user.ctrl` permissions.
 
 Confirm the organization is enabled:
 
 ```bash
 limacharlie extension list --oid $OID
-```
-
-Once the extension is publicly subscribable, the same enable is a single
-command (and a **Subscribe** button on **Extensions → Cloud Security** in the
-console):
-
-```bash
-limacharlie extension subscribe --name ext-cloud-security --oid $OID
 ```
 
 Until the organization is subscribed, every Cloud Security API route returns

--- a/docs/cloud-security/graph.md
+++ b/docs/cloud-security/graph.md
@@ -1,10 +1,5 @@
 # Security Graph & Queries
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Every sweep builds a graph of the estate: resources, identities, and data
 stores as nodes; reachability, exposure, permissions, and vulnerability
 relationships as edges. The graph is what turns three individually-boring

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -1,10 +1,5 @@
 # Cloud Security
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 LimaCharlie Cloud Security is an agentless cloud-native application protection
 platform (CNAPP) built into the same tenant, permission model, and automation
 surface as the rest of LimaCharlie. It continuously enumerates your cloud,
@@ -55,9 +50,9 @@ demand, or continuously from a change feed. See
 ## How it works
 
 1. **Enable** the organization for the `ext-cloud-security` extension — the
-   subscription is the product's enable (and billing) gate. While Cloud
-   Security is in Private Beta, contact us to have it enabled for your
-   organization.
+   subscription is the product's enable (and billing) gate. Subscribe from
+   **Extensions → Cloud Security** in the console or with
+   `limacharlie extension subscribe --name ext-cloud-security`.
 2. **Connect providers**: one `cloudsec_provider` Hive record per cloud
    account / IdP tenant / AI org. A pre-save credential test probes every
    permission the collector needs and reports which are missing.

--- a/docs/cloud-security/provider-setup/anthropic.md
+++ b/docs/cloud-security/provider-setup/anthropic.md
@@ -1,10 +1,5 @@
 # Anthropic
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects your Anthropic organization as an AI-security surface: the member
 directory (including pending invites — staged seats that have never logged in),
 workspaces, and API keys from the Console plane, plus — for Claude

--- a/docs/cloud-security/provider-setup/auth0.md
+++ b/docs/cloud-security/provider-setup/auth0.md
@@ -1,10 +1,5 @@
 # Auth0
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects the Auth0 tenant as identity posture: the user directory (with MFA
 state), roles and role membership, applications and their machine (M2M)
 identities, client grants as entitlement edges, APIs (resource servers), and

--- a/docs/cloud-security/provider-setup/aws.md
+++ b/docs/cloud-security/provider-setup/aws.md
@@ -1,10 +1,5 @@
 # Amazon Web Services
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Read-only inventory via an IAM identity that **assumes a read-only role**.
 Two topologies:
 

--- a/docs/cloud-security/provider-setup/azure.md
+++ b/docs/cloud-security/provider-setup/azure.md
@@ -1,10 +1,5 @@
 # Microsoft Azure
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects the Azure estate — VMs and scale sets, storage, Key Vault, SQL/Cosmos,
 AKS, networking and NSGs, Azure OpenAI — plus the tenant's Entra ID directory
 (users, groups, service principals, app registrations, roles) and, where

--- a/docs/cloud-security/provider-setup/cloudflare.md
+++ b/docs/cloud-security/provider-setup/cloudflare.md
@@ -1,10 +1,5 @@
 # Cloudflare
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 The lightest provider: a **scoped, read-only API token** plus your **account
 ID**. No infrastructure to stand up.
 

--- a/docs/cloud-security/provider-setup/entra.md
+++ b/docs/cloud-security/provider-setup/entra.md
@@ -1,10 +1,5 @@
 # Microsoft Entra ID
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 A **directory-only** connection for organizations that use Entra ID or
 Microsoft 365 but have no Azure infrastructure to enumerate. It collects the
 tenant-global identity surface over Microsoft Graph: users, groups and

--- a/docs/cloud-security/provider-setup/gcp.md
+++ b/docs/cloud-security/provider-setup/gcp.md
@@ -1,10 +1,5 @@
 # Google Cloud
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects the Google Cloud estate across every project in scope — compute,
 storage, networking, IAM, KMS, databases, secrets, Pub/Sub — plus CIEM (who can
 reach what), Vertex AI inventory, and agentless workload vulnerabilities from

--- a/docs/cloud-security/provider-setup/github.md
+++ b/docs/cloud-security/provider-setup/github.md
@@ -1,10 +1,5 @@
 # GitHub
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects a GitHub organization: org settings, members (including outside
 collaborators) and teams (identities), repositories and their branch protection
 (data stores), installed GitHub Apps, deploy keys and Actions secrets (machine

--- a/docs/cloud-security/provider-setup/google-workspace.md
+++ b/docs/cloud-security/provider-setup/google-workspace.md
@@ -1,10 +1,5 @@
 # Google Workspace
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects identity posture from Google Workspace — users, groups and
 membership, admin roles, user security posture, devices, inbound-SSO profiles,
 and Gemini-in-Workspace usage — via the Admin SDK and Cloud Identity APIs.

--- a/docs/cloud-security/provider-setup/index.md
+++ b/docs/cloud-security/provider-setup/index.md
@@ -1,10 +1,5 @@
 # Provider Setup
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 [Getting Started](../getting-started.md) walks the end-to-end flow with a
 Google Cloud example. This section is the per-provider companion: for **every**
 supported platform, the exact scopes and permissions the collector needs, the

--- a/docs/cloud-security/provider-setup/limacharlie.md
+++ b/docs/cloud-security/provider-setup/limacharlie.md
@@ -1,10 +1,5 @@
 # LimaCharlie
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Inventories your **own LimaCharlie tenancy** as an estate, like any other SaaS
 platform: org members as identities (with MFA state), API keys as machine
 identities, sensors as assets, installation keys, telemetry outputs, extension

--- a/docs/cloud-security/provider-setup/okta.md
+++ b/docs/cloud-security/provider-setup/okta.md
@@ -1,10 +1,5 @@
 # Okta
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects the Okta directory as identity posture: users (with MFA factors and
 admin roles), groups and membership, application inventory and per-user app
 assignments, and external identity providers (federation / social trust).

--- a/docs/cloud-security/provider-setup/onepassword.md
+++ b/docs/cloud-security/provider-setup/onepassword.md
@@ -1,10 +1,5 @@
 # 1Password
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects the 1Password account directory — users and groups with membership —
 into the identity graph, unified by email with your cloud and IdP identities.
 Optionally, a **1Password Connect** server adds vault (secret-store) inventory.

--- a/docs/cloud-security/provider-setup/openai.md
+++ b/docs/cloud-security/provider-setup/openai.md
@@ -1,10 +1,5 @@
 # OpenAI
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 Collects your OpenAI platform organization as an AI-security surface: projects,
 members (including pending invites — staged seats that have never logged in)
 and service accounts, API keys (with last-used timestamps, so dormant

--- a/docs/cloud-security/providers.md
+++ b/docs/cloud-security/providers.md
@@ -1,10 +1,5 @@
 # Connecting Providers
 
-!!! warning "Private Beta"
-    Cloud Security is currently in **Private Beta**. Features, APIs, and
-    configuration formats described here may change before general
-    availability. Contact us if you would like access.
-
 A provider connection is one `cloudsec_provider` Hive record: a `provider_type`,
 the scope to enumerate, and a read-only credential. All collection is agentless.
 The credential itself always lives in the [secret](../7-administration/config-hive/secrets.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -564,6 +564,7 @@ nav:
       - AI Skills: 9-ai-sessions/skills.md
       - AI Memory: 9-ai-sessions/memory.md
       - SOPs: 9-ai-sessions/sops.md
+      - Organization Notes: 9-ai-sessions/org-notes.md
       - Command Line Interface: 9-ai-sessions/cli.md
       - Alternative Providers: 9-ai-sessions/alternative-providers.md
       - API Reference: 9-ai-sessions/api-reference.md

--- a/snippets/python/org_note_create.py
+++ b/snippets/python/org_note_create.py
@@ -1,0 +1,15 @@
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.hive import Hive, HiveRecord
+
+client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+org = Organization(client)
+Hive(org, "org_notes").set(HiveRecord(
+    name="prod-network",
+    data={
+        "text": "# Production Network\n- 10.10.0.0/16 is production.",
+        "description": "Production network layout and ownership",
+    },
+    enabled=True,
+    tags=["network", "reference"],
+))

--- a/snippets/python/org_note_list.py
+++ b/snippets/python/org_note_list.py
@@ -1,0 +1,14 @@
+from limacharlie.client import Client
+from limacharlie.sdk.organization import Organization
+from limacharlie.sdk.hive import Hive
+
+client = Client(oid="YOUR_OID", api_key="YOUR_API_KEY")
+org = Organization(client)
+notes = Hive(org, "org_notes")
+
+# The index: name and description of every note, cheap to scan.
+for name, record in notes.list().items():
+    print(name, (record.data or {}).get("description"))
+
+# The body of the one that matters.
+print(notes.get("prod-network").data["text"])


### PR DESCRIPTION
## What

Adds a page for the **`org_notes` hive** (Organization Notes) and brings the existing SOP page back in line with the product.

The `sop` hive had a full reference page; `org_notes` — same record shape, same lazy-load access pattern, read by the same AI agents — had none. Its only appearances in the docs were two compliance permission tables, both citing `org_notes.read`, which is not a permission (the real verbs are `get` / `set` / `del` / `get.mtd` / `set.mtd`), so a key issued from those tables grants no note access at all.

## Changes

**New — `docs/9-ai-sessions/org-notes.md`**

- Record format: `text` (required, non-empty is the only validation) and `description` (used by agents to decide relevance), with a realistic example.
- Limits: 1 MB per record; created **disabled** like every hive record.
- How agents actually consume notes: list the index (`limacharlie note list --brief`), then fetch by key — the same two-step pattern documented for SOPs.
- Full permission table, CLI (`limacharlie note`, whose hive is `org_notes`), REST (`/v1/hive/org_notes/{oid}`), Python SDK, Git Sync coverage.
- Draws the boundaries against the three things it gets confused with: SOPs (procedure vs. reference), AI Memory (agent-authored vs. human-authored — and why mirroring notes into memory goes stale), and case/investigation notes (incident-scoped vs. org-scoped).

**Fixes**

- `org_notes.read` → `org_notes.get` in `compliance/skills.md` and `compliance/case-reviewer-agent.md`.
- `docs/8-reference/permissions.md`: added the `org_notes.*` block (it listed `sop.*` but skipped this hive).
- `docs/9-ai-sessions/sops.md`: web UI location is now **Organization Settings → SOPs**; the "listing returns full records" note now names `--brief`, the index-only form it was describing without naming it; cross-links to the new page.
- Config Hive index and the AI nav now list Organization Notes next to SOPs.

Two runnable Python examples added under `snippets/python/` so CI compiles them against the pinned SDK rather than letting inline code drift.

## Verification

- `mkdocs build --strict` → clean (all new links and snippet includes resolve)
- `python -m py_compile snippets/python/org_note_*.py` → clean
- `scripts/check-list-numbering.py` → 0 new breaks
- Record shape, validation, size limit, permission names, CLI group/flags and REST paths each checked against the implementing code, not memory.

Paired with the UI move that changes the SOP page's stated location: https://github.com/refractionPOINT/web-app-frontend/pull/4168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4ashJWHXXMFpn7KbMmccP

---

## Also in this PR: Cloud Security is GA

Second commit, unrelated to the hive docs: Cloud Security is no longer in Private Beta, so the beta framing comes out.

- Removed the `!!! warning "Private Beta"` admonition from all **26** Cloud Security pages (the 25 under `cloud-security/` plus `8-reference/cloud-security-api-iac.md`), including its "may change before general availability" caveat.
- **Getting Started step 1** claimed `ext-cloud-security` is "not publicly subscribable — you cannot turn it on yourself. Contact us", with the self-serve command demoted to a "once the extension is publicly subscribable" aside. The extension is public now (verified against the unauthenticated public extension registry), so subscribing is now the primary path: console **Subscribe** button or `limacharlie extension subscribe`. The `billing.ctrl` + `user.ctrl` requirement is kept — that is what the subscribe endpoint enforces. The blanket "requires an active billing subscription" claim is dropped, since the free-tier trial section right below it already states the real terms.
- **Overview → How it works** step 1 pointed at contacting us to have the org enabled; now points at the same self-serve subscribe.

`mkdocs build --strict` and the list-numbering check are clean after both commits.
