### PR TITLE
docs(dr): unit tests do not support stateful rules

### DIFF
--- a/docs/3-detection-response/stateful-rules.md
+++ b/docs/3-detection-response/stateful-rules.md
@@ -200,6 +200,14 @@ Stateful rules are forward-looking only and changing a rule will reset its state
 
 Practically speaking, this means that if you change a rule that detects `excel.exe -> cmd.exe`, `excel.exe` will need to be relaunched while the updated rule is running for it to then begin watching for `cmd.exe`.
 
+[Rule unit tests](unit-tests.md) do not cover stateful rules. They evaluate the `detect` block one event at a time with no cross-event state, so a rule using `with child`, `with descendant` or `with events` is **rejected outright when it carries a `tests` block**:
+
+```text
+error parsing rule: rule context does not support stateful operators
+```
+
+Use [Replay](../5-integrations/services/replay.md) to exercise a stateful rule instead — it compiles the rule with the full engine and runs it over historical sensor traffic or a list of events supplied in the request, so the correlation is actually evaluated.
+
 ### Using Events in Actions
 
 Using `report` to report a detection works according to the [Choosing Event to Report](#choosing-event-to-report) section earlier. Other actions have a subtle difference: they will *always* observe the latest event in the chain.

--- a/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
+++ b/docs/3-detection-response/tutorials/dr-rule-building-guidebook.md
@@ -1832,7 +1832,8 @@ tests:
 
 - `match` contains tests that should trigger the rule.
 - `non_match` contains tests that should NOT trigger the rule.
-- Each test is a list of events (to support stateful rules with multiple events).
+- Each test is a list of events, evaluated independently: a `match` test passes if **any** of its events matches, a `non_match` test fails if **any** of them matches. The list is a set of alternatives, not an ordered chain.
+- **Stateful rules cannot have `tests`.** A rule using `with child`, `with descendant` or `with events` is rejected when it carries a `tests` block (`rule context does not support stateful operators`); use [Replay](../../5-integrations/services/replay.md) for those. See [Unit Tests](../unit-tests.md).
 - Events must include both `event` and `routing` objects.
 - Platform values in `routing/plat` are numeric (e.g., `268435456` for Windows).
 

--- a/docs/3-detection-response/unit-tests.md
+++ b/docs/3-detection-response/unit-tests.md
@@ -90,6 +90,14 @@ A practical split for a stateful rule:
 - Test each side of the relationship on its own by temporarily lifting the sub-rule into a standalone stateless rule with its own `tests` — this validates the paths, operators and values.
 - Test the correlation itself with Replay, over traffic that contains the real chain of events.
 
+When you supply the events yourself rather than replaying stored traffic, the correlation only resolves if the events carry what links them:
+
+- The **same `routing/sid`**, since stateful state is tracked per sensor.
+- The parent's **`routing/this`** atom repeated as the child's **`routing/parent`** atom (`with descendant` follows the chain further down).
+- The events in **chronological order**. Stateful evaluation is forward-looking: a child that arrives before its parent does not match.
+
+A match reports the *first* event of the chain unless the rule sets `report latest event: true`, so expect the parent event in the result.
+
 ### Example
 
 ```yaml

--- a/docs/3-detection-response/unit-tests.md
+++ b/docs/3-detection-response/unit-tests.md
@@ -4,6 +4,23 @@
 
 A D&R rule record can optionally contain unit tests. These tests describe events that should match, and events that should not match. When a D&R rule is updated or created, LimaCharlie will simulate the rules and if the tests fail, an error is produced.
 
+!!! warning "Not supported for stateful rules"
+    Unit tests evaluate the `detect` block one event at a time, with no
+    cross-event state. A rule that uses a
+    [stateful operator](stateful-rules.md) — `with child`, `with descendant`
+    or `with events` — **cannot carry `tests`**: creating or updating it is
+    rejected with
+
+    ```text
+    error parsing rule: rule context does not support stateful operators
+    ```
+
+    The rule itself is fine; it is the combination with `tests` that fails.
+    Remove the `tests` block to save the rule, and exercise stateful logic
+    with [Replay](../5-integrations/services/replay.md) instead, which runs
+    the full engine over a real event stream. See
+    [Testing stateful rules](#testing-stateful-rules) below.
+
 ### Structure
 
 A typical D&R rule looks like:
@@ -22,7 +39,14 @@ A typical D&R rule looks like:
 }
 ```
 
-The `match` and `non_match` both have the same format: they contain a list of lists of events. Each top list element is a unit test, and the content of a test is a list of events as would be seen by LimaCharlie. The reason for the test to be a list is to accomodate for [Stateful Detections](stateful-rules.md) which operate across multiple events.
+The `match` and `non_match` both have the same format: they contain a list of lists of events. Each top list element is a unit test, and the content of a test is a list of events as would be seen by LimaCharlie.
+
+The events inside one test are **alternatives, not a sequence**. Each is evaluated against the `detect` block independently, and the test as a whole is judged on whether any of them matched:
+
+- A **`match`** test passes as soon as one of its events matches, and fails if none of them do. So a test holding three events asserts "at least one of these three is caught by the rule".
+- A **`non_match`** test fails as soon as one of its events matches. So a test holding three events asserts "none of these three is caught by the rule".
+
+Nothing is carried from one event to the next, and nothing is carried between tests. This is why a test with several events is useful for grouping variants of the same idea (three ways of spelling the same command line, say) but cannot express a chain of events that only means something in order — see the stateful-rule limitation above.
 
 Here's an example:
 
@@ -41,6 +65,30 @@ Here's an example:
   }
 }
 ```
+
+### Event types must line up with the rule
+
+When the rule declares the events it applies to (`event:` or `events:` in the `detect` block), test events are checked against that declaration:
+
+- In a **`match`** test, an event of any other type is an error, not a silent skip:
+
+    ```text
+    test 2 failed validation: test event type 'NEW_DOCUMENT' does not match rule's expected event(s): [NEW_PROCESS]
+    ```
+
+    This usually means the `routing/event_type` in the test event is missing or misspelled.
+
+- In a **`non_match`** test, an event of another type is skipped. A rule scoped to `NEW_PROCESS` can never match a `NEW_DOCUMENT` event, so asserting it does not match proves nothing.
+
+### Testing stateful rules
+
+Unit tests cannot cover [stateful rules](stateful-rules.md): `tests` on a rule using `with child`, `with descendant` or `with events` is rejected outright (see the warning at the top of this page). The correct tool is [Replay](../5-integrations/services/replay.md), which compiles the rule with the full D&R engine — stateful operators included — and evaluates it forward over a real event stream, either historical sensor traffic (`limacharlie replay run --detect-file … --start … --end …`) or events supplied directly in the API request.
+
+A practical split for a stateful rule:
+
+- Keep the rule's `tests` block empty or absent.
+- Test each side of the relationship on its own by temporarily lifting the sub-rule into a standalone stateless rule with its own `tests` — this validates the paths, operators and values.
+- Test the correlation itself with Replay, over traffic that contains the real chain of events.
 
 ### Example
 


### PR DESCRIPTION
## The problem

The Unit Tests page said the list-of-events shape exists "to accomodate for Stateful Detections which operate across multiple events", and the rule-building guidebook repeated it ("to support stateful rules with multiple events").

Both are wrong, and in the expensive direction: a rule using `with child`, `with descendant` or `with events` is **rejected** when it carries a `tests` block. The unit-test runner builds a standalone evaluator with no engine behind it — which is where stateful state lives — so create/update fails with:

```text
error parsing rule: rule context does not support stateful operators
```

A reader following the current docs writes a stateful rule with tests, gets an error that names neither `tests` nor the actual restriction, and has nothing to go on.

## Verified, not assumed

Against the validate endpoint (dry-run, nothing written):

| Rule | `tests`? | Result |
|---|---|---|
| `with child` stateful | no | valid |
| `with child` stateful | yes | `error parsing rule: rule context does not support stateful operators` |
| stateless | yes | valid |

Also verified the real meaning of the event list: a `match` test whose **first** event does not match but whose second does **validates** — so the events in a test are independent alternatives, not an ordered chain. A `match` test passes as soon as one event matches; a `non_match` test fails as soon as one matches. Nothing carries between events or between tests.

And the recommended alternative works: replaying a `with child` rule through Replay compiles and runs (Replay uses the full engine and forces forward-looking evaluation for stateful requests).

Event-type validation was read from the same code path and reproduced: a foreign event type is a hard error in a `match` test (`test 2 failed validation: test event type 'NEW_DOCUMENT' does not match rule's expected event(s): [NEW_PROCESS]`) and silently skipped in a `non_match` test.

## Changes

- **`3-detection-response/unit-tests.md`** — warning up front that stateful rules cannot carry tests, with the exact error and the fix; corrected explanation of what a multi-event test means; new **Testing stateful rules** section (keep `tests` off the stateful rule, unit-test the sub-rules standalone, test the correlation with Replay); note on event-type validation.
- **`3-detection-response/tutorials/dr-rule-building-guidebook.md`** — same correction in its Unit Testing key-points list.
- **`3-detection-response/stateful-rules.md`** — its "Testing Stateful Rules" caveat previously only covered live forward-looking behaviour; it now states unit tests are not an option and points at Replay, since that is where a reader looks first.

`mkdocs build --strict` and the list-numbering check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4ashJWHXXMFpn7KbMmccP

---

## Replay-as-the-alternative: verified end to end

The first pass only established that Replay *compiles* a stateful rule. That is not the same as evaluating the correlation, so it was checked properly by feeding Replay an atom-linked event pair (no side effects — Replay's `report` callback only collects results, it emits no detections):

| Events fed to Replay (`cmd.exe -> whoami.exe`, `with child`) | Result |
|---|---|
| stateless control rule | match (sanity check) |
| parent `cmd.exe`, then child `whoami.exe` — same `sid`, child's `routing/parent` = parent's `routing/this` | **match**, reporting the **parent** event |
| child only, no parent | no match |
| child before parent (reversed order) | no match |

The last two are what make it conclusive: the chain is genuinely tracked, and evaluation is forward-only.

Second commit documents the consequence, since it is the trap for anyone moving a test out of `tests` and into Replay with hand-written events: same `routing/sid`, the parent's `routing/this` repeated as the child's `routing/parent`, chronological order, and a match reports the first event of the chain unless `report latest event: true` is set.
