### PR TITLE
docs(cloud-security): GCP serverless scopes — Cloud Run + Cloud Functions

### DIFF
--- a/docs/cloud-security/provider-setup/gcp.md
+++ b/docs/cloud-security/provider-setup/gcp.md
@@ -115,11 +115,15 @@ Each adds one inventory or analysis surface. Skipping one leaves that surface
 !!! note "2nd-gen functions are authorized as Cloud Run services"
     A 2nd-gen Cloud Function runs on Cloud Run, and its **invoker** permission
     lives on the underlying Cloud Run service (`roles/run.invoker`) rather than
-    on the function (`roles/cloudfunctions.invoker` is the 1st-gen role). A
-    least-privilege grant with `roles/cloudfunctions.viewer` but **not**
-    `roles/run.viewer` will therefore list your 2nd-gen functions while leaving
-    every one of them without a public-access verdict. If you use 2nd-gen
-    functions, grant both.
+    on the function (`roles/cloudfunctions.invoker` is the 1st-gen role). So
+    assessing a 2nd-gen function's public access reads the **Cloud Run** side,
+    not the Cloud Functions side.
+
+    If you are assembling a least-privilege grant rather than using the required
+    baseline, grant both `roles/run.viewer` and `roles/cloudfunctions.viewer` and
+    let `provider test` confirm it: the `serverless` check exercises both APIs and
+    reports each separately, so it will tell you if one half is missing rather
+    than leaving you to reason about role contents.
 
 !!! note "`osconfig_vuln` does not prove the inventory join"
     The `osconfig_vuln` check probes the vulnerability-report read only, so it
@@ -270,6 +274,6 @@ the GCP-specific checks follow.
 | `iam` fails on `getIamPolicy` | `roles/viewer` alone does not cover every `getIamPolicy` | Add `roles/iam.securityReviewer` |
 | A check passes with *"API not enabled on the probed project"* | Benign — the sweep skips API-disabled projects | Enable the named API if you want that surface; otherwise ignore |
 | `activity_ciem` fails with *Recommender API not enabled* | Recommender / Policy Analyzer not enabled on the probed project | Enable `recommender.googleapis.com` and `policyanalyzer.googleapis.com` |
-| `serverless` fails on `run` only | The grant covers Cloud Functions but not Cloud Run | Add `roles/run.viewer`. 2nd-gen functions are authorized as Cloud Run services, so without it they list with no public-access verdict |
+| `serverless` fails on `run` only | The grant reaches Cloud Functions but not Cloud Run | Add `roles/run.viewer`. 2nd-gen functions are authorized as Cloud Run services, so without that read they list with no public-access verdict |
 | Cloud Run services appear but none is ever flagged public | `getIamPolicy` is denied on Cloud Run, so the invoker verdict is unobserved rather than negative | Add `roles/iam.securityReviewer` (or `roles/run.viewer`) and re-run the sweep |
 | Inventory is missing whole projects | Those projects are not `ACTIVE`, or the grant is on a narrower node | Confirm project state, and that the binding is at the scope you configured |

--- a/docs/cloud-security/provider-setup/gcp.md
+++ b/docs/cloud-security/provider-setup/gcp.md
@@ -104,6 +104,14 @@ Each adds one inventory or analysis surface. Skipping one leaves that surface
     verdict rather than guess — so serverless exposure findings are **absent,
     not empty**, which is a different thing from "you have none".
 
+!!! note "Services published only through a load balancer"
+    A Cloud Run service or function whose ingress is **internal and Cloud Load
+    Balancing** cannot be reached at its own `run.app` URL, but it *can* be
+    published to the internet through an external load balancer in front of it.
+    We do not yet collect load balancers, so such a service is inventoried but
+    is **not** reported as internet-facing. Services reachable directly at their
+    own URL are assessed normally.
+
 !!! note "2nd-gen functions are authorized as Cloud Run services"
     A 2nd-gen Cloud Function runs on Cloud Run, and its **invoker** permission
     lives on the underlying Cloud Run service (`roles/run.invoker`) rather than

--- a/docs/cloud-security/provider-setup/gcp.md
+++ b/docs/cloud-security/provider-setup/gcp.md
@@ -1,9 +1,9 @@
 # Google Cloud
 
 Collects the Google Cloud estate across every project in scope — compute,
-storage, networking, IAM, KMS, databases, secrets, Pub/Sub — plus CIEM (who can
-reach what), Vertex AI inventory, and agentless workload vulnerabilities from
-VM Manager.
+serverless (Cloud Run and Cloud Functions), storage, networking, IAM, KMS,
+databases, secrets, Pub/Sub — plus CIEM (who can reach what), Vertex AI
+inventory, and agentless workload vulnerabilities from VM Manager.
 
 **Auth model:** a **service-account key** (JSON) granted read-only roles at the
 **organization**, **folder**, or **project** you want enumerated. The collector
@@ -32,6 +32,8 @@ discovers every active project underneath that node by itself.
       pubsub.googleapis.com \
       apikeys.googleapis.com \
       osconfig.googleapis.com \
+      run.googleapis.com \
+      cloudfunctions.googleapis.com \
       aiplatform.googleapis.com \
       notebooks.googleapis.com \
       recommender.googleapis.com \
@@ -85,7 +87,31 @@ Each adds one inventory or analysis surface. Skipping one leaves that surface
 | `roles/recommender.iamViewer` | Unused-privilege findings (activity-based CIEM) | `activity_ciem` |
 | `roles/policyanalyzer.activityAnalysisViewer` | Dormant-identity / last-authentication findings | `activity_ciem` |
 | `roles/aiplatform.viewer` | Vertex AI endpoint and model inventory | `vertex_ai` |
+| `roles/run.viewer` | Cloud Run service inventory **and its public-access verdict** (`run.services.list` + `run.services.getIamPolicy`) | `serverless` |
+| `roles/cloudfunctions.viewer` | Cloud Functions inventory (1st and 2nd gen) plus their invoker policies (`cloudfunctions.functions.list` + `cloudfunctions.functions.getIamPolicy`) | `serverless` |
 | `roles/cloudidentity.groups.readonly` | Google-group **membership expansion**, so `group:` IAM bindings resolve to real people | `cloud_identity` |
+
+!!! note "Serverless already works on the required baseline"
+    The required `roles/viewer` + `roles/iam.securityReviewer` pair **already**
+    grants both the list and the `getIamPolicy` reads for Cloud Run and Cloud
+    Functions, so you do not need to add anything for serverless coverage. The
+    two roles above exist for the least-privilege alternative (`roles/browser`
+    plus per-service viewers), where they are what turns serverless coverage on.
+
+    Both halves of each grant matter, and the second is the one that gets
+    missed: without `getIamPolicy` we can list a service but cannot tell whether
+    it is invocable by *anyone on the internet*. In that case we report no
+    verdict rather than guess — so serverless exposure findings are **absent,
+    not empty**, which is a different thing from "you have none".
+
+!!! note "2nd-gen functions are authorized as Cloud Run services"
+    A 2nd-gen Cloud Function runs on Cloud Run, and its **invoker** permission
+    lives on the underlying Cloud Run service (`roles/run.invoker`) rather than
+    on the function (`roles/cloudfunctions.invoker` is the 1st-gen role). A
+    least-privilege grant with `roles/cloudfunctions.viewer` but **not**
+    `roles/run.viewer` will therefore list your 2nd-gen functions while leaving
+    every one of them without a public-access verdict. If you use 2nd-gen
+    functions, grant both.
 
 !!! note "`osconfig_vuln` does not prove the inventory join"
     The `osconfig_vuln` check probes the vulnerability-report read only, so it
@@ -139,7 +165,9 @@ for ROLE in roles/secretmanager.viewer \
             roles/osconfig.inventoryViewer \
             roles/recommender.iamViewer \
             roles/policyanalyzer.activityAnalysisViewer \
-            roles/aiplatform.viewer; do
+            roles/aiplatform.viewer \
+            roles/run.viewer \
+            roles/cloudfunctions.viewer; do
   gcloud organizations add-iam-policy-binding "$ORG_ID" \
     --member "serviceAccount:${SA}" --role "$ROLE"
 done
@@ -215,6 +243,7 @@ the GCP-specific checks follow.
 | `activity_ciem` | — | Unused-privilege and dormant-identity findings unavailable. |
 | `osconfig_vuln` | — | Workload vulnerability findings unavailable. |
 | `vertex_ai` | — | Vertex AI endpoint inventory unavailable. |
+| `serverless` | — | Cloud Run / Cloud Functions inventory unavailable, and with it the "invocable by anyone on the internet" verdict for that tier. Reported per API, so a partial grant names the half that is missing. |
 | `cloud_identity` | — | Group membership is not expanded; `group:` bindings do not resolve to people. |
 
 !!! tip "Org-scope tests probe one representative project"
@@ -233,4 +262,6 @@ the GCP-specific checks follow.
 | `iam` fails on `getIamPolicy` | `roles/viewer` alone does not cover every `getIamPolicy` | Add `roles/iam.securityReviewer` |
 | A check passes with *"API not enabled on the probed project"* | Benign — the sweep skips API-disabled projects | Enable the named API if you want that surface; otherwise ignore |
 | `activity_ciem` fails with *Recommender API not enabled* | Recommender / Policy Analyzer not enabled on the probed project | Enable `recommender.googleapis.com` and `policyanalyzer.googleapis.com` |
+| `serverless` fails on `run` only | The grant covers Cloud Functions but not Cloud Run | Add `roles/run.viewer`. 2nd-gen functions are authorized as Cloud Run services, so without it they list with no public-access verdict |
+| Cloud Run services appear but none is ever flagged public | `getIamPolicy` is denied on Cloud Run, so the invoker verdict is unobserved rather than negative | Add `roles/iam.securityReviewer` (or `roles/run.viewer`) and re-run the sweep |
 | Inventory is missing whole projects | Those projects are not `ACTIVE`, or the grant is on a narrower node | Confirm project state, and that the binding is at the scope you configured |


### PR DESCRIPTION
## What was asked

Cloud Run and Cloud Functions inventory is now collected for Google Cloud connections, together
with a verdict on whether each workload can be invoked from the internet with no authentication.
Document the scopes that verdict needs — before a customer discovers them as a silent denial.

## What was done

All in `docs/cloud-security/provider-setup/gcp.md`.

- **The required baseline already covers it.** `roles/viewer` + `roles/iam.securityReviewer`
  grant both the list and the `getIamPolicy` reads, so nothing changes for a customer following
  the standard setup. Said explicitly, so the two new rows are not misread as new requirements.
- **Two optional rows** — `roles/run.viewer` and `roles/cloudfunctions.viewer` — for the
  least-privilege alternative (`roles/browser` plus per-service viewers), where they are what
  turns serverless coverage on. Added to the setup script too.
- **Both halves of each grant are called out.** Without `getIamPolicy` we can list a service but
  cannot tell whether anyone on the internet can invoke it, and we report **no verdict** rather
  than guess — so serverless exposure findings are *absent, not empty*, which is a different
  thing from "you have none".
- **The 2nd-gen trap.** A 2nd-gen Cloud Function runs on Cloud Run and its *invoker* permission
  lives on the underlying Cloud Run service (`roles/run.invoker`), not on the function
  (`roles/cloudfunctions.invoker` is the 1st-gen role). So a grant with
  `roles/cloudfunctions.viewer` but **not** `roles/run.viewer` lists 2nd-gen functions while
  leaving every one of them without a public-access verdict.
- **New `serverless` row** in the preflight-check table, and two troubleshooting rows — including
  the symptom that looks like good news: services listed, none ever flagged public, because
  `getIamPolicy` is denied.
- `run.googleapis.com` + `cloudfunctions.googleapis.com` added to the enable list; the page intro
  now mentions serverless alongside compute.

## Testing

- Verified against the public Google Cloud IAM and Cloud Functions documentation: the permission
  names (`run.services.list`, `run.services.getIamPolicy`, `cloudfunctions.functions.list`,
  `cloudfunctions.functions.getIamPolicy`), the role names, and the 2nd-gen invoker behaviour
  (the Cloud Functions access-control page documents granting `roles/run.invoker` to `allUsers`
  via `gcloud run services add-iam-policy-binding`).
- Markdown-only change: table rows plus three admonitions and two script lines. No numbered lists
  touched, so the list-numbering check is unaffected. `mkdocs` is not installed locally, so the
  rendered-site checks run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7CkEf1fEa9Y8dBn5Utrx1