### PR TITLE
docs(cloud-security): add cis-m365 to the shipped framework list

### DIFF
--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -15,11 +15,16 @@ limacharlie cloudsec compliance report --framework cis-gcp
 limacharlie cloudsec compliance frameworks
 ```
 
-Ten frameworks ship today — `cis-aws`, `cis-azure`, `cis-gcp` (the default),
-`soc2`, `pci-dss`, `hipaa`, `iso-27001`, `nist-csf`, `nist-ai-rmf`, and
-`owasp-llm`. The last two are AI frameworks: they assess the OpenAI and
+Eleven frameworks ship today — `cis-aws`, `cis-azure`, `cis-gcp` (the default),
+`cis-m365`, `soc2`, `pci-dss`, `hipaa`, `iso-27001`, `nist-csf`, `nist-ai-rmf`,
+and `owasp-llm`. The last two are AI frameworks: they assess the OpenAI and
 Anthropic estate connected through the
-[AI providers](providers.md#ai-security-aispm). The set
+[AI providers](providers.md#ai-security-aispm). `cis-m365` is graded off the
+Microsoft Entra directory, so it covers the benchmark's Entra chapter and reports
+NOT_ASSESSED for the admin centers that are not collected (Defender, Purview,
+Exchange, SharePoint, Teams) — read each control's description for what it
+assesses and why. It applies to a tenant connected as an `entra` provider, or as
+the Entra half of an `azure` one. The set
 grows over time, so `limacharlie cloudsec compliance frameworks`
 (`GET /compliance/frameworks`) — which carries each framework's `id`, `name`,
 `version`, and control counts — is the source of truth for valid


### PR DESCRIPTION
## What was asked

A customer asked for the **CIS Microsoft 365 Foundations Benchmark** under Cloud Security → Compliance → Framework. It is being added to the shipped framework set; this page's list needs to match.

## What was done

`docs/cloud-security/compliance.md` carries both a **count** ("Ten frameworks ship today") and an **exhaustive list**, and the same paragraph then points at `limacharlie cloudsec compliance frameworks` / `GET /compliance/frameworks` as the source of truth. That combination is what makes a stale list read as authoritative rather than as a simple omission — a reader checks the prose, sees a closed set, and does not run the command.

- count → eleven, `cis-m365` added to the list;
- added what the framework actually covers, because listing it without that over-promises: it is graded off the Microsoft Entra directory, so it covers the benchmark's Entra chapter and reports `NOT_ASSESSED` for the admin centers that are not collected (Defender, Purview, Exchange, SharePoint, Teams), with each control's description carrying its own reason. Noted that it applies to a tenant connected as an `entra` provider or as the Entra half of an `azure` one.

## Testing

Prose only — no code, no build. The claims about coverage and applicability match the shipping catalog's control set and its per-control descriptions.

## Note

Land this **with** the backend change that adds the framework, not before — until then the list would name an id `GET /compliance/frameworks` does not return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8MaumkdjpNKcNUw3mJNtR