### PR TITLE
docs(cloud-security): document the AWS iam_boundaries provider-test check

### DIFF
--- a/docs/cloud-security/provider-setup/aws.md
+++ b/docs/cloud-security/provider-setup/aws.md
@@ -115,6 +115,7 @@ the AWS-specific checks follow.
 | `auth` | ✅ | `sts:AssumeRole` failed — wrong external ID, trust policy, or credentials. Nothing else is probed. |
 | `ec2` | ✅ | Compute inventory unavailable. |
 | `iam` | ✅ | IAM inventory unavailable — the CIEM access graph cannot be built. |
+| `iam_boundaries` | — | IAM permission boundaries unreadable (`iam:GetAccountAuthorizationDetails`). A principal whose boundary caps it below its policies is scored on the uncapped policies, so it can be reported as an administrator when it is not. |
 | `s3` | ✅ | Storage inventory unavailable. |
 | `regions` | — | Only meaningful when `aws_regions` is **unset** (with it set the check is skipped as unnecessary, and still counts as passing). Enabled-region enumeration was denied, so the sweep falls back to `us-east-1` alone — list the regions you want in `aws_regions`. |
 | `organizations` | — | Member-account discovery unavailable; only the connected account is swept. |


### PR DESCRIPTION
## What was asked

The AWS provider test gained an optional `iam_boundaries` check (IAM permission boundary collection, parity package C2). The verify-and-coverage table on the AWS provider-setup page should list it, like every other probe.

## What was done

One row in `docs/cloud-security/provider-setup/aws.md`, stating what is lost if the check fails: a principal whose permissions boundary caps it below its attached policies is scored on the uncapped policies, so it can be reported as an administrator when it is not.

The check is **optional** and needs no policy change — `iam:GetAccountAuthorizationDetails` is covered by `iam:Get*` in `SecurityAudit`, which the page already tells operators to attach, so a role built the documented way passes. The row exists for operators who attach a hand-rolled least-privilege policy instead; the "With `SecurityAudit` + `ViewOnlyAccess`, every optional surface above also passes" line below the table remains true and is unchanged.

## Testing

Markdown only.

## Note

The `org_policies` check (parity package C1) is also missing from this table; it belongs to that package's own docs change and is deliberately left alone here to avoid two PRs editing the same rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3AnxeGmcGA9scrsRZFtg9
