### PR TITLE
docs(cloud-security): make the Workspace customer ID unmissable

### DIFF
--- a/docs/cloud-security/provider-setup/google-workspace.md
+++ b/docs/cloud-security/provider-setup/google-workspace.md
@@ -52,10 +52,8 @@ https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.google
     `admin.reports.audit.readonly` reads the Admin SDK **Reports** audit stream
     to land Gemini-in-Workspace usage as an application with per-user access
     edges — only the set of users seen in the trailing window, never any
-    prompt or response content. Leaving it out is safe: the surface degrades to
-    unobserved (previously collected rows are kept, not deleted) and
-    `provider test` reports it as a failed **optional** check, so the connection
-    stays healthy overall.
+    prompt or response content. Skipping it costs only that surface: it degrades
+    to unobserved and previously collected rows are kept, never deleted.
 
 ## Register domain-wide delegation
 
@@ -205,6 +203,23 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `devices_ci` | — | Cloud Identity device inventory unavailable. |
 | `reports` | — | Gemini-in-Workspace usage unavailable (no AI-application rows or per-user access edges). |
 
+!!! warning "An ungranted optional scope still shows the connection as Failed"
+    The optional surfaces above degrade safely — the surface goes unobserved,
+    its previously collected rows are kept rather than deleted, and
+    `provider test` still reports **OK** overall, because only the required
+    checks decide that verdict.
+
+    The **Last Sync** badge on the providers page works differently. It reports
+    *partial coverage*: any collector left uncovered marks the sync **Failed**,
+    even when every required surface succeeded. So a connection that is working
+    as intended, minus one optional scope you chose not to grant, sits on a
+    permanent **Failed** badge.
+
+    Hover the badge for the error detail — it names the collectors that were
+    left uncovered and why. If the reason is a scope you deliberately skipped,
+    the connection is healthy and the badge can be ignored; grant the scope to
+    clear it.
+
 ## Troubleshooting
 
 | `provider test` error | Cause | Fix |
@@ -215,4 +230,4 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `token mint failed (HTTP 401): scope not granted to the delegated admin` | DWD missing scopes (all-or-nothing mint), a non-`.readonly` variant, or not yet propagated | Register the **full** scope list exactly; wait for propagation; confirm the service account's client ID matches |
 | `core` fails: `HTTP 403: Not Authorized to access this resource/api` | A token **was** minted (so the scopes are registered) but the caller has no Workspace admin authority. Almost always the secret is a **raw service-account key with no `admin_email`** — typically the GCP provider's secret reused verbatim — so nothing is impersonated and the delegation you configured is never used. It is silently accepted as the no-delegation form. Otherwise, `admin_email` names a user who is not a Super Admin | Give Workspace its **own** secret in the wrapper envelope with `admin_email`; leave the GCP provider's secret untouched. Reusing the same *service account* is fine — reusing the same *secret* is not |
 | `HTTP 403: … API has not been used in project …` | Admin SDK / Cloud Identity API not enabled | Enable the named API in the service account's project |
-| `reports` fails: `HTTP 401: Access denied. You are not authorized to read activity records.` | The token minted (so the DWD registration itself is fine) but the impersonated admin cannot read the Reports audit stream — either `admin.reports.audit.readonly` is missing from the DWD scope list, or `admin_email` names an admin without the *Reports* privilege | Add the scope to the delegation and impersonate a Super Admin. Optional surface: leaving it as-is only drops Gemini-in-Workspace usage |
+| `reports` fails: `HTTP 401: Access denied. You are not authorized to read activity records.` | The token minted (so the DWD registration itself is fine) but the impersonated admin cannot read the Reports audit stream — either `admin.reports.audit.readonly` is missing from the DWD scope list, or `admin_email` names an admin without the *Reports* privilege | Add the scope to the delegation and impersonate a Super Admin. Optional surface: leaving it as-is drops only Gemini-in-Workspace usage — but it does leave the connection's **Last Sync** badge on Failed, per the note above |

--- a/docs/cloud-security/provider-setup/google-workspace.md
+++ b/docs/cloud-security/provider-setup/google-workspace.md
@@ -48,13 +48,14 @@ Copy-paste block for the DWD scopes field (one comma-separated line):
 https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.group.member.readonly,https://www.googleapis.com/auth/admin.directory.user.security,https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly,https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly,https://www.googleapis.com/auth/admin.directory.device.mobile.readonly,https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly,https://www.googleapis.com/auth/cloud-identity.devices.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly
 ```
 
-!!! info "Gemini usage has no preflight check"
+!!! info "What the Gemini scope collects"
     `admin.reports.audit.readonly` reads the Admin SDK **Reports** audit stream
     to land Gemini-in-Workspace usage as an application with per-user access
     edges — only the set of users seen in the trailing window, never any
-    prompt or response content. It is the one surface `provider test` does not
-    probe: if the scope is missing (or the Admin SDK API is not enabled) the
-    connection still reports OK and Gemini usage is simply left uncollected.
+    prompt or response content. Leaving it out is safe: the surface degrades to
+    unobserved (previously collected rows are kept, not deleted) and
+    `provider test` reports it as a failed **optional** check, so the connection
+    stays healthy overall.
 
 ## Register domain-wide delegation
 
@@ -166,6 +167,26 @@ internal_domains: [example.com]
 In the web app: **Add provider → Google Workspace**, then set **Customer ID**
 (`my_customer`), **Credentials** (`gw-credentials`), and **Refresh interval**.
 
+!!! tip "Use `my_customer` unless you have a reason not to"
+    `my_customer` is an alias Google resolves to the customer the impersonated
+    admin (or the service account) belongs to, so it is correct for every tenant
+    and there is nothing to look up or mistype. Set an explicit ID only when a
+    reseller-style account has to be pinned to a specific customer.
+
+    **Customer ID is not your organization's name.** It is an opaque ID Google
+    issues, like `C01ab2cd3`. Find it in the **Google Admin console** →
+    **Account** → **Account settings** → **Profile**, next to **Customer ID**.
+
+    Any other value is rejected — but Google rejects it in a way that reads like
+    a permission problem, not a typo: the Admin SDK answers an unrecognized
+    customer with a bare `HTTP 400: Bad Request` that never names the field or
+    echoes the value. Every required surface fails at once, so the connection
+    shows **Failed** and `provider test`'s first check — *Authenticate + read
+    directory users* — fails, even though the credential and the delegation are
+    fine. If `provider test` reports a 400 on that check, it re-runs the same
+    read against `my_customer` and tells you outright when the customer ID is
+    the culprit.
+
 ## Verify
 
 ```bash
@@ -182,13 +203,16 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `devices_mobile` | — | Mobile device inventory unavailable. |
 | `devices_chromeos` | — | ChromeOS device inventory unavailable. |
 | `devices_ci` | — | Cloud Identity device inventory unavailable. |
+| `reports` | — | Gemini-in-Workspace usage unavailable (no AI-application rows or per-user access edges). |
 
 ## Troubleshooting
 
 | `provider test` error | Cause | Fix |
 |---|---|---|
+| `HTTP 400: Bad Request` on the user check, with every other check failing too | `workspace_customer_id` is not a customer ID Google recognizes — most often the organization's **name** rather than the ID. Google returns this same opaque 400 for every customer-aimed call, which reads as a permission problem and sends people back to re-audit delegation and scopes that are already correct | Set `workspace_customer_id` to `my_customer`, or to the ID from **Admin console → Account → Account settings → Profile**. `provider test` names this explicitly when it can confirm it: the same read is retried against `my_customer`, and if that succeeds the check reports the real customer ID to use |
 | `HTTP 400: Invalid input` on the user check | Secret is missing or mis-nested the impersonation admin → token has no subject → `my_customer` unresolvable | Use the **wrapper** envelope above: nest the key under `service_account_json`, with `admin_email` as a sibling. If you meant the no-delegation setup, grant the service account a Workspace admin role instead |
 | Users or groups from a secondary domain are missing | `domain` is set in the secret, narrowing collection to that one domain | Remove `domain` from the secret; declare internal domains with `internal_domains` on the record |
 | `token mint failed (HTTP 401): scope not granted to the delegated admin` | DWD missing scopes (all-or-nothing mint), a non-`.readonly` variant, or not yet propagated | Register the **full** scope list exactly; wait for propagation; confirm the service account's client ID matches |
 | `core` fails: `HTTP 403: Not Authorized to access this resource/api` | A token **was** minted (so the scopes are registered) but the caller has no Workspace admin authority. Almost always the secret is a **raw service-account key with no `admin_email`** — typically the GCP provider's secret reused verbatim — so nothing is impersonated and the delegation you configured is never used. It is silently accepted as the no-delegation form. Otherwise, `admin_email` names a user who is not a Super Admin | Give Workspace its **own** secret in the wrapper envelope with `admin_email`; leave the GCP provider's secret untouched. Reusing the same *service account* is fine — reusing the same *secret* is not |
 | `HTTP 403: … API has not been used in project …` | Admin SDK / Cloud Identity API not enabled | Enable the named API in the service account's project |
+| `reports` fails: `HTTP 401: Access denied. You are not authorized to read activity records.` | The token minted (so the DWD registration itself is fine) but the impersonated admin cannot read the Reports audit stream — either `admin.reports.audit.readonly` is missing from the DWD scope list, or `admin_email` names an admin without the *Reports* privilege | Add the scope to the delegation and impersonate a Super Admin. Optional surface: leaving it as-is only drops Gemini-in-Workspace usage |


### PR DESCRIPTION
## Why

A Cloud Security customer followed this page precisely — service account, Admin SDK + Cloud Identity APIs enabled, domain-wide delegation registered with the full scope list — and the connection failed on every sweep. They spent the session re-checking delegation and scopes, which were correct throughout.

The cause was `workspace_customer_id`, set to their organization's **name** rather than a Google customer ID. Google rejects that with a bare `HTTP 400: Bad Request` on every required surface — the field is never named and the value is never echoed — so it reads as a permission problem.

This page gave them nothing to catch it with. The only mention was:

```yaml
workspace_customer_id: my_customer          # or an explicit customer ID
```

No indication of what a customer ID looks like, where to find it, or what a wrong one does.

## Changes

**Customer ID guidance** (new tip under *Create the provider record*):

- Recommend `my_customer` outright — it is an alias Google resolves from the impersonated admin, so it is correct for every tenant and there is nothing to look up or mistype. An explicit ID is for pinning a reseller-style account.
- State plainly that the customer ID is **not** the organization's name, show the shape (`C01ab2cd3`), and give the Admin console path: **Account → Account settings → Profile**.
- Describe the failure signature — every required surface failing at once with a 400 that looks like a permission error — so it is self-diagnosable, and note that `provider test` now confirms this cause by retrying the read against `my_customer`.

**New troubleshooting row** for `HTTP 400: Bad Request` with every check failing.

## Also: two places this page had drifted from the product

Found while tracing the customer's logs, which showed a Reports-surface 401 alongside the customer-ID failure.

- The *"Gemini usage has no preflight check"* note claimed `provider test` does not probe the Reports surface and that a missing scope still reports the connection OK. **It does probe it** (`reports` check in `test.go`) and reports a failed *optional* check. Rewritten to describe what the scope collects and what skipping it actually costs.
- The **Verify** table was missing the `reports` row — it listed 8 of the 9 checks the product returns.
- **New troubleshooting row** for `HTTP 401: Access denied. You are not authorized to read activity records.`, distinguishing the missing scope from an `admin_email` that lacks the Reports privilege, and noting it is optional.

## Related

Product-side counterpart makes the error itself say this: `provider test` re-runs the failing read against `my_customer` and, when that succeeds, reports the tenant's real customer ID to paste — plus the sweep's collector-task failures now name the field in the connection's **Failed** tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)