### PR TITLE
docs(cloud-security): document custom posture rules and remediation SLAs

### DIFF
--- a/docs/8-reference/cloud-security-api-iac.md
+++ b/docs/8-reference/cloud-security-api-iac.md
@@ -62,7 +62,7 @@ multi-tenant policy management a script, not a UI workflow.
 | Hive | Record | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per connection | what to collect — one of thirteen connectors spanning cloud infra, identity/IdP, SaaS, AI, and LimaCharlie self-inventory (see [Providers](../cloud-security/providers.md) for the full list) |
-| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation — accepted but not yet evaluated; see the [Configuration reference](../cloud-security/configuration.md)), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment) |
+| `cloudsec_policy` | many, typed by `policy_type` | `classification` (crown jewels), `coverage` (EDR expectation — accepted but not yet evaluated; see the [Configuration reference](../cloud-security/configuration.md)), `emission` (event feed), `exclusions` (resource escape hatch), `suppression` (finding disposition rules), `compliance` (scoped framework assignment), [`rules`](../cloud-security/custom-rules.md) (your own posture detections, plus overrides of the built-in ones), [`sla`](../cloud-security/remediation-sla.md) (remediation due dates) |
 | `cloudsec_query` | one per saved query | org-shared saved graph queries (the Query Console library) |
 
 !!! note "`limacharlie sync` does not cover these hives"
@@ -195,7 +195,9 @@ For richer automation the same stream also carries `cloud_finding.updated` (an
 open finding materially changed: a severity move in either direction, the
 subject becoming internet-reachable, or one of its CVEs entering CISA KEV)
 and the disposition verbs `cloud_finding.resolved` / `.dismissed` /
-`.reopened` / `.assigned`. Those last four cover both human triage and a
+`.reopened` / `.assigned`, plus `cloud_finding.sla_breached` when a finding
+passes the due date an [`sla` policy](../cloud-security/remediation-sla.md)
+assigned it. The four disposition verbs cover both human triage and a
 `suppression` policy acting on its own: read `actor` to tell them apart (a user id
 versus `policy:<rule name>`), and branch on the payload's `resolution` rather than
 the verb, since an accepted risk and a fixed one both arrive as `.resolved`.

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -40,8 +40,8 @@ Shared behaviors:
 
 | Route | Returns |
 |---|---|
-| `GET /findings` | `{findings, next_cursor}` — the risk-ranked worklist. Filters: `severity[]`, `finding_class[]`, `status[]`, `account[]`, `reachable`, `kev`, `q`, `sort`, `order`, `cursor`, `limit`. |
-| `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors. |
+| `GET /findings` | `{findings, next_cursor}` — the risk-ranked worklist. Filters: `severity[]`, `finding_class[]`, `status[]`, `account[]`, `owner[]`, `sla[]`, `reachable`, `kev`, `q`, `sort`, `order`, `cursor`, `limit`. `sort` is `lc_risk` (default), `severity`, `first_seen`, or `due_at`; `due_at` is the one key that defaults to **ascending** and sorts findings with no due date last. |
+| `GET /findings/facets` | `{facets}` — cross-filtered facet counts under the same selectors, including an `sla` dimension counting each state. |
 | `GET /findings/classes` | `{classes}` — the canonical `finding_class` enum (the 11 values), for building selectors. |
 | `GET /findings/causes` | `{causes, distinct}` — findings grouped by their **cause**, the mutable object (a firewall rule, a role binding) whose single edit resolves all of them. Takes the full findings selectors, plus `cause` for the exact count of one cause and `limit` (default 20, max 200) for the top causes; `distinct` is the total number of causes matching the filter. |
 | `GET /findings/{finding_id}` | `{finding}` — one finding in full. |
@@ -160,6 +160,7 @@ carry the same shape) — key fields:
 | `runtime_sids` | Sensors resolved onto the affected asset. |
 | `status`, `resolution`, `resolved_by`, `resolution_expires_at`, `owner`, `ticket` | The triage overlay. |
 | `first_seen`, `last_seen` | Lifecycle timestamps. |
+| `due_at`, `sla_source`, `sla_state` | The remediation clock. `due_at` (the deadline) and `sla_source` (the policy clause that set it, or `default`) are stored; `sla_state` — `breached` \| `due_soon` \| `on_track` \| `exempt` \| `none` — is **derived on every read** from `due_at`, `first_seen`, and `status`, because it changes with the clock and nothing writes when a deadline passes. All three are absent until the organization writes an [`sla` policy](remediation-sla.md); there is no default SLA. |
 
 ## Events
 
@@ -182,6 +183,11 @@ summary still counts the whole estate).
 - `cloud_finding.still_open` — re-asserted at most once a day for open
   findings with a linked ticket (the case-sync verb); the payload carries the
   `ticket` alongside the identity fields.
+- `cloud_finding.sla_breached` — emitted once, on the first projection pass
+  that observes an open finding past its `due_at`. The breach is latched, so
+  the event never re-fires for the same breach of the same deadline. Requires
+  an [`sla` policy](remediation-sla.md); granularity is the reprojection
+  cadence, not the second.
 
 **Disposition** — flat payload
 `{finding_id, fingerprint, finding_class, actor, note?}`, plus the finding's

--- a/docs/cloud-security/api-reference.md
+++ b/docs/cloud-security/api-reference.md
@@ -160,7 +160,7 @@ carry the same shape) — key fields:
 | `runtime_sids` | Sensors resolved onto the affected asset. |
 | `status`, `resolution`, `resolved_by`, `resolution_expires_at`, `owner`, `ticket` | The triage overlay. |
 | `first_seen`, `last_seen` | Lifecycle timestamps. |
-| `due_at`, `sla_source`, `sla_state` | The remediation clock. `due_at` (the deadline) and `sla_source` (the policy clause that set it, or `default`) are stored; `sla_state` — `breached` \| `due_soon` \| `on_track` \| `exempt` \| `none` — is **derived on every read** from `due_at`, `first_seen`, and `status`, because it changes with the clock and nothing writes when a deadline passes. All three are absent until the organization writes an [`sla` policy](remediation-sla.md); there is no default SLA. |
+| `due_at`, `sla_source`, `sla_state` | The remediation clock. `due_at` (the deadline) and `sla_source` (the policy clause that set it, or `default`) are stored, and are **absent** until the organization writes an [`sla` policy](remediation-sla.md) that covers the finding — there is no default SLA. `sla_state` is always present: it is **derived on every read** from `due_at`, `first_seen`, and `status` (because it changes with the clock and nothing writes when a deadline passes) and reads `none` for any finding no clause covers. Values: `breached` \| `due_soon` \| `on_track` \| `exempt` \| `none`. |
 
 ## Events
 

--- a/docs/cloud-security/automation.md
+++ b/docs/cloud-security/automation.md
@@ -94,6 +94,101 @@ The `account` matcher takes globs, including leading-`!` negation —
 }
 ```
 
+## Custom posture rules
+
+Your own CSPM detections are a `rules`-typed `cloudsec_policy` record, which
+makes them the easiest part of the product to keep in a git repository and push
+to a fleet. The full authoring contract — the detection format, the operator
+allowlist, `scope`, id stability, and the per-organization bounds — is in
+[Custom Posture Rules](custom-rules.md).
+
+```bash
+cat > rules.json <<EOF
+{
+  "policy_type": "rules",
+  "rules": {
+    "rules": [
+      {
+        "id": "custom-public-bucket-outside-cdn",
+        "resource_type": "DataStore",
+        "finding_class": "public_exposure",
+        "severity": "HIGH",
+        "title": "Storage bucket is readable by anyone on the internet",
+        "detect": {
+          "op": "and",
+          "rules": [
+            {"op": "is", "path": "event/store_kind", "value": "bucket"},
+            {"op": "is", "path": "event/is_public", "value": true},
+            {"op": "starts with", "path": "event/name", "value": "cdn-", "not": true}
+          ]
+        }
+      }
+    ],
+    "overrides": [
+      {"rule_id": "bucket-uniform-access-disabled", "disabled": true}
+    ]
+  }
+}
+EOF
+limacharlie hive set --hive-name cloudsec_policy --key my-rules \
+  --oid $OID --input-file rules.json --enabled
+```
+
+The write is validated synchronously — every `detect` block is compiled on the
+real detection engine — so a bad rule fails your pipeline loudly instead of
+saving and silently never matching. That makes `hive set` a usable CI gate: a
+non-zero exit is a rule that could not run.
+
+## Remediation SLAs
+
+An `sla`-typed record puts a due date on findings. There is no default one, so
+adopting an SLA is a single write — see [Remediation SLAs](remediation-sla.md).
+
+```bash
+cat > sla.json <<EOF
+{
+  "policy_type": "sla",
+  "sla": {
+    "default_due_days": { "CRITICAL": 7, "HIGH": 30, "MEDIUM": 90, "LOW": 180 }
+  }
+}
+EOF
+limacharlie hive set --hive-name cloudsec_policy --key sla \
+  --oid $OID --input-file sla.json --enabled
+```
+
+### Escalating an SLA breach
+
+The first projection pass that observes a finding past its due date emits
+`cloud_finding.sla_breached` — once per breach, never re-fired for the same
+deadline. The payload is flat: `finding_id`, `fingerprint`, `finding_class`,
+`severity`, `resource_urn`, `owner`, `ticket`, and `actor: "policy:sla"`.
+
+```yaml
+detect:
+  event: cloud_finding.sla_breached
+  op: exists
+  path: event/fingerprint
+respond:
+  - action: extension request
+    extension name: ext-cases
+    extension action: update_case
+    extension request:
+      detect_id: "{{ .event.fingerprint }}"
+      reopen_if_closed: true
+      note: "Remediation SLA breached — this finding is past its due date"
+```
+
+Because the event carries `owner` and `severity`, the same hook routes just as
+well to a paging Output or a team channel: branch on `severity` for who gets
+woken up, and on `owner` for where it lands.
+
+!!! note "Breach webhooks are capped per pass"
+    A pass that newly breaches a very large number of findings pushes at most
+    **200** breach events, so an SLA adopted over an old backlog cannot flood
+    your stream on day one. Every breach is still reflected in the findings API
+    — read `sla_state` there when you need the complete set.
+
 ## Saved queries
 
 Save a graph query as a `cloudsec_query` record and it appears in every
@@ -236,6 +331,9 @@ operator/policy disposition).
       the verb, to tell "fixed" from "accepted". These are not only human
       actions: a `suppression` policy emits the same verbs with `actor` set to
       `policy:<rule-name>`.
+    - `cloud_finding.sla_breached` — an open finding passed the `due_at` its
+      [`sla` policy](remediation-sla.md) assigned, emitted exactly once per
+      breach. See [Escalating an SLA breach](#escalating-an-sla-breach).
     - `cloudsec.sync_completed` — the first-sync summary
       (`{total, by_class, by_severity}`) emitted once instead of a
       per-finding `created` flood, so onboarding a large estate is one event,

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -32,6 +32,7 @@ limacharlie cloudsec topology
 
 # Findings worklist + triage
 limacharlie cloudsec finding list --severity CRITICAL --class toxic_combination --kev
+limacharlie cloudsec finding list --sla breached --sort due_at        # what is late
 limacharlie cloudsec finding facets --status open
 limacharlie cloudsec finding classes                      # the finding_class enum
 limacharlie cloudsec finding get fnd_0a1b...
@@ -126,11 +127,16 @@ the one command that does not resolve a single `--oid`.
     the generic `limacharlie api <path>` escape hatch — see the
     [API Reference](api-reference.md).
 
-    Two things that look like missing commands are really something else.
+    Some things that look like missing commands are really something else.
     **Scheduled queries** are not a separate feature: a scheduled query is a
     `cloudsec_query` Hive record carrying a `schedule` block, authored with
     `limacharlie hive set --hive-name cloudsec_query` (see
-    [Configuration](configuration.md#cloudsec_query)). **Workload groups**
+    [Configuration](configuration.md#cloudsec_query)). **Custom posture rules**
+    and **remediation SLAs** are likewise `cloudsec_policy` Hive records
+    (`policy_type` `rules` and `sla`) written with
+    `limacharlie hive set --hive-name cloudsec_policy` — see
+    [Custom Posture Rules](custom-rules.md) and
+    [Remediation SLAs](remediation-sla.md). **Workload groups**
     are not a view of their own either: they arrive on findings as
     `source_scope` / `target_scope` in `finding list`, and as the
     `ComputeGroup` node type in graph queries.
@@ -152,6 +158,20 @@ limacharlie cloudsec finding list --cursor "<next_cursor>" --limit 50
 
 Boolean tri-state flags (`--kev/--no-kev`, `--reachable/--no-reachable`)
 send the filter only when given, so the server default applies otherwise.
+
+`--sla` selects on the derived [remediation-SLA
+state](remediation-sla.md#stored-vs-derived) — `breached`, `due_soon`,
+`on_track`, `exempt`, `none` — and is repeatable like the other filters. It
+applies to `finding list`, `finding facets`, `finding causes`, and
+`export findings`. `--sort due_at` is the matching sort key, and the one key
+that defaults to **ascending** (soonest deadline first), keeping findings with
+no due date last rather than dropping them.
+
+!!! note "`--sla` needs a CLI newer than 5.6.1"
+    The SLA selector and the `due_at` sort key ship in the first `limacharlie`
+    release after 5.6.1. On an older CLI, use the `sla=` and `sort=due_at`
+    parameters on the [REST route](api-reference.md#reads) — the server-side
+    feature is live either way.
 
 The other lists carry a subset, so check `--help` before assuming a flag is
 there. `caasm coverage` behaves like `finding list` (repeatable filters,

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -39,11 +39,11 @@ The report is per-control, and each control lands in one of four states:
   the manual / attestation controls (policy documents, board sign-off,
   interview evidence): the framework marks them as not auto-assessable, so no
   rule is run and no verdict is invented. A control also lands here when the
-  detection that would have decided it never ran — including when **you have
-  disabled every rule that evidences it** through a
-  [`rules` policy](custom-rules.md#compliance-interaction). A zero-violation
-  result from a detector that did not run is not evidence of compliance, so it
-  is never reported as a PASS.
+  detection that would have decided it never ran — including when a
+  [`rules` policy](custom-rules.md#compliance-interaction) has **disabled every
+  rule the control relies on** and it has no other basis to be graded from. A
+  zero-violation result from a detector that did not run is not evidence of
+  compliance, so it is never reported as a PASS.
 - **NOT_APPLICABLE** — the control has nothing to assess in *this* estate:
   either the framework's cloud has no resources connected, or the control
   declares no resource types to apply to.

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -38,7 +38,12 @@ The report is per-control, and each control lands in one of four states:
 - **NOT_ASSESSED** — the control cannot be evaluated automatically. These are
   the manual / attestation controls (policy documents, board sign-off,
   interview evidence): the framework marks them as not auto-assessable, so no
-  rule is run and no verdict is invented.
+  rule is run and no verdict is invented. A control also lands here when the
+  detection that would have decided it never ran — including when **you have
+  disabled every rule that evidences it** through a
+  [`rules` policy](custom-rules.md#compliance-interaction). A zero-violation
+  result from a detector that did not run is not evidence of compliance, so it
+  is never reported as a PASS.
 - **NOT_APPLICABLE** — the control has nothing to assess in *this* estate:
   either the framework's cloud has no resources connected, or the control
   declares no resource types to apply to.

--- a/docs/cloud-security/configuration.md
+++ b/docs/cloud-security/configuration.md
@@ -8,7 +8,7 @@ tenant onboarding and fleet-wide policy a script, not a UI workflow (see
 | Hive | Records | Purpose |
 |---|---|---|
 | `cloudsec_provider` | one per cloud / IdP / SaaS / AI connection | what to collect and with which credential |
-| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, emission, exclusions, suppression, compliance assignments |
+| `cloudsec_policy` | many, discriminated by `policy_type` | classification, coverage, emission, exclusions, suppression, compliance assignments, custom posture rules, remediation SLAs |
 | `cloudsec_query` | one per saved query | shared saved graph queries |
 
 !!! info "Permissions"
@@ -266,6 +266,36 @@ is `kind` (`accepted`/`false_positive`), `reason` (required), `ttl_days`.
 A named framework assignment over a scoped subset of the estate — see
 [Compliance](compliance.md#scoped-assignments). Fields: `framework_id`
 (required, lowercase slug), `description`, `scope` (the account/name matchers).
+
+### `rules` — your own posture rules
+
+Your own CSPM detections, plus retunes of the built-in ones — see
+[Custom Posture Rules](custom-rules.md) for the full contract. Two independent
+lists, at least one non-empty:
+
+| List | Entries |
+|---|---|
+| `rules` | Your own rules. Required per rule: `id` (must start with `custom-`), `resource_type`, `finding_class` (`misconfig` or `public_exposure`), `severity`, `title`, `detect` (a D&R detection block). Optional: `name`, `subject_path`, `criticality_mult`, `meta`. |
+| `overrides` | `{rule_id, disabled?, severity?}` — retunes a built-in or custom rule for this organization only. An override that sets neither field is rejected. |
+
+Every `detect` block is compiled on the real detection engine when you save, so a
+rule that could never run is rejected while you can still read the error. Rules
+use a [closed operator
+allowlist](custom-rules.md#the-operator-allowlist), and per-organization bounds
+apply (200 rules, 25 per resource type, 1000 overrides, 512 KiB composed).
+
+### `sla` — remediation due dates
+
+The organization's remediation clock: how long a finding may stay open before it
+is late. See [Remediation SLAs](remediation-sla.md).
+
+| Field | Meaning |
+|---|---|
+| `default_due_days` | Per-severity fallback (`CRITICAL` … `INFO`), applied when no rule matched. |
+| `rules` | Ordered `{name, match, due_days}` clauses, **first match wins**. `match` accepts `severity`, `finding_class`, `rule`, `account`, `owner`; an empty `match` is a deliberate catch-all. `due_days: 0` is an **exemption** (no due date, scan stops), not "due immediately". |
+
+There is **no default SLA**: with no `sla` record every finding reads `none` and
+nothing is ever breached.
 
 ## cloudsec_query
 

--- a/docs/cloud-security/custom-rules.md
+++ b/docs/cloud-security/custom-rules.md
@@ -1,0 +1,493 @@
+# Custom Posture Rules
+
+The built-in CSPM pack is not the ceiling. A `rules`-typed
+[`cloudsec_policy`](configuration.md#cloudsec_policy) record lets an organization
+author its **own** posture detections — and retune, re-severity, or switch off the
+built-in ones — in exactly the same format the built-in pack uses.
+
+There is no separate rule language to learn: a posture rule is a **real D&R
+detection**, in the same `op` / `path` / `value` dictionary vocabulary as the
+detection & response rules you already write, evaluated against a cloud resource
+presented as a `cloud_resource.<ResourceType>` event whose body is the resource's
+normalized properties.
+
+!!! info "Authored as Hive records"
+    Unlike classification, coverage, exclusions, and suppression, custom rules
+    have **no console editor**. They are written as Hive JSON through
+    `limacharlie hive set` (or the Hive API), which also makes them the easiest
+    policy to keep in a git repository and push to a fleet — see
+    [Automation & IaC](automation.md#custom-posture-rules).
+
+## A first rule
+
+```json
+{
+  "policy_type": "rules",
+  "rules": {
+    "rules": [
+      {
+        "id": "custom-public-bucket-outside-cdn",
+        "name": "Public bucket outside the CDN convention",
+        "resource_type": "DataStore",
+        "finding_class": "public_exposure",
+        "severity": "HIGH",
+        "title": "Storage bucket is readable by anyone on the internet",
+        "detect": {
+          "op": "and",
+          "rules": [
+            {"op": "is", "path": "event/store_kind", "value": "bucket"},
+            {"op": "is", "path": "event/is_public", "value": true},
+            {"op": "starts with", "path": "event/name", "value": "cdn-", "not": true}
+          ]
+        },
+        "meta": {
+          "description": "A bucket granting read access to anyone, outside the cdn- naming convention used for deliberately public assets.",
+          "rationale": "Anonymous read on a bucket exposes every object in it, and our public assets are all published under the cdn- prefix.",
+          "references": ["https://cloud.google.com/storage/docs/access-control/making-data-public"],
+          "false_positives": "A newly created public asset bucket that has not been renamed to the cdn- convention yet."
+        }
+      }
+    ]
+  }
+}
+```
+
+```bash
+limacharlie hive set --hive-name cloudsec_policy --key my-rules \
+  --oid $OID --input-file rules.json --enabled
+```
+
+The record is validated **synchronously**. The Hive compiles every `detect` block
+on the real detection engine and checks every vocabulary, so a rule that could
+never run is rejected while you are still looking at the error — never accepted
+and then silently skipped hours later inside a projection you cannot see.
+
+An organization may hold **many** `rules` records; they compose into one policy in
+record-name order.
+
+## The record
+
+`rules` is an object with two independent lists, `rules` (your own detections) and
+`overrides` (retunes of rules that already exist). At least one must be non-empty
+— a record that adds nothing and overrides nothing is rejected rather than saved
+as a no-op.
+
+### Rule fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | ✔ | Stable identifier, kebab-case, **must start with `custom-`**, max 64 characters. Never rename it — see [Rule ids are permanent](#rule-ids-are-permanent). |
+| `resource_type` | ✔ | Which resources the rule is evaluated against; routes it to `cloud_resource.<type>` events. |
+| `finding_class` | ✔ | `misconfig` or `public_exposure` — the whole authorable set (see below). |
+| `severity` | ✔ | `CRITICAL` \| `HIGH` \| `MEDIUM` \| `LOW` \| `INFO`. |
+| `title` | ✔ | What the operator reads on the finding. State the **risk**, not the setting: "Bucket is readable by anyone on the internet", never "uniform bucket-level access is disabled". Max 256 characters. |
+| `detect` | ✔ | The detection block (see [Writing the detection](#writing-the-detection)). |
+| `name` | | A short internal label, for your own bookkeeping. |
+| `subject_path` | | A **top-level property key** — a single lookup, *not* a detection path — used as the finding's subject instead of the resource URN. `email`, never `event/email`. Max 256 characters. |
+| `criticality_mult` | | Risk multiplier applied to `lc_risk`, `0` to `1.6`. `0` means unset (1.0). |
+| `meta` | | Authoring metadata: `description`, `rationale`, `references`, `no_framework`, `false_positives`. Inert at evaluation time — it exists so the reasoning travels with the rule. |
+
+`resource_type` must be one of:
+
+`Account` · `AIService` · `Application` · `ComputeInstance` · `ConfigStore` ·
+`DataStore` · `DNSZone` · `EnrollmentKey` · `HasPermission` · `Identity` ·
+`Network` · `TelemetryOutput`
+
+!!! note "Only two finding classes, on purpose"
+    A custom rule may emit `misconfig` or `public_exposure` and nothing else. The
+    other classes in the [finding-class
+    enum](findings.md#the-worklist) are produced by other engines and carry
+    lifecycle behavior a single-resource rule cannot honor: `vulnerability`,
+    `malware`, `secret`, and `scan_finding` are asserted by scanners;
+    `ciem_risk`, `privilege_escalation`, and `toxic_combination` come from grant
+    expansion and attack paths; the coverage-gap classes drive their own
+    carry-forward semantics. A finding in one of those classes is read by
+    consumers that assume an evidence source a posture rule does not have.
+
+    ```text
+    rule 0 ("custom-critical-vuln"): finding_class "vulnerability" is invalid
+    (want one of misconfig, public_exposure)
+    ```
+
+## Rule ids are permanent
+
+**Once a rule has produced findings, its id is never renamed.** The id is
+load-bearing in two places:
+
+- **The finding fingerprint.** A finding's dedup key is derived from the rule id
+  and the resources it names. Rename the id and every finding the rule ever
+  produced closes and a brand-new one opens: a create/close storm through the
+  `cloud_finding.*` feed, every operator disposition (accepted / false positive)
+  orphaned, and every linked ticket pointing at a dead finding.
+- **The compliance join.** Framework catalogs map controls to rules **by id**.
+
+The corollary is worth internalising: **severity is safe to change, detection is
+not.** Severity is not a fingerprint input, so retuning it updates findings in
+place. Changing what a rule *detects* while keeping its id re-purposes every
+historical finding underneath it — if you need different semantics, ship a new id
+and retire the old one.
+
+### Why `custom-`
+
+Every customer-authored id must start with `custom-`, enforced at write time and
+again when the pack is resolved:
+
+```text
+rule 0: id "public-bucket" must start with "custom-" — custom rule ids share the
+finding fingerprint space and the compliance join with the built-in rules, so
+they are namespaced to keep them from ever colliding
+```
+
+Your ids land in the same fingerprint space and the same compliance keyspace as
+the built-ins, so the namespace makes a collision impossible by construction —
+and it keeps the built-in id space free to grow without ever asking whether some
+tenant already took a name.
+
+## Writing the detection
+
+`detect` is the same nested dictionary a D&R rule's `detect` block uses:
+`{"op": …, "path": …, "value": …}` leaves, composed with
+`{"op": "and" | "or", "rules": [ … ]}`, and negated by adding `"not": true` to
+any node.
+
+Paths are rooted at `event/`, and the event body is the resource's normalized
+properties. `limacharlie cloudsec resource get "lcrn:..."` prints a real
+resource, which is the fastest way to see the exact property names for a type.
+
+### The operator allowlist
+
+A rule may use only these operators, anywhere in its `detect` tree:
+
+`and` · `cidr` · `contains` · `ends with` · `exists` · `is` · `is greater than` ·
+`is lower than` · `is older than` · `matches` · `or` · `scope` · `starts with`
+
+This is a **safety boundary, not a curated convenience list**. The detection
+engine is shared with the endpoint product, and most of its other operators reach
+for things a cloud resource does not have — sensor platform, tags, process trees,
+or a service resolved through callbacks the posture evaluator does not supply.
+Anything outside the list is rejected at write time:
+
+```text
+rule 0 ("custom-tagged-prod"): detect uses operator(s) is tagged, which a posture
+rule may not use (allowed: and, cidr, contains, ends with, exists, is, is greater
+than, is lower than, is older than, matches, or, scope, starts with)
+```
+
+`is tagged` is excluded even though it is harmless, because it reads *sensor*
+tags a cloud resource never has: it would install cleanly and never match, which
+is worse than being told no.
+
+### Value syntaxes and paths that are rejected
+
+| Rejected | Why |
+|---|---|
+| `[[name]]` in any `value` | A sensor-variable reference. It resolves through a callback the posture evaluator does not supply — a cloud resource has no sensor variables. Use a literal value or an `event/` path. |
+| `{{ … }}` in any `value` | Templates can carry a pattern the regex budgets cannot see. Their only extra capability here is `secret`, which the posture evaluator does not supply either. |
+| `*` or `?` in a `path` | A wildcard makes the engine walk the resource's **entire** property tree for every row, so the cost is set by your data rather than by the rule (measured at 187× a literal path). Name the field explicitly. |
+
+Path redirection (`<<event/other_field>>`) is fine — it is a pure extractor over
+the same event the rule already addresses.
+
+```text
+rule 0 ("custom-any-public"): detect uses the wildcard path(s) event/*/is_public
+— a wildcard makes the engine walk the resource's ENTIRE props tree for every
+row, so the cost is set by the data rather than by the rule (measured at 187x a
+literal path). Name the field explicitly
+```
+
+### `scope` — the trap that manufactures false positives
+
+**Whenever two conditions must hold on the *same element* of a list, they must be
+inside a `scope`.** This is the single most common way a hand-written posture
+rule goes wrong.
+
+Without `scope`, the engine flattens the list and the conditions are free to match
+across *different* elements. A firewall allowing `[{udp, 22}, {tcp, 443}]` will
+satisfy "protocol is tcp AND port is 22" — one condition from each element — and
+report SSH open to the world on a host where it is not.
+
+Inside a `scope`, the sub-rule's paths are **relative to the scoped element**
+(`protocol`, not `event/ingress_rule/protocols/protocol`):
+
+```json
+{
+  "policy_type": "rules",
+  "rules": {
+    "rules": [
+      {
+        "id": "custom-postgres-open-to-internet",
+        "resource_type": "Network",
+        "finding_class": "public_exposure",
+        "severity": "CRITICAL",
+        "title": "PostgreSQL (5432) is reachable from the entire internet",
+        "detect": {
+          "op": "and",
+          "rules": [
+            {"op": "or", "rules": [
+              {"op": "is", "path": "event/network_kind", "value": "firewall_rule"},
+              {"op": "is", "path": "event/network_kind", "value": "aws_security_group"},
+              {"op": "is", "path": "event/network_kind", "value": "azure_nsg"}
+            ]},
+            {"op": "is", "path": "event/ingress_rule/allow", "value": true},
+            {"op": "is", "path": "event/ingress_rule/disabled", "value": true, "not": true},
+            {"op": "or", "rules": [
+              {"op": "is", "path": "event/ingress_rule/source_cidrs/v", "value": "0.0.0.0/0"},
+              {"op": "is", "path": "event/ingress_rule/source_cidrs/v", "value": "::/0"}
+            ]},
+            {"op": "scope", "path": "event/ingress_rule/protocols", "rule": {
+              "op": "and",
+              "rules": [
+                {"op": "or", "rules": [
+                  {"op": "is", "path": "protocol", "value": "tcp"},
+                  {"op": "is", "path": "protocol", "value": "all"}
+                ]},
+                {"op": "or", "rules": [
+                  {"op": "exists", "path": "ports", "not": true},
+                  {"op": "is", "path": "covers_all_ports", "value": true},
+                  {"op": "is", "path": "ports_effective/v", "value": "5432"}
+                ]}
+              ]
+            }}
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Two related path rules the example above also demonstrates:
+
+- **Lists of scalars are addressed through `/v`.** The resource→event adapter
+  reshapes arrays of plain values into arrays of objects, so a list of CIDRs is
+  matched as `event/ingress_rule/source_cidrs/v`.
+- **Absence is not a value.** `{"op": "exists", "path": "ports", "not": true}` is
+  how you match "no ports listed" — and in the firewall family that absence means
+  *all* ports, the worst case, not a benign default.
+
+### Never fire on silence
+
+**A rule must assert on an observed bad state, never on the absence of a fact.**
+
+The collectors use observation-gated properties: a boolean is absent when the
+collector could not determine it, and only an explicit value is stamped. A rule
+written as "encryption disabled" against a field that is merely *missing* fires
+on every resource the collector could not fully inspect — and a partial sweep
+then reads as an estate-wide breach. If a rule genuinely means "this setting is
+missing", pair it with a positive signal that the resource *was* successfully
+inspected.
+
+### Two more write-time checks worth knowing
+
+`subject_path` is a top-level property key resolved by a single lookup, not a
+detection path — writing it in `event/…` form is rejected rather than silently
+resolving to nothing:
+
+```text
+rule 0 ("custom-public-bucket"): subject_path "event/name" looks like a detection
+path, but it is a top-level props key (a single map lookup) — it would resolve to
+nothing and the finding would silently fall back to the resource urn
+```
+
+And an override that changes nothing is rejected, because the failure mode is an
+operator walking away believing they turned a rule off:
+
+```text
+override 0 ("bucket-uniform-access-disabled") does nothing: set disabled=true or
+a severity
+```
+
+## Overriding a built-in
+
+An `overrides` entry retunes a rule that already exists — built-in or one of your
+own — **for your organization only**:
+
+```json
+{
+  "policy_type": "rules",
+  "rules": {
+    "overrides": [
+      {"rule_id": "bucket-uniform-access-disabled", "disabled": true},
+      {"rule_id": "open-admin-port-to-internet", "severity": "CRITICAL"}
+    ]
+  }
+}
+```
+
+An override can set `disabled` and/or `severity`. It deliberately **cannot**
+change a rule's detection, resource type, or finding class: those decide what a
+finding *means*, and redefining a built-in while keeping its id would corrupt the
+compliance join — a control pointing at that id would be evidenced by a detection
+the framework never asked for.
+
+To change what a rule detects, author a `custom-` rule and disable the built-in in
+the same record:
+
+```json
+{
+  "policy_type": "rules",
+  "rules": {
+    "rules": [
+      {
+        "id": "custom-sa-key-older-than-30d",
+        "resource_type": "Identity",
+        "finding_class": "misconfig",
+        "severity": "HIGH",
+        "title": "Service-account credential has not been rotated in 30 days",
+        "subject_path": "email",
+        "criticality_mult": 1.2,
+        "detect": {
+          "op": "and",
+          "rules": [
+            {"op": "or", "rules": [
+              {"op": "is", "path": "event/kind", "value": "service_account"},
+              {"op": "is", "path": "event/kind", "value": "app_integration"}
+            ]},
+            {"op": "is greater than", "path": "event/oldest_key_age_days", "value": 30}
+          ]
+        },
+        "meta": {
+          "rationale": "Our key-rotation standard is 30 days; the built-in rule only fires at 90."
+        }
+      }
+    ],
+    "overrides": [
+      {"rule_id": "stale-user-managed-sa-key", "disabled": true}
+    ]
+  }
+}
+```
+
+### Precedence, exactly
+
+1. The built-in pack is the base.
+2. Valid custom rules are appended. An invalid one is dropped and reported.
+3. A duplicate custom id, or one shadowing a built-in, is dropped and reported —
+   **first wins**, deterministic because records compose in sorted record-name
+   order.
+4. Overrides apply **last**, over the union, so they can retune a built-in or a
+   custom rule. **Disable wins over severity.**
+5. An override naming an id that is not in the pack is dropped and **reported** —
+   a typo must never read as a successfully-disabled rule.
+
+## How evaluation works
+
+Evaluation is **stateless and per resource**. Each rule is tested against every
+resource of its `resource_type`, on every projection pass, using only that
+resource's own properties.
+
+Two consequences matter in practice:
+
+- **A new rule applies to your whole existing estate**, not just to resources
+  that change afterwards. There is nothing to backfill and no re-scan to
+  request — the next projection re-derives findings across everything already in
+  inventory.
+- **Findings close by themselves.** When the condition stops being true, the
+  finding closes on the next pass, exactly like a built-in one.
+
+The record reaches the engine at the end of the **next collection sweep**, and
+applies on the projection after it. Change the provider's `sync_now` nonce to a
+new value to trigger a sweep immediately instead of waiting for the refresh
+cadence.
+
+Findings from custom rules are ordinary findings. They land in the same
+risk-ranked worklist, carry `lc_risk` and its breakdown, and support the full
+lifecycle: dispositions, owners, tickets, cases, `suppression` policy,
+[remediation SLAs](remediation-sla.md), cause grouping, CSV export, and the
+`cloud_finding.*` [event feed](findings.md#findings-are-events-too). There is no
+rule-id filter on the worklist, but free-text search matches the finding body, so
+`limacharlie cloudsec finding list -q custom-public-bucket-outside-cdn` pulls up
+everything one rule produced.
+
+Evidence is rendered from the **affected resource type**, using the same
+renderers the built-in rules use, so a custom finding carries a real
+offending-configuration detail. Rule-specific evidence wording and the
+ready-to-apply remediation snippets are authored per built-in rule, so a custom
+rule's findings may carry none — which is the practical reason to write the
+`title` as the action an operator must take.
+
+!!! warning "Measure a broad rule before you trust it"
+    A rule that matches a quarter of its resource type is a rule that buries the
+    rest of your worklist. Before relying on a new rule, check what it actually
+    produced (`limacharlie cloudsec finding facets`) — a single near-universal
+    condition can produce six-figure finding counts on a large estate. If the
+    condition is real but the *unit* is wrong (an account-level setting reported
+    once per bucket), express it at the level it is actually fixed, or ship it at
+    `LOW`/`INFO` so it stays out of the default worklist while remaining
+    queryable and countable for compliance.
+
+## Compliance interaction
+
+Disabling a rule affects compliance, and it does so **honestly**. A control whose
+only evidence comes from rules you disabled is reported **`NOT_ASSESSED`** — never
+a pass.
+
+A zero-violation result from a detector that did not run means nothing, so it is
+reported as what it is: not assessed. This is the same verdict the platform gives
+a control no detector covers at all, and it keeps `NOT_ASSESSED` out of the
+compliance score's denominator rather than inflating it into a green check. See
+[Compliance](compliance.md).
+
+Custom rules do not evidence framework controls: catalogs join controls to rule
+ids, and no catalog names a `custom-` id.
+
+## Bounds
+
+The projector that evaluates rules is shared infrastructure, so the limits below
+are availability bounds, not just per-tenant quotas.
+
+| Bound | Value |
+|---|---|
+| Rules per organization | 200 |
+| Rules on any **one** resource type | 25 |
+| Overrides per organization | 1000 |
+| Composed policy size (all `rules` records together) | 512 KiB |
+| Size of one record | 256 KiB |
+| `detect` size per rule | 8 KiB |
+| `scope` operators per rule | 2, never nested |
+| `detect` nesting depth | 32 |
+| Rule id / title length | 64 / 256 characters |
+| `criticality_mult` | 0 – 1.6 |
+| Findings produced per pass | 25,000 per evaluator |
+
+The 25-rules-per-resource-type bound is the one that surprises people, and it is
+the one that matters most: every rule is evaluated against every row of its type
+and resolves its own path independently, so per-row cost is (rules on the type) ×
+(elements at the path) — a product neither the rule count nor the byte budget
+bounds. Spread rules across resource types the way the built-in pack does.
+
+!!! note "Reject per record, truncate across records"
+    **Within one record the Hive rejects**: you are there, you can read the
+    error, and a record you cannot save is better than one that saves and
+    silently never applies. **Across records the collector truncates**, keeping
+    the first entries in record-name order and reporting the rest — by then
+    nobody is watching, and one runaway generator must not cost you the rules
+    that were fine.
+
+    Because several records compose, an organization can exceed the per-type and
+    org-wide bounds across records even though every individual record was legal.
+    The excess is dropped, not applied, and reported on each sweep.
+
+!!! info "A bad rule cannot break your posture"
+    Rule resolution never fails. Every rejection comes back as data: the built-in
+    pack survives intact, and a rule that will not compile — or uses an operator
+    outside the allowlist — is dropped rather than left to silently never match.
+
+    The finding budget is deliberately **all-or-nothing**: a pack that blows the
+    25,000-findings-per-pass cap has *all* of its custom findings dropped for that
+    pass and reported, rather than an arbitrary subset kept. The cap is reached in
+    row order, which is not stable between passes, so keeping a partial set would
+    churn the finding feed forever.
+
+## What custom rules are not
+
+- **Not cross-resource correlation.** A rule sees exactly one resource. "Public
+  workload that can reach a sensitive database" is a relationship, not a
+  property — that is what the [security graph](graph.md) and attack paths are
+  for, and a [saved query on a schedule](configuration.md#scheduled-queries-any-saved-query-as-a-detection-source)
+  turns any graph query into a detection source with no new rule syntax.
+- **Not temporal.** There is no "changed in the last hour" or "seen N times":
+  evaluation is a stateless function of the resource's current properties.
+- **Not a new finding class.** `misconfig` and `public_exposure` are the whole
+  authorable set.
+- **Not a console feature.** Authoring is Hive JSON through the CLI or API.

--- a/docs/cloud-security/custom-rules.md
+++ b/docs/cloud-security/custom-rules.md
@@ -372,23 +372,21 @@ the same record:
 
 ## How evaluation works
 
-Evaluation is **stateless and per resource**. Each rule is tested against every
-resource of its `resource_type`, on every projection pass, using only that
-resource's own properties.
+A saved record reaches the engine at the end of the **next collection sweep**,
+and is applied on the projection after it. Change the provider's `sync_now` nonce
+to a new value to trigger a sweep immediately instead of waiting for the refresh
+cadence.
 
-Two consequences matter in practice:
+Once it is there, evaluation is **stateless and per resource**: each rule is
+tested against every resource of its `resource_type`, on every projection pass,
+using only that resource's own properties. Two consequences matter in practice:
 
 - **A new rule applies to your whole existing estate**, not just to resources
-  that change afterwards. There is nothing to backfill and no re-scan to
-  request — the next projection re-derives findings across everything already in
+  that change afterwards. Nothing has to be backfilled — the first projection
+  after the policy lands re-derives findings across everything already in
   inventory.
 - **Findings close by themselves.** When the condition stops being true, the
   finding closes on the next pass, exactly like a built-in one.
-
-The record reaches the engine at the end of the **next collection sweep**, and
-applies on the projection after it. Change the provider's `sync_now` nonce to a
-new value to trigger a sweep immediately instead of waiting for the refresh
-cadence.
 
 Findings from custom rules are ordinary findings. They land in the same
 risk-ranked worklist, carry `lc_risk` and its breakdown, and support the full
@@ -414,7 +412,7 @@ rule's findings may carry none — which is the practical reason to write the
     condition is real but the *unit* is wrong (an account-level setting reported
     once per bucket), express it at the level it is actually fixed, or ship it at
     `LOW`/`INFO` so it stays out of the default worklist while remaining
-    queryable and countable for compliance.
+    queryable.
 
 ## Compliance interaction
 
@@ -444,8 +442,11 @@ are availability bounds, not just per-tenant quotas.
 | Composed policy size (all `rules` records together) | 512 KiB |
 | Size of one record | 256 KiB |
 | `detect` size per rule | 8 KiB |
+| Total `detect` budget across the organization | 64 KiB, with a rule containing a `scope` charged **10×** its size |
 | `scope` operators per rule | 2, never nested |
 | `detect` nesting depth | 32 |
+| Compiled size of one regex (`matches` pattern) | 1000 instructions |
+| Compiled regex size, summed per rule and per organization | 5000 instructions |
 | Rule id / title length | 64 / 256 characters |
 | `criticality_mult` | 0 – 1.6 |
 | Findings produced per pass | 25,000 per evaluator |
@@ -455,6 +456,17 @@ the one that matters most: every rule is evaluated against every row of its type
 and resolves its own path independently, so per-row cost is (rules on the type) ×
 (elements at the path) — a product neither the rule count nor the byte budget
 bounds. Spread rules across resource types the way the built-in pack does.
+
+!!! note "The regex bounds are program size, not pattern length"
+    If you use the `matches` operator, the budget is charged against the
+    **compiled program size** of the pattern, not how long the pattern is.
+    Nothing about a pattern's length bounds its program: a 253-byte alternation
+    compiles to 7 instructions, while a 230-byte nested-group pattern compiles to
+    over 200,000. A byte limit would accept the expensive one and reject the
+    cheap one, so the check counts instructions instead — which is why the number
+    in a rejection message will not correspond to anything you can see by looking
+    at the pattern. Flatten nested groups and large bounded repeats, or express
+    the same set as an `or` of `is` / `starts with` leaves, which is far cheaper.
 
 !!! note "Reject per record, truncate across records"
     **Within one record the Hive rejects**: you are there, you can read the

--- a/docs/cloud-security/custom-rules.md
+++ b/docs/cloud-security/custom-rules.md
@@ -154,6 +154,22 @@ Paths are rooted at `event/`, and the event body is the resource's normalized
 properties. `limacharlie cloudsec resource get "lcrn:..."` prints a real
 resource, which is the fastest way to see the exact property names for a type.
 
+!!! note "A few facets are computed at evaluation time"
+    Some properties a rule can match on are derived when the rule runs rather
+    than stored on the resource, so they do **not** appear in `resource get`:
+
+    - **Network** — `covers_all_ports` (the rule's port range spans the whole
+      port space) and `ports_effective` (the explicitly listed ports plus every
+      well-known port a listed range contains). Both exist because a declarative
+      rule cannot expand a port range itself; the firewall example below uses
+      them.
+    - **Identity** — `dormant`, `mfa_known` / `mfa_enabled`,
+      `credential_recently_used`, and `service_linked` (an AWS service-linked
+      role).
+
+    Everything else you can match on is a stored property, visible in
+    `resource get`.
+
 ### The operator allowlist
 
 A rule may use only these operators, anywhere in its `detect` tree:
@@ -406,9 +422,11 @@ rule's findings may carry none — which is the practical reason to write the
 
 !!! warning "Measure a broad rule before you trust it"
     A rule that matches a quarter of its resource type is a rule that buries the
-    rest of your worklist. Before relying on a new rule, check what it actually
-    produced (`limacharlie cloudsec finding facets`) — a single near-universal
-    condition can produce six-figure finding counts on a large estate. If the
+    rest of your worklist. Before relying on a new rule, count what it actually
+    produced — the worklist has no rule-id facet, so search for the id
+    (`limacharlie cloudsec finding list -q custom-your-rule-id`) — because a
+    single near-universal condition can produce six-figure finding counts on a
+    large estate. If the
     condition is real but the *unit* is wrong (an account-level setting reported
     once per bucket), express it at the level it is actually fixed, or ship it at
     `LOW`/`INFO` so it stays out of the default worklist while remaining
@@ -426,8 +444,16 @@ a control no detector covers at all, and it keeps `NOT_ASSESSED` out of the
 compliance score's denominator rather than inflating it into a green check. See
 [Compliance](compliance.md).
 
-Custom rules do not evidence framework controls: catalogs join controls to rule
-ids, and no catalog names a `custom-` id.
+The reverse direction is worth knowing before you write a broad rule. Your own
+rules can never make a control **pass** — a control passes when nothing proves a
+violation, and a rule only ever adds findings. They can, however, make one
+**fail**: framework catalogs join controls to detections two ways, by rule id
+(no catalog names a `custom-` id) and by **finding class**, scoped to the
+control's resource types. `public_exposure` is a class several frameworks join
+on, so a `public_exposure` rule over a resource type such a control scopes to
+attaches to it as evidence and flips it to FAIL. `misconfig` is not a class-join
+key in any shipped catalog, so a `misconfig` rule never moves a compliance
+verdict.
 
 ## Bounds
 

--- a/docs/cloud-security/custom-rules.md
+++ b/docs/cloud-security/custom-rules.md
@@ -166,6 +166,10 @@ resource, which is the fastest way to see the exact property names for a type.
     - **Identity** — `dormant`, `mfa_known` / `mfa_enabled`,
       `credential_recently_used`, and `service_linked` (an AWS service-linked
       role).
+    - **HasPermission** — `effective_public_grant`: the grant really does expose
+      the target to the internet, after accounting for a `deny` statement and
+      for a target whose own public-access block neutralizes it. Match on this
+      rather than on `public_principal`, which is only half the question.
 
     Everything else you can match on is a stored property, visible in
     `resource get`.
@@ -423,14 +427,14 @@ rule's findings may carry none — which is the practical reason to write the
 !!! warning "Measure a broad rule before you trust it"
     A rule that matches a quarter of its resource type is a rule that buries the
     rest of your worklist. Before relying on a new rule, count what it actually
-    produced — the worklist has no rule-id facet, so search for the id
-    (`limacharlie cloudsec finding list -q custom-your-rule-id`) — because a
-    single near-universal condition can produce six-figure finding counts on a
-    large estate. If the
-    condition is real but the *unit* is wrong (an account-level setting reported
-    once per bucket), express it at the level it is actually fixed, or ship it at
-    `LOW`/`INFO` so it stays out of the default worklist while remaining
-    queryable.
+    produced — the worklist has no rule-id facet, so search for the id with
+    `limacharlie cloudsec finding list -q custom-your-rule-id`. A single
+    near-universal condition can produce six-figure finding counts on a large
+    estate, and past the per-pass budget below it costs you *every* custom
+    finding, not just its own. If the condition is real but the *unit* is wrong
+    (an account-level setting reported once per bucket), express it at the level
+    it is actually fixed, or ship it at `LOW`/`INFO` so it stays out of the
+    default worklist while remaining queryable.
 
 ## Compliance interaction
 
@@ -475,7 +479,7 @@ are availability bounds, not just per-tenant quotas.
 | Compiled regex size, summed per rule and per organization | 5000 instructions |
 | Rule id / title length | 64 / 256 characters |
 | `criticality_mult` | 0 – 1.6 |
-| Findings produced per pass | 25,000 per evaluator |
+| Custom findings kept in one projection pass | 25,000 per evaluator — the pass runs two, so roughly 50,000 per organization |
 
 The 25-rules-per-resource-type bound is the one that surprises people, and it is
 the one that matters most: every rule is evaluated against every row of its type

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -175,7 +175,7 @@ limacharlie cloudsec finding list --sla breached --sort due_at
 ```
 
 In the console the **Risks** table gains a sortable **Due** column and the filter
-rail a **Due** facet. There is no default SLA: with no policy record every
+rail an **SLA** facet. There is no default SLA: with no policy record every
 finding reads `none`.
 
 ## Chokepoints — fix one thing

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -59,6 +59,15 @@ Each finding carries:
   `epss`, `in_kev`.
 - Runtime context: `runtime_sids` — the LimaCharlie sensors running on the
   affected asset, when the fusion mapping resolves any.
+- Remediation clock: `due_at`, `sla_source`, and the derived `sla_state` —
+  present once the organization has written an
+  [`sla` policy](remediation-sla.md); absent (and `sla_state: none`) until then.
+
+!!! tip "Your own rules land here too"
+    Detections you author yourself with a
+    [`rules` policy](custom-rules.md) produce ordinary findings: same worklist,
+    same ranking, same triage verbs, same events. Nothing about the rest of this
+    page treats them differently.
 
 Attack-path and `toxic_combination` findings headline the durable **workload
 group** rather than a single ephemeral node: a GKE/EKS/AKS node pool, a GCE
@@ -155,6 +164,20 @@ An operator's explicit disposition always wins over policy.
     Reading findings requires `cloudsec.get`; every disposition, owner,
     ticket, and chokepoint write requires `cloudsec.set`.
 
+## Due dates
+
+With an [`sla` policy](remediation-sla.md) written, every covered finding carries
+a `due_at` and a derived state — `breached`, `due_soon`, `on_track`, `exempt`, or
+`none` — so the worklist can be worked by deadline as well as by risk:
+
+```bash
+limacharlie cloudsec finding list --sla breached --sort due_at
+```
+
+In the console the **Risks** table gains a sortable **Due** column and the filter
+rail a **Due** facet. There is no default SLA: with no policy record every
+finding reads `none`.
+
 ## Chokepoints — fix one thing
 
 Attack paths tend to share hops. The chokepoint view ranks resources by how
@@ -210,6 +233,10 @@ the world):
 - `cloud_finding.still_open` — re-asserted at most once per day for open
   findings that carry a linked ticket, the heartbeat that keeps a Case honest
   when the cloud was never actually fixed.
+- `cloud_finding.sla_breached` — emitted once, on the first projection pass that
+  observes an open finding past the `due_at` its
+  [`sla` policy](remediation-sla.md) assigned. Never re-fired for the same
+  breach of the same deadline.
 
 **Operator-disposition verbs** (flat payload
 `{finding_id, fingerprint, finding_class, actor, status, resolution, note?}`):

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -26,6 +26,8 @@ rules, Cases, and Outputs you already use.
 | **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources, including LimaCharlie's own sensors) with coverage-gap and device-posture findings — "seen by the identity provider, no EDR". |
 | **Security graph & topology** | An explorable graph of resources, identities, and their relationships (`can_reach`, `exposed_to`, `has_permission_on`, `can_assume`, …) plus an aggregated estate topology view, with a query language and saved queries. |
 | **Runtime fusion** | Bidirectional resolution between LimaCharlie sensors and the cloud assets they run on — pivot from a cloud finding to the live endpoint and back. |
+| **Your own detections** | Author your own CSPM rules — in the same detection format as the built-in pack — and disable, re-severity, or replace any built-in rule for your organization. |
+| **Remediation SLAs** | Declare how long a finding may stay open, per severity, class, account, or owner, and work the worklist by deadline as well as by risk. |
 | **MSSP fleet** | A cross-tenant fleet board that rolls up risk across every organization you manage. |
 
 ## Supported providers
@@ -121,10 +123,14 @@ organization you manage.
   formats, and first-run troubleshooting.
 - [Findings & Triage](findings.md) — the worklist, finding classes,
   dispositions, chokepoints.
+- [Remediation SLAs](remediation-sla.md) — due dates on findings, the derived
+  states, and breach events.
 - [Security Graph & Queries](graph.md) — attack paths, topology, graph
   queries, CIEM, DSPM, sensor↔asset resolution.
 - [Compliance](compliance.md) — frameworks, reports, scoped assignments.
 - [CAASM](caasm.md) — third-party asset inventory, coverage gaps, device posture.
+- [Custom Posture Rules](custom-rules.md) — author your own CSPM detections and
+  retune the built-in ones.
 - [Configuration Reference](configuration.md) — the `cloudsec_provider`,
   `cloudsec_policy`, and `cloudsec_query` Hive records.
 - [Command Line Interface](cli.md) — the `limacharlie cloudsec` command

--- a/docs/cloud-security/remediation-sla.md
+++ b/docs/cloud-security/remediation-sla.md
@@ -2,7 +2,8 @@
 
 A remediation SLA puts a **due date** on findings, so the worklist can answer
 *"what is late?"* rather than only *"what is bad?"*. You declare how long a
-finding of a given severity, class, account, or owner may stay open; every
+finding of a given severity, class, detecting rule, account, or owner may stay
+open; every
 covered finding then carries a `due_at`, and being breached is a plain
 comparison against the clock rather than a stored judgement somebody has to
 maintain.
@@ -104,8 +105,9 @@ to make the number look better.
 }
 ```
 
-Many `sla` records compose: rule lists concatenate in record order, and the
-per-severity defaults merge first-record-wins.
+Many `sla` records compose: rule lists concatenate in **record-name** order — so
+first-match-wins is deterministic across records too — and the per-severity
+defaults merge first-record-wins.
 
 ### Matching
 
@@ -273,3 +275,9 @@ Matching is a linear scan per finding on the projection hot path, over a set tha
 reaches tens of thousands of rows, so the rule count is a per-row cost multiplier.
 Ten years is not an SLA; the `due_days` ceiling keeps a fat-fingered value from
 producing an "on track until 4021" row that reads like a bug.
+
+The rule count is checked twice, and the two behave differently on purpose. A
+single record over the limit is **rejected** when you save it — you are there and
+can read the error. Records that compose past it are **truncated** in record-name
+order, keeping the rules that fit, because refusing the whole composed policy
+would silently leave the previous one applied forever.

--- a/docs/cloud-security/remediation-sla.md
+++ b/docs/cloud-security/remediation-sla.md
@@ -28,6 +28,14 @@ oversight waiting to be fixed:
 So adoption is a single Hive write, and the starter policy below is what to
 write.
 
+!!! note "It takes one sweep to land"
+    Like every other `cloudsec_policy` record, an `sla` policy reaches the engine
+    at the end of the **next collection sweep**, and the due dates are stamped on
+    the projection after it. Writing the record and immediately reading
+    `sla_state: none` across the estate does not mean it was rejected — change
+    the provider's `sync_now` nonce to trigger a sweep straight away instead of
+    waiting for the refresh cadence.
+
 ## The starter policy
 
 The four-tier shape below is the common industry default and a reasonable place
@@ -108,7 +116,7 @@ per-severity defaults merge first-record-wins.
 - Within a rule, keys **AND** together and lists **OR** within a key. An empty key
   is unconstrained, and an **entirely empty `match` is a deliberate catch-all** —
   that is how you say "everything else in 90 days" as the last rule.
-- The `rule` name is required and must be unique within the record. It is
+- Each rule's `name` is required and must be unique within the record. It is
   recorded on every finding the clause dates (as `sla_source`), so an operator
   can always see *which* clause put the date there.
 
@@ -116,7 +124,7 @@ per-severity defaults merge first-record-wins.
 |---|---|
 | `severity` | The finding's severity, exact, case-insensitive. |
 | `finding_class` | The finding's class (`misconfig`, `vulnerability`, `toxic_combination`, …), exact, case-insensitive. |
-| `rule` | The detecting rule's id, exactly (e.g. `public-bucket`). |
+| `rule` | The **detecting** rule's id, matched exactly — e.g. `public-data-store`. A misspelled id silently matches nothing, so copy it from a real finding (`limacharlie cloudsec finding get <id>`) rather than typing it. |
 | `account` | The finding's account, with the shared [glob dialect](configuration.md#glob-syntax) including leading-`!` negation. |
 | `owner` | The **assigned** owner, same glob dialect. |
 
@@ -143,11 +151,15 @@ the honest simple thing.
 ## Stored vs derived
 
 **Stored on the finding:** `due_at` (= `first_seen` + the matched window) and
-`sla_source` (the rule name that matched, or `default`). Both are deterministic
-from the finding's first detection and the policy, so they change only when the
-finding is created or the policy is edited.
+`sla_source` (the rule name that matched, or `default`). Both are recomputed on
+every projection pass from the finding's current attributes, so a deadline moves
+when the inputs a clause matches on move — most visibly, **assigning or
+reassigning an owner** re-runs the scan and can hand the finding to a different
+`owner`-scoped clause, with no policy edit involved. A severity change does the
+same.
 
-**Derived at read time, never stored:** the `sla_state`.
+**Derived at read time, never stored:** the `sla_state`. It is always present —
+a finding no clause covers reads `none`.
 
 | State | Meaning |
 |---|---|
@@ -196,10 +208,16 @@ closing removes it, so the recurrence is a new finding with a new `first_seen`.
 
 When a projection pass first observes a finding past its due date it emits
 `cloud_finding.sla_breached` into the organization's event stream (subject to the
-[`emission` policy](configuration.md#emission-the-event-feed)) and records the
-breach, so the event fires **exactly once** per breach rather than on every pass.
-A D&R rule can route it to a ticket, a page, or an escalation — see
+[`emission` policy](configuration.md#emission-the-event-feed)) and latches the
+breach, so the event fires **once per breached deadline** rather than on every
+pass. A D&R rule can route it to a ticket, a page, or an escalation — see
 [Automation & IaC](automation.md#escalating-an-sla-breach).
+
+The latch is held against the *specific* `due_at` it fired for. If the deadline
+later moves — a policy edit, or an owner change that hands the finding to a
+different clause — the old commitment no longer exists, the finding is re-armed,
+and a breach of the **new** deadline fires again. That is the intended reading:
+each distinct commitment gets its own alert.
 
 !!! warning "Granularity is the reprojection cadence, not the second"
     A breach is noticed on the next projection pass that touches your
@@ -210,8 +228,8 @@ A D&R rule can route it to a ticket, a page, or an escalation — see
 
 In the console, the **Risks** worklist carries a sortable **Due** column showing
 the relative deadline (`in 6d`, `12d ago`, `today`), toned by state, with the
-exact date and the clause that set it on hover. The filter rail carries a **Due**
-facet with a count per state.
+exact date and the clause that set it on hover. The filter rail carries an
+**SLA** facet with a count per state.
 
 On the CLI and API, `sla` is a repeatable selector on the findings surfaces, and
 `due_at` is a sort key:

--- a/docs/cloud-security/remediation-sla.md
+++ b/docs/cloud-security/remediation-sla.md
@@ -1,0 +1,257 @@
+# Remediation SLAs
+
+A remediation SLA puts a **due date** on findings, so the worklist can answer
+*"what is late?"* rather than only *"what is bad?"*. You declare how long a
+finding of a given severity, class, account, or owner may stay open; every
+covered finding then carries a `due_at`, and being breached is a plain
+comparison against the clock rather than a stored judgement somebody has to
+maintain.
+
+It is one `sla`-typed [`cloudsec_policy`](configuration.md#cloudsec_policy)
+record.
+
+## There is no default SLA
+
+An organization with no `sla` policy record has **no due dates and nothing
+breached**. Every finding reads `none`. That is deliberate, and it is not an
+oversight waiting to be fixed:
+
+- An SLA is a commitment **you** make about your own remediation capacity. The
+  platform inventing one on your behalf is the same category of mistake as
+  declaring your data sensitive without being told — which is why the
+  [`classification` policy](configuration.md#classification-crown-jewels) works
+  the same way.
+- A built-in default would mean that every existing estate instantly acquires a
+  five- or six-figure `breached` count for work nobody ever promised to do. A
+  manufactured number is worse than a missing one.
+
+So adoption is a single Hive write, and the starter policy below is what to
+write.
+
+## The starter policy
+
+The four-tier shape below is the common industry default and a reasonable place
+to begin. It is a **recommendation, not a default** — nothing applies it until you
+write it:
+
+```json
+{
+  "policy_type": "sla",
+  "sla": {
+    "default_due_days": { "CRITICAL": 7, "HIGH": 30, "MEDIUM": 90, "LOW": 180 }
+  }
+}
+```
+
+```bash
+limacharlie hive set --hive-name cloudsec_policy --key sla \
+  --oid $OID --input-file sla.json --enabled
+```
+
+Start there, watch the breach count for a cycle, then add rules to **tighten** the
+part of the estate you actually care about — internet-exposed resources,
+production accounts, crown-jewel data stores — rather than loosening the defaults
+to make the number look better.
+
+## The record
+
+| Field | Meaning |
+|---|---|
+| `default_due_days` | Per-severity fallback, keyed by `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` / `INFO` (case-insensitive). Applied only when **no** rule matched. A severity absent from the map gets no due date. |
+| `rules` | An **ordered** list of `{name, match, due_days}` clauses. First match wins. |
+
+```json
+{
+  "policy_type": "sla",
+  "sla": {
+    "default_due_days": { "CRITICAL": 7, "HIGH": 30, "MEDIUM": 90, "LOW": 180 },
+    "rules": [
+      {
+        "name": "sandbox-is-exempt",
+        "match": { "account": ["sandbox-*", "*-scratch"] },
+        "due_days": 0
+      },
+      {
+        "name": "production-criticals",
+        "match": { "severity": ["CRITICAL"], "account": ["prod-*"] },
+        "due_days": 3
+      },
+      {
+        "name": "known-exploited-vulns",
+        "match": { "finding_class": ["vulnerability"], "severity": ["CRITICAL", "HIGH"] },
+        "due_days": 14
+      },
+      {
+        "name": "platform-team",
+        "match": { "owner": ["*@platform.example.com"] },
+        "due_days": 14
+      },
+      {
+        "name": "everything-else",
+        "match": {},
+        "due_days": 90
+      }
+    ]
+  }
+}
+```
+
+Many `sla` records compose: rule lists concatenate in record order, and the
+per-severity defaults merge first-record-wins.
+
+### Matching
+
+- **Rules are ordered and the first match wins** — the same convention the
+  [`suppression`](automation.md#suppression-rules-finding-disposition-policy) and
+  [`exclusions`](configuration.md#exclusions-the-escape-hatch) policies use. Put
+  the narrow clauses first.
+- Within a rule, keys **AND** together and lists **OR** within a key. An empty key
+  is unconstrained, and an **entirely empty `match` is a deliberate catch-all** —
+  that is how you say "everything else in 90 days" as the last rule.
+- The `rule` name is required and must be unique within the record. It is
+  recorded on every finding the clause dates (as `sla_source`), so an operator
+  can always see *which* clause put the date there.
+
+| `match` key | Matches |
+|---|---|
+| `severity` | The finding's severity, exact, case-insensitive. |
+| `finding_class` | The finding's class (`misconfig`, `vulnerability`, `toxic_combination`, …), exact, case-insensitive. |
+| `rule` | The detecting rule's id, exactly (e.g. `public-bucket`). |
+| `account` | The finding's account, with the shared [glob dialect](configuration.md#glob-syntax) including leading-`!` negation. |
+| `owner` | The **assigned** owner, same glob dialect. |
+
+!!! note "An owner rule never claims the untriaged backlog"
+    An unassigned finding has an empty owner, and no glob matches an empty
+    value — so an `owner`-scoped rule silently skips everything nobody has picked
+    up. If untriaged findings should also have a clock, write a separate
+    catch-all rule for them.
+
+### `due_days: 0` is an exemption, not "due immediately"
+
+A matched rule with `due_days: 0` assigns **no** due date and **stops** the scan.
+It does not fall through to the next rule or to `default_due_days`.
+
+That is what lets you write "never put a clock on the sandbox" as an early rule
+ahead of a broad catch-all, instead of having to express the complement as a
+glob.
+
+`due_days` is a whole number of **calendar** days, 0 to 3650. Calendar rather than
+business days: business days need a per-organization holiday and region calendar
+that nothing in the platform models, and half-modelling one would be worse than
+the honest simple thing.
+
+## Stored vs derived
+
+**Stored on the finding:** `due_at` (= `first_seen` + the matched window) and
+`sla_source` (the rule name that matched, or `default`). Both are deterministic
+from the finding's first detection and the policy, so they change only when the
+finding is created or the policy is edited.
+
+**Derived at read time, never stored:** the `sla_state`.
+
+| State | Meaning |
+|---|---|
+| `breached` | Past `due_at`. |
+| `due_soon` | Inside the tail of its own window (see below). |
+| `on_track` | Has a due date, comfortably ahead of it. |
+| `exempt` | The finding is not `open`, so the clock does not report on it. |
+| `none` | No policy clause covers it, so it has no clock. |
+
+The state is a function of the current clock, so materializing it would be wrong
+the moment after it was written — nothing wakes up when a due date passes. It is
+computed on every read from `due_at`, `first_seen`, and `status`.
+
+!!! info "`due_soon` is a fraction of the window, not a fixed lead time"
+    A finding reads `due_soon` in the final **quarter** of its own window, clamped
+    to at least a day and at most a week.
+
+    A flat warning window is wrong at both ends of a normal policy: under a flat
+    7-day warning a 3-day `CRITICAL` would read "due soon" from the instant it was
+    created and never once read as on track, while a 180-day `LOW` would get four
+    days' notice on a six-month commitment.
+
+### Due dates anchor to first-seen
+
+The window runs from `first_seen` — when the platform first detected the
+condition — not from when you wrote the policy or last looked at the worklist.
+Adopting an SLA therefore tells you the truth about your existing backlog
+immediately, including findings that are already past due on day one.
+
+## Exempt, not paused
+
+A finding that is not `open` — an accepted risk, a mitigation, a policy
+suppression — is `exempt`. It **keeps** its `due_at`; the state simply does not
+report on it, and it is never counted as breached.
+
+When it returns to `open` (an acceptance expires, a suppression rule is deleted)
+the **original** due date applies again, which may mean it is immediately
+breached. That is deliberate: the risk was live for the whole acceptance window —
+that is precisely what "accepted" means, a live risk carried on purpose — so its
+age is real, and resetting the clock would launder it.
+
+A finding that genuinely went away and came back gets a fresh clock for free:
+closing removes it, so the recurrence is a new finding with a new `first_seen`.
+
+## Breach events
+
+When a projection pass first observes a finding past its due date it emits
+`cloud_finding.sla_breached` into the organization's event stream (subject to the
+[`emission` policy](configuration.md#emission-the-event-feed)) and records the
+breach, so the event fires **exactly once** per breach rather than on every pass.
+A D&R rule can route it to a ticket, a page, or an escalation — see
+[Automation & IaC](automation.md#escalating-an-sla-breach).
+
+!!! warning "Granularity is the reprojection cadence, not the second"
+    A breach is noticed on the next projection pass that touches your
+    organization — a change-driven reprojection, or the periodic full backstop at
+    worst. Do not build anything that assumes minute-accurate breach timing.
+
+## Working the clock
+
+In the console, the **Risks** worklist carries a sortable **Due** column showing
+the relative deadline (`in 6d`, `12d ago`, `today`), toned by state, with the
+exact date and the clause that set it on hover. The filter rail carries a **Due**
+facet with a count per state.
+
+On the CLI and API, `sla` is a repeatable selector on the findings surfaces, and
+`due_at` is a sort key:
+
+```bash
+# Everything past due, soonest deadline first.
+limacharlie cloudsec finding list --sla breached --sort due_at
+
+# What is about to go late in production.
+limacharlie cloudsec finding list --sla due_soon --account prod-app --sort due_at
+
+# The breach/on-track split for the whole estate.
+limacharlie cloudsec finding facets --status open
+```
+
+`--sla` is repeatable (OR within the key, AND with the other filters) and takes
+`breached`, `due_soon`, `on_track`, `exempt`, or `none`. It reaches
+`finding list`, `finding facets`, `finding causes`, and `export findings`; the
+exported CSV rows carry `due_at`, `sla_state`, and `sla_source` alongside the
+usual worklist fields.
+
+!!! note "`--sort due_at` is the one ascending sort"
+    Every other sort key defaults to descending. `due_at` defaults to
+    **ascending** — soonest deadline first, which is the only useful reading of a
+    deadline column — and it places findings with **no** due date last rather than
+    dropping them from the page.
+
+    `--sla` and `--sort due_at` require a `limacharlie` CLI newer than 5.6.1. On
+    an older CLI, pass `sla=` and `sort=due_at` on the
+    [REST route](api-reference.md#reads) directly.
+
+## Bounds
+
+| Bound | Value |
+|---|---|
+| Rules per composed policy | 200 |
+| `due_days` | 0 – 3650 |
+| Rule name length | 128 characters |
+
+Matching is a linear scan per finding on the projection hot path, over a set that
+reaches tens of thousands of rows, so the rule count is a per-row cost multiplier.
+Ten years is not an SLA; the `due_days` ceiling keeps a fat-fingered value from
+producing an "on track until 4021" row that reads like a bug.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -596,9 +596,11 @@ nav:
           - Anthropic: cloud-security/provider-setup/anthropic.md
           - LimaCharlie: cloud-security/provider-setup/limacharlie.md
       - Findings & Triage: cloud-security/findings.md
+      - Remediation SLAs: cloud-security/remediation-sla.md
       - Security Graph & Queries: cloud-security/graph.md
       - Compliance: cloud-security/compliance.md
       - CAASM: cloud-security/caasm.md
+      - Custom Posture Rules: cloud-security/custom-rules.md
       - Configuration Reference: cloud-security/configuration.md
       - Command Line Interface: cloud-security/cli.md
       - API Reference: cloud-security/api-reference.md


### PR DESCRIPTION
## What was asked

Two customer-facing Cloud Security features are live and undocumented in the public docs: the `rules` and `sla` policy types on the `cloudsec_policy` hive. Document both, matching the existing section's structure and tone, with every JSON example validated against the real hive write gate before it ships.

## What was done

**Two new pages**

- `docs/cloud-security/custom-rules.md` — **Custom Posture Rules** (`policy_type: "rules"`). What a rule is (a real D&R detection over one canonical resource, presented as a `cloud_resource.<type>` event — not a new DSL); the record schema; why rule ids are permanent (fingerprint input *and* compliance-catalog join key) and why they are namespaced `custom-`; the operator allowlist as a safety boundary; the rejected value syntaxes (`[[name]]`, `{{ … }}`) and wildcard paths; the `scope` cross-element trap with a worked firewall example; "never fire on silence"; override precedence; how evaluation works (stateless per resource — a new rule applies to the whole existing estate, findings close by themselves, they land in the normal worklist with full lifecycle); the compliance interaction; the bounds and the reject-per-record / truncate-across-records stance; and an explicit "what this is not" (no cross-resource or temporal correlation, no console editor).
- `docs/cloud-security/remediation-sla.md` — **Remediation SLAs** (`policy_type: "sla"`). Why there is no default SLA and why that is deliberate; the starter policy; the record schema and match semantics (ordered, first-match-wins, AND across keys / OR within a key, empty `match` as a deliberate catch-all); `due_days: 0` as an exemption rather than "due immediately"; stored (`due_at`, `sla_source`) vs derived (`sla_state`) and why the state cannot be materialized; `due_soon` as the final quarter of the finding's own window; due dates anchoring to first-seen; exempt-not-paused; breach events; the bounds; and the worklist / CLI / API surface.

**Existing pages extended**

| Page | Change |
|---|---|
| `configuration.md` | `cloudsec_policy` purposes row updated; new `rules` and `sla` policy-type sections |
| `findings.md` | SLA fields on the finding, a **Due dates** section, `cloud_finding.sla_breached`, and a note that self-authored rules produce ordinary findings |
| `cli.md` | `--sla` and `--sort due_at`, plus the note that both are Hive-authored records rather than missing commands |
| `api-reference.md` | `sla[]` / `owner[]` selectors and the `due_at` sort key, the finding's SLA fields, and the breach event |
| `automation.md` | IaC recipes for both records and an **Escalating an SLA breach** D&R rule |
| `compliance.md` | the disabled-rule case added to the `NOT_ASSESSED` definition |
| `index.md`, `mkdocs.yml` | capability rows, documentation list, nav |

**Two things worth a reviewer's attention**

- The CLI's `--sla` / `--sort due_at` are merged but **not in a released version** — 5.6.1 is the newest on PyPI and does not carry them. The CLI page says so explicitly and points at the REST parameters in the meantime; that note should be deleted once a release ships.
- The API-reference findings row previously omitted `owner[]`, which the gateway has been forwarding; it is listed alongside `sla[]` now.

## Testing

**Every JSON example was validated against the live hive write gate** on a test organization, in the exact form it appears in the docs — all 8 records (4 rule examples, 2 SLA examples, 2 Automation recipes) extracted programmatically from the rendered pages and written back. All accepted; the validation record was deleted afterwards and the organization's pre-existing records were left untouched and verified intact.

The six rejection messages quoted in the docs are the gate's real output, captured verbatim (missing `custom-` prefix, wildcard path, disallowed operator, `subject_path` written as a detection path, non-authorable `finding_class`, no-op override). The operator allowlist published in the docs is the one the gate itself prints in that error.

Repo checks:

- `mkdocs build --strict` — clean
- `python scripts/check-list-numbering.py docs site --baseline …` — 0 new numbering breaks
- `pytest tests/` — 57 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyyEPjqXMJWRWtTnBjchnS