### PR TITLE
docs(vulnerability-reporting): document the per-CVE listing `total`

### DIFF
--- a/docs/5-integrations/extensions/limacharlie/vulnerability-reporting.md
+++ b/docs/5-integrations/extensions/limacharlie/vulnerability-reporting.md
@@ -440,6 +440,31 @@ Request:
 
 Pass `normalized_package_name` so the resolution overlay can compute host-scope fingerprints; without it, only org-scope resolution hits land. Filters supported: `platform`, `platform_string`, `criticality`, `env`, `exposure`, `resolution`.
 
+Response:
+
+```json
+{
+  "hosts": [
+    {
+      "sid": "1dfa4a11-...",
+      "hostname": "web1.prod",
+      "platform_string": "linux",
+      "resolution": null
+    }
+  ],
+  "cursor": "1000",
+  "total": 4211
+}
+```
+
+`total` is the number of **distinct hosts affected by the CVE across every page** — not the number of rows in this page. Because computing it costs an extra aggregate query, it is returned **only on the first page** (the request that omits `cursor`); follow-up pages omit the field. It is also omitted when the request carries a `criticality`, `env`, `exposure` or `resolution` filter, since those are applied per page after the aggregate is computed and no total would be accurate. Treat a missing `total` as "not available" rather than as zero, and keep following `cursor` until it comes back empty — that, not `total`, is what tells you the listing is finished.
+
+:::note
+An empty `hosts` array does **not** mean the listing is over. When one of the per-page filters above is in play, a page can legitimately come back with no rows and a non-empty `cursor`. Stop only when `cursor` is empty.
+:::
+
+`query_cve_vuln_packages` follows the same `total` contract, counting distinct `(package_name, package_version)` pairs across all pages.
+
 #### `query_cve`
 
 Request:


### PR DESCRIPTION
`query_cve_vuln_hosts` had no documented response at all, and `total` on it and on `query_cve_vuln_packages` is easy to misread — it counts the **whole result set**, not the rows in the page you are holding, and it is only returned on the first page.

Adds the response example plus the three things a paging caller actually has to know:

- `total` is **first-page-only** (the request that omits `cursor`); later pages omit the field.
- It is **omitted** when the request carries a `criticality` / `env` / `exposure` / `resolution` filter, because those are applied per page and no total would be accurate. A missing `total` means "not available", not zero.
- An **empty `hosts` array with a non-empty `cursor` is a legitimate mid-listing page** under those filters — so `cursor`, never `total` or the row count, is what tells you the listing is finished.

Docs-only; no code in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1XzAUsz12jPUhfofUja5M