### PR TITLE
docs(sensors): clarify the run STDOUT limit is bytes, and that going over returns nothing

### DIFF
--- a/docs/2-sensors-deployment/endpoint-agent/payloads.md
+++ b/docs/2-sensors-deployment/endpoint-agent/payloads.md
@@ -21,6 +21,16 @@ Payloads are uploaded to the LimaCharlie platform and given a name. The task `ru
 
 The STDOUT and STDERR data will be returned in a related `RECEIPT` event, up to 1 MB. If your payload generates more data, we recommend to pipe the data to a file on disk and use the `log_get` command to retrieve it.
 
+!!! warning "The 1 MB limit is measured in bytes, and exceeding it returns no output at all"
+    Two things about this limit surprise people:
+
+    - **It is 1 MB of raw output bytes, not characters.** Output encoded as UTF-16 costs two bytes per character, so it reaches the limit at roughly 524,000 characters instead of 1,048,000. Windows tooling frequently produces UTF-16 — `Out-File`, `>` redirection and `Export-Csv` in Windows PowerShell all default to it — so a command that looks well under the limit can be at it.
+    - **Going over the limit does not truncate the output — it removes it.** The `RECEIPT` still arrives, with the payload's exit code in `ERROR`, but `STDOUT` is absent rather than clipped at 1 MB. Very close to the limit the `RECEIPT` may not arrive at all.
+
+    So if a `run` returns a receipt with no output, or no receipt, treat the output size as the first suspect. Writing to a file and collecting it with `log_get` (or `artifact_get`) has no such limit and is the right approach for anything that might approach it.
+
+    To keep large output under the limit, emit UTF-8 or ASCII rather than UTF-16 — in PowerShell, `Out-File -Encoding utf8` or `[Console]::Out.Write()` — which doubles the number of characters that fit.
+
 The payload is retrieved by the endpoint agent over HTTPS to the Ingestion API DNS endpoint. This DNS entry is available from the Sensor Download section of the web app if you need to allow it.
 
 ## Upload / Download via REST


### PR DESCRIPTION
## Why

`payloads.md` promised STDOUT "up to 1 MB" with no mention of encoding, and no mention of what happens past the limit. Both surprise people, and both cost real support time on a recent case.

## What was measured

End to end against a live 5.3.5 Windows sensor, bisecting the character count until receipts stopped arriving:

| Encoding | Delivered intact | Failed | In bytes |
| --- | --- | --- | --- |
| single-byte | 1,047,656 chars | 1,048,828 chars | ~1,048,576 |
| UTF-16LE+BOM | 522,812 chars | 524,218 chars | ~1,048,576 |

Both ceilings land on **1,048,576** — the limit is raw output **bytes**, exactly as the page implies numerically. Encoding matters only because UTF-16 costs two bytes per character, so it halves the *character* budget. That matters in practice because Windows tooling produces UTF-16 by default in several common cases (`Out-File`, `>` redirection, `Export-Csv` in Windows PowerShell), so a command that looks comfortably under the limit can be sitting on it.

**Exceeding the limit does not truncate — it removes the output.** The `RECEIPT` still arrives with the exit code in `ERROR`, but `STDOUT` is absent rather than clipped at 1 MB. Confirmed at six sizes from 1.05 MB to 1.4 MB. Within a few hundred bytes of the cap, no `RECEIPT` arrives at all.

That last part is the reason for this PR: "up to 1 MB" reads as a promise of clipping, so someone debugging an empty receipt has no reason to suspect size. That is exactly how the support case went.

## What the page now says

- The limit is bytes, not characters, with the UTF-16 halving spelled out and the common Windows sources named.
- Going over returns no output rather than truncated output, and near the boundary may return no receipt.
- The workarounds, since halving the byte cost is usually easier than restructuring a payload: emit UTF-8/ASCII instead of UTF-16, or write to a file and collect it with `log_get` / `artifact_get`, which have no such limit.

## Notes

- The two behaviours above the cap are arguably **sensor bugs** rather than intended design, and are tracked on the sensor side (refractionPOINT/lc_sensor#808). This PR documents what the platform does today regardless — an accurate description of current behaviour is worth having whether or not the behaviour changes.
- `markdownlint-cli2` could not be run locally (the pinned dependency needs Node 20+, this box has 18). The admonition follows the existing shape used elsewhere in this directory, and `MD013` is disabled in `.markdownlint-cli2.jsonc`, so the long lines are fine. CI lint will be the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)