### PR TITLE
docs(sensors): lower Linux glibc floor to 2.12

### DIFF
--- a/docs/10-release-notes/index.md
+++ b/docs/10-release-notes/index.md
@@ -478,7 +478,7 @@ AI-assisted detection read-out, navigation improvements, showing org selector co
 
 **Linux:**
 
-- Fix some Linux GLIBC compatibility issues. The minimum GLIBC supported version is now 2.16 (released 2012) for all 3 supported architectures (x86, x86_64, and ARM64)
+- Fix some Linux GLIBC compatibility issues. The minimum GLIBC supported version is now 2.17 (released 2012) for all 3 supported architectures (x86, x86_64, and ARM64)
 - Fix the Linux Alpine / musl libc binaries
 
 **macOS:**

--- a/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
+++ b/docs/2-sensors-deployment/endpoint-agent/linux/installation.md
@@ -30,7 +30,17 @@ The agent exposes one runtime override for compatibility scenarios (the eBPF tie
 
 ### System Requirements
 
-The agent runs on glibc-based distributions back to glibc 2.17 (RHEL 7 / CentOS 7 / Debian 8 era and newer). For older or non-glibc systems use the **Alpine / musl** build, which is statically linked and has no host libc dependency. Older distributions like RHEL 5 / 6 are not supported by the standard glibc build because of the libc baseline; the musl build can be evaluated for those cases but kernel telemetry will be limited to whatever the host kernel exposes (see the tier table above).
+The agent runs on glibc-based distributions back to **glibc 2.12** (released May 2010). In practice that covers:
+
+- RHEL / CentOS / Oracle Linux **6** and newer (glibc 2.12)
+- Debian **7** (wheezy) and newer (glibc 2.13)
+- Ubuntu **12.04 LTS** and newer (glibc 2.15)
+
+Anything below that baseline — RHEL / CentOS **5** (glibc 2.5), Debian 6 (2.11), Ubuntu 10.04 (2.11) — is not supported by the standard glibc build. For those hosts, or for non-glibc systems, use the **Alpine / musl** build, which is statically linked and has no host libc dependency.
+
+On distributions this old, expect reduced kernel telemetry: RHEL / CentOS 6 ships kernel 2.6.32, which supports the netlink proc connector tier (real-time process create / exit) but not eBPF. Check the tier table above for what each kernel generation provides.
+
+Run `ldd --version` to check the glibc version on a host.
 
 ### Deb Package
 


### PR DESCRIPTION
## Summary

The Linux agent's glibc baseline is dropping to **2.12** (released May 2010), which brings **RHEL / CentOS 6** into support. The "System Requirements" section on the Linux install page still documented a glibc 2.17 / RHEL 7 baseline and explicitly listed RHEL 6 as unsupported.

## Changes

**`docs/2-sensors-deployment/endpoint-agent/linux/installation.md`**

- glibc baseline is now 2.12, with the per-distro mapping spelled out: RHEL / CentOS / Oracle Linux 6+ (2.12), Debian 7+ (2.13), Ubuntu 12.04 LTS+ (2.15).
- RHEL / CentOS 5 (glibc 2.5), Debian 6 (2.11), and Ubuntu 10.04 (2.11) stay excluded from the glibc build; those and non-glibc hosts are pointed at the Alpine / musl build.
- Added the kernel-tier consequence: RHEL / CentOS 6 ships kernel 2.6.32, which clears the netlink `CN_PROC` bar (2.6.15) but has no eBPF, so those hosts run in the netlink tier.
- Added `ldd --version` as the way to check a host's glibc version.

**`docs/10-release-notes/index.md`**

- Corrected the Endpoint Agent 4.33.7 (2025-05-22) entry: the floor it introduced was glibc 2.17, not 2.16.

## Version verification

| Distro | glibc | Kernel | Under a 2.12 floor |
|---|---|---|---|
| RHEL / CentOS 5 | 2.5 | 2.6.18 | ✗ below floor |
| RHEL / CentOS 6 | 2.12 | 2.6.32 | ✓ at the floor, netlink tier |
| RHEL / CentOS 7 | 2.17 | 3.10 | ✓ |
| Debian 6 (squeeze) | 2.11.2 | — | ✗ |
| Debian 7 (wheezy) | 2.13 | — | ✓ |
| Ubuntu 10.04 LTS | 2.11.1 | — | ✗ |
| Ubuntu 12.04 LTS | 2.15 | — | ✓ |

Cross-checked against the [glibc version history](https://en.wikipedia.org/wiki/Glibc) and DistroWatch package tables for [RHEL](https://distrowatch.com/table.php?distribution=redhat), [Debian](https://distrowatch.com/table.php?distribution=debian), and [Ubuntu](https://distrowatch.com/table.php?distribution=ubuntu).

## Note on timing

This documents a floor the shipping binary does not have yet — worth merging alongside the agent release that lowers it, not ahead of it. No release-notes entry was added for the new floor since the agent version isn't known yet.

## Left alone

Line 21 of the install page tells readers to compare `uname -r` against 5.4, while the tier table says eBPF wants 5.7+. Pre-existing inconsistency, out of scope here — needs a call on which value is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)