### PR TITLE
docs(adapters): document Microsoft national cloud endpoints (GCC High, DoD)

### DIFF
--- a/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
@@ -58,6 +58,22 @@ Then create a Defender adapter in LimaCharlie with:
 - Tenant ID
 - Client ID
 - Client Secret
+- Endpoint (optional) — see below
+
+#### National clouds (GCC High, DoD)
+
+US Government tenants are network-isolated from the commercial cloud: they authenticate against a different identity host and call a different Microsoft Graph service root, and an access token issued by one deployment is **not** valid against another. The optional `endpoint` option selects the deployment:
+
+| `endpoint` | Deployment | Identity host | Microsoft Graph |
+|------------|------------|---------------|-----------------|
+| `enterprise` (default) | Global / commercial | `login.microsoftonline.com` | `graph.microsoft.com` |
+| `gcc-gov` | Microsoft 365 GCC (moderate) | `login.microsoftonline.com` | `graph.microsoft.com` |
+| `gcc-high-gov` | US Government GCC High (L4) | `login.microsoftonline.us` | `graph.microsoft.us` |
+| `dod-gov` | US Government DoD (L5) | `login.microsoftonline.us` | `dod-graph.microsoft.us` |
+
+Leaving `endpoint` empty keeps the commercial endpoints, so existing adapters need no change. Microsoft 365 GCC (moderate) runs on the worldwide endpoints — `gcc-gov` exists so the deployment can be named explicitly and behaves identically to `enterprise`. Register the application in the government portal (`portal.azure.us`) rather than `portal.azure.com`.
+
+The same `endpoint` option, with the same four values, is used by the [Microsoft Entra ID](microsoft-entra-id.md) and [Microsoft 365](microsoft-365.md) adapters.
 
 ## Deployment Configurations
 
@@ -71,6 +87,7 @@ All adapters support the same `client_options`, which you should always specify 
 ### Adapter-specific Options
 
 - `connection_string` - The connection string provided in Azure for connecting to the Azure Event Hub, including the `EntityPath=...` at the end which identifies the Hub Name (this component is sometimes now shown in the connection string provided by Azure).
+- `endpoint` - API adapter only. The Microsoft national cloud the tenant lives in: `enterprise` (default), `gcc-gov`, `gcc-high-gov` or `dod-gov`. See [National clouds](#national-clouds-gcc-high-dod).
 
 ## Guided Deployment
 

--- a/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-defender.md
@@ -73,7 +73,7 @@ US Government tenants are network-isolated from the commercial cloud: they authe
 
 Leaving `endpoint` empty keeps the commercial endpoints, so existing adapters need no change. Microsoft 365 GCC (moderate) runs on the worldwide endpoints — `gcc-gov` exists so the deployment can be named explicitly and behaves identically to `enterprise`. Register the application in the government portal (`portal.azure.us`) rather than `portal.azure.com`.
 
-The same `endpoint` option, with the same four values, is used by the [Microsoft Entra ID](microsoft-entra-id.md) and [Microsoft 365](microsoft-365.md) adapters.
+The same four values are used by the [Microsoft Entra ID](microsoft-entra-id.md) adapter, where `endpoint` is likewise optional, and by the [Microsoft 365](microsoft-365.md) adapter, where it is **required** (that adapter calls the Office 365 Management Activity API, which has a distinct host per deployment including GCC moderate).
 
 ## Deployment Configurations
 
@@ -120,6 +120,9 @@ defender:
   tenant_id: "hive://secret/azure-tenant-id"
   client_id: "hive://secret/azure-defender-client-id"
   client_secret: "hive://secret/azure-defender-client-secret"
+  # Optional; omit for a commercial tenant. One of enterprise (default),
+  # gcc-gov, gcc-high-gov, dod-gov.
+  endpoint: "enterprise"
   client_options:
     identity:
       oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
@@ -43,6 +43,23 @@ For the full list of risk detection types, see [Microsoft's documentation](https
 - `sign_ins` requires the `AuditLog.Read.All` and `Directory.Read.All` application permissions, and the tenant must hold an Entra ID P1 (or P2) license — a Microsoft Graph requirement, the same one that applies to streaming SignInLogs to an Event Hub.
 - `audit_logs` requires the `AuditLog.Read.All` application permission.
 
+#### National clouds (GCC High, DoD)
+
+US Government tenants are network-isolated from the commercial cloud: they authenticate against a different identity host and call a different Microsoft Graph service root, and an access token issued by one deployment is **not** valid against another. The optional `endpoint` option selects the deployment:
+
+| `endpoint` | Deployment | Identity host | Microsoft Graph |
+|------------|------------|---------------|-----------------|
+| `enterprise` (default) | Global / commercial | `login.microsoftonline.com` | `graph.microsoft.com` |
+| `gcc-gov` | Microsoft 365 GCC (moderate) | `login.microsoftonline.com` | `graph.microsoft.com` |
+| `gcc-high-gov` | US Government GCC High (L4) | `login.microsoftonline.us` | `graph.microsoft.us` |
+| `dod-gov` | US Government DoD (L5) | `login.microsoftonline.us` | `dod-graph.microsoft.us` |
+
+Leaving `endpoint` empty keeps the commercial endpoints, so existing adapters need no change. Microsoft 365 GCC (moderate) runs on the worldwide endpoints — `gcc-gov` exists so the deployment can be named explicitly and behaves identically to `enterprise`.
+
+All three streams (`risk_detections`, `sign_ins`, `audit_logs`) are available in both US Government L4 and L5. Register the application in the government portal (`portal.azure.us`) rather than `portal.azure.com`; the app registration, permissions and admin consent steps below are otherwise the same.
+
+The same `endpoint` option, with the same four values, is used by the [Microsoft Defender](microsoft-defender.md) and [Microsoft 365](microsoft-365.md) adapters.
+
 ### Azure Event Hub
 
 When using Event Hub, you receive whatever data you configure Azure to stream. You must configure **Azure Diagnostic Settings** in Entra ID to send logs to your Event Hub. Common log types include:
@@ -103,7 +120,8 @@ Create a new Adapter within LimaCharlie, and select Microsoft Entra ID. Select `
    2. Client ID
    3. Client Secret
    4. Streams (optional): comma separated values among `risk_detections`, `sign_ins` and `audit_logs`; empty means `risk_detections` only
-   5. *Note: You can use the Secrets Manager for these values if you wish!*
+   5. Endpoint (optional): the Microsoft national cloud the tenant lives in — `enterprise`, `gcc-gov`, `gcc-high-gov` or `dod-gov`. Leave it empty for a commercial tenant; see [National clouds](#national-clouds-gcc-high-dod)
+   6. *Note: You can use the Secrets Manager for these values if you wish!*
 
 Click **Complete Cloud Installation**, and the Adapter should be created successfully. Monitor the **Platform Logs** for any errors.
 

--- a/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
+++ b/docs/2-sensors-deployment/adapters/types/microsoft-entra-id.md
@@ -58,7 +58,7 @@ Leaving `endpoint` empty keeps the commercial endpoints, so existing adapters ne
 
 All three streams (`risk_detections`, `sign_ins`, `audit_logs`) are available in both US Government L4 and L5. Register the application in the government portal (`portal.azure.us`) rather than `portal.azure.com`; the app registration, permissions and admin consent steps below are otherwise the same.
 
-The same `endpoint` option, with the same four values, is used by the [Microsoft Defender](microsoft-defender.md) and [Microsoft 365](microsoft-365.md) adapters.
+The same four values are used by the [Microsoft Defender](microsoft-defender.md) adapter, where `endpoint` is likewise optional, and by the [Microsoft 365](microsoft-365.md) adapter, where it is **required** (that adapter calls the Office 365 Management Activity API, which has a distinct host per deployment including GCC moderate).
 
 ### Azure Event Hub
 


### PR DESCRIPTION
## Why

A customer running a **GCC High** tenant reported that the Entra ID adapter has no way to point at the government API endpoints. It doesn't — that's being added in usp-adapters#315. While confirming it, two documentation gaps turned up:

- The **Defender** adapter has supported an `endpoint` option for a while, and it is **not documented anywhere**. Only the Microsoft 365 adapter page mentions the four names.
- The **Entra ID** page will need the same section once the adapter change lands.

## Change

Adds a "National clouds (GCC High, DoD)" section to both the Entra ID and Defender adapter pages, covering:

- the four deployment names and the identity host + Graph service root each resolves to;
- why it matters — the deployments are network-isolated and an access token issued by one is not valid against another;
- that GCC moderate runs on the worldwide endpoints, so `gcc-gov` behaves identically to `enterprise` and exists to name the deployment explicitly;
- that leaving the option empty keeps existing commercial adapters working unchanged;
- that the app registration is created in `portal.azure.us` rather than `portal.azure.com` for government tenants.

Each page cross-links the other two Microsoft adapters that share the option, `endpoint` is added to the Defender adapter-specific options list, and the Entra ID web UI field list gains the optional field.

For Entra ID it also records that **all three streams** — `risk_detections`, `sign_ins` and `audit_logs` — are available in both US Government L4 and L5. Verified against the per-API national cloud availability tables in Microsoft's Graph v1.0 reference for `list riskDetections`, `list signIns` and `list directoryAudits` (all three: ✅ for Global, US Gov L4 and US Gov L5).

## Merge order

The Defender half is accurate today and can merge whenever. The **Entra ID half describes an option that does not exist yet** — it should land only once usp-adapters#315 is merged and released, otherwise the docs describe a field the deployed adapter ignores. Happy to split it into two PRs if that ordering is awkward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HDc2vjRKAdqk95UxdG2mt
