### PR TITLE
docs(ai-sessions): document PATCH /v1/sessions/{id} (rename)

### DIFF
--- a/docs/9-ai-sessions/api-reference.md
+++ b/docs/9-ai-sessions/api-reference.md
@@ -181,6 +181,48 @@ GET /v1/sessions/{sessionId}
 }
 ```
 
+#### Rename Session
+
+```text
+PATCH /v1/sessions/{sessionId}
+```
+
+Update a session's user-facing name. The name is metadata over the session
+record, so renaming works in every state, `ended` included.
+
+##### Request Body
+
+```json
+{
+  "name": "Ransomware triage - host WIN-DC01"
+}
+```
+
+Leading and trailing whitespace is trimmed. The trimmed name must be non-empty
+and at most 200 characters.
+
+##### Response: 200 OK
+
+Returns the updated session in the same shape as [Get Session](#get-session).
+
+```json
+{
+  "session": {
+    "id": "abc123",
+    "name": "Ransomware triage - host WIN-DC01",
+    "status": "running",
+    "region": "us-central1",
+    "created_at": "2025-01-15T10:30:00Z"
+  }
+}
+```
+
+**Error Responses:**
+
+- `400`: Missing or malformed body, empty name (`name_required`), or a name over 200 characters (`name_too_long`)
+- `403`: The session belongs to another user
+- `404`: No such session
+
 #### Terminate Session
 
 ```text


### PR DESCRIPTION
The user-session API reference lists `GET /v1/sessions/{id}`, both `DELETE`s and the fork endpoints — but not the rename, because the endpoint did not exist. [ai-sessions#121](https://github.com/refractionPOINT/ai-sessions/pull/121) adds it, after the web app had been calling it into a `405 Method Not Allowed` since the session browser shipped ([tracking#4640](https://github.com/refractionPOINT/tracking/issues/4640)).

Documents:

- the request body and that whitespace is trimmed
- the non-empty, ≤200-character rule
- the 200 response (same `SessionResponse` shape as Get Session)
- the `400` / `403` / `404` cases, including the `name_required` and `name_too_long` error codes

Renaming is accepted in every state including `ended`, which is noted — the name is metadata over the session record, not runtime state, so users can curate their history after the fact.

Nothing added to `user-sessions.md`: rename is not a lifecycle concept, so the API reference is the right and sufficient home for it.

Merge after (or alongside) ai-sessions#121 so the docs don't describe an endpoint that isn't deployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Nwe6hcQqvPXU4Zpos7XVL