### PR TITLE
docs(release-notes): publish Endpoint Agent 5.3.7

### DIFF
--- a/docs/10-release-notes/index.md
+++ b/docs/10-release-notes/index.md
@@ -18,6 +18,30 @@ Release notes for LimaCharlie platform components, organized by date.
 
     For discussion and email notification of the same releases, set the [Platform Updates category](https://community.limacharlie.com/c/platform-updates/5) in the community forum to Watching. For service availability rather than releases, subscribe on the [status page](https://status.limacharlie.io/).
 
+## 2026-08-24
+
+### Endpoint Agent 5.3.7
+
+#### New Features
+
+- On Linux, DNS events now report the process that sent the query or received the response, where the kernel supports it (verified on 5.15 and newer); older kernels keep delivering DNS events without a process ID. DNS events on Windows and macOS are unchanged.
+- On Linux, kernel telemetry — file, process, socket, network and DNS — now loads on kernel 5.4, where it previously failed to load entirely. Network isolation still requires a newer kernel.
+
+#### Bug Fixes
+
+- On Linux, fixed all network connection telemetry being lost on kernels that cannot support network isolation; connection tracking now loads independently of isolation.
+- On Linux, fixed the DNS tracker staying on packet capture for the life of the sensor when it started before kernel acquisition was ready, leaving DNS events without a process ID on hosts where the kernel could provide one.
+- On Linux, fixed the process tracker staying on its netlink fallback under the same conditions, which could leave short-lived processes without a path or command line.
+- On Linux, hardened kernel DNS collection against packets whose declared payload length exceeds what they carry; such packets could corrupt the sensor's buffer and caused the DNS events behind them to be discarded.
+- On Linux, fixed sensor diagnostics reporting every kernel telemetry subprogram as inactive when the reporting component had simply not yet queried the kernel; the status is now omitted until it is known.
+- Fixed a possible deadlock when the sensor is stopped by a signal on Linux and macOS.
+
+#### Improvements
+
+- On Linux, sensor diagnostics now report whether DNS events are being attributed to a process.
+
+---
+
 ## 2026-08-20
 
 ### Web App 6.2.0


### PR DESCRIPTION
Publishes the Endpoint Agent 5.3.7 sensor release notes to `docs/10-release-notes/index.md`, dated 2026-08-24.

## What

A new `## 2026-08-24` date group with a `### Endpoint Agent 5.3.7` entry, above the existing `## 2026-08-20` group. Two new features, six bug fixes, one improvement — all Linux kernel-telemetry work: process attribution on kernel DNS events (kernel 5.15+), kernel telemetry now loading on kernel 5.4, connection tracking decoupled from network isolation, the DNS/process trackers no longer sticking on their fallbacks after a slow kernel acquisition, hardening against DNS packets with an oversized declared payload, corrected subprogram status in diagnostics, and a signal-stop deadlock fix on Linux and macOS.

## How

Generated with the repo's own `scripts/publish-release-note.py` rather than hand-edited, so the entry keeps the structure `hooks/release_feed.py` reads:

```
python3 scripts/publish-release-note.py --component sensor --version 5.3.7 --date 2026-08-24 --body "..."
```

The body is the upstream release note verbatim, with its `##` sections demoted to `####` (the script rejects h1–h3 in a body, since those would forge the page's own date/entry structure). No `--url`, matching every other entry on this page.

## Verification

- `scripts/check-release-note-headings.py --baseline scripts/release-note-headings-baseline.json` — 0 new findings (22 pre-existing baselined).
- Parsed the page through `hooks/release_feed.py`: the entry resolves to date `2026-08-24`, title `Endpoint Agent 5.3.7`, component `endpoint-agent`, guid `tag:docs.limacharlie.io,2026-08-24:release/endpoint-agent-5-3-7`, not breaking; guids remain unique across all 79 entries. It goes out on both the everything feed and the Endpoint Agent feed.

`check-release-feeds.py`, `check-list-numbering.py` and markdownlint need a `mkdocs build` / node toolchain that isn't available locally — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
