### PR TITLE
docs(cloud security): the consolidated Code Scanning docs — supersedes #355, #360, #361

### DIFF
--- a/docs/cloud-security/code-scanning.md
+++ b/docs/cloud-security/code-scanning.md
@@ -1,134 +1,593 @@
-# Code Scanning and Pushed Results
+# Code Scanning
 
-Cloud Security can analyze source code in two ways:
+Cloud Security scans the source repositories behind your cloud estate and files
+what it finds into the same risk-ranked worklist as everything else. Vulnerable
+dependencies, credentials committed to git, misconfigured infrastructure-as-code,
+container images, code weaknesses and end-of-life runtimes all arrive as ordinary
+[findings](findings.md) — same shape, same triage verbs, same automation events.
 
-- **Hosted scanning** checks repositories selected by your source-control
-  connection and code-scanning policy.
-- **Pushed results** let a developer or CI pipeline scan a checkout locally, or
-  upload an existing SARIF or CycloneDX document.
+The point is not to add a second security product next to the first one. It is
+that a dependency advisory means something different when the graph can show the
+image it is baked into and the workload running that image, and an
+infrastructure-as-code check means something different when the bucket it
+declares is a bucket you actually own.
 
-Both paths write to the same findings worklist. Use pushed results when source
-code must stay in your environment, when you already run another scanner, or
-when you want scan feedback on every push instead of waiting for a scheduled
-hosted scan.
+!!! info "In the console it's the **Code** page"
+    Repositories, their scan status and their findings live under **Cloud
+    Security → Code**. The same findings also appear on **Risks**, where the
+    **Repository** filter narrows to one repository.
+
+## What it scans
+
+| Lane | What it reads | Finding class |
+|---|---|---|
+| **Dependencies (SCA)** | lockfiles and manifests, resolved to a software bill of materials, matched against the vulnerability database | `vulnerability` |
+| **Malicious packages** | the same dependency set, matched against a malicious-package feed | `malware` |
+| **Secrets** | credentials in the working tree, and — as a separate switch — in the full commit history | `secret` |
+| **Infrastructure as code** | Terraform, CloudFormation, Kubernetes manifests, Helm charts, Dockerfiles | `misconfig` |
+| **Container images** | images the repositories reference, and optionally images your workloads run | `vulnerability` on the image |
+| **Static analysis (SAST)** | source files, against a curated rule pack mapped to CWE | `code_weakness` |
+| **Licenses** | dependency licenses that carry obligation or compatibility risk | `license_risk` |
+| **End-of-life runtimes** | language and base-image runtimes past their published support date | `eol_runtime` |
+
+Dependency findings carry the package, the installed version and the **fixed
+version** where one exists, plus EPSS and KEV so the queue is ordered by
+exploitability rather than by CVSS alone. Secrets found only in history carry a
+different remediation — rotate, because deleting the file does not un-leak the
+credential.
+
+## How scanning works, and what leaves your repository
+
+Scanning code means reading code. The invariant is therefore not "we never read
+it", it is **we never keep it**:
+
+- Each scan runs in an **ephemeral, sandboxed container** in your data
+  region. It shallow-clones the repository into scratch storage, runs the
+  engines, writes one normalized report, and is destroyed.
+- The container runs with **no cloud identity attached**, a read-only root
+  filesystem, restricted egress and a hard 30-minute wall clock. It reaches
+  your source-control host, our object storage and our vulnerability-database
+  mirror, and nothing else.
+- The access token it is handed is **scoped to the single repository being
+  scanned** and expires in an hour.
+- **Only the report leaves.** Findings, the bill of materials and hashes — never
+  file contents, never a diff, never a secret's value.
+- A discovered secret is stored as a **salted hash**. There is no field on a
+  finding capable of holding the credential, which is deliberate: the plaintext
+  never reaches storage, a log, or an event.
+- The connected GitHub App stays **read-only**. Publishing pull-request checks
+  or opening fix pull requests takes a **separate, opt-in App** that you create
+  and install yourself (see [Pull-request checks](#pull-request-checks-and-merge-gating)).
+  The read connection never gains a write permission.
+
+## Turning it on
+
+Two things are required: the App needs to be able to read repository contents,
+and you need a `code_scanning` policy that says which repositories to scan.
+
+Before either, you need:
+
+- the organization subscribed to `ext-cloud-security` — this is a **separate**
+  gate from permissions, and without it every `code` route answers `403`
+  whatever the API key can do;
+- an API key with `cloudsec.get`, plus `cloudsec.set` to write a policy or push
+  a document. See [API Keys](../7-administration/access/api-keys.md);
+- the current [LimaCharlie CLI](cli.md); and
+- Docker, for local scans only. Pushing an existing document does not need it.
+
+Authenticate interactively with `limacharlie auth login`, or set `LC_OID` and
+`LC_API_KEY` in CI.
+
+The policy can also be edited in the console under **Cloud Security → Policies →
+Code scanning**: turn on **Enable code scanning**, add the repository's
+`<owner>/<repository>` under **Include**, and select at least one engine.
+
+### 1. Grant `Contents: Read-only`
+
+The connector's baseline permissions inventory repositories but cannot read them.
+Add the **Contents → Read-only** *Repository* permission to your GitHub App and
+approve the permission change on the organization's installation page — GitHub
+requires an owner to accept a permission increase on an existing installation.
+
+See [GitHub provider setup](provider-setup/github.md) for the full permission
+table, including the two **optional** alert permissions that let LimaCharlie
+ingest GitHub's own Dependabot, code-scanning and secret-scanning alerts and
+deduplicate them against its own findings.
+
+!!! warning "Without it, scans fail with a clear error, not silently"
+    A repository selected for scanning while the App lacks `Contents` reports
+    `github_app_missing_contents_permission` on the code scan status, with the
+    remediation attached. Nothing is scanned and no findings are invented.
+
+### 2. Create the policy
+
+Code scanning is **opt-in**. With no `code_scanning` policy the lane never runs
+— it does not default to scanning everything you connected.
+
+```yaml
+# code-policy.yaml
+policy_type: code_scanning
+enabled: true
+repos:
+  include: ["acme/api-*", "acme/payments"]
+  exclude: ["acme/api-archive"]
+scanners:
+  sca: true
+  secrets: true
+  secrets_history: true
+  iac: true
+  sast: true
+  images: true
+  licenses: true
+severity_floor: LOW          # LOW means no floor: record everything
+schedule: daily
+image_sources: ["dockerfile"]
+autofix_registry_access: true
+```
+
+```bash
+limacharlie hive set --hive-name cloudsec_policy --key code-scanning \
+    --input-file code-policy.yaml --enabled
+```
+
+| Field | Meaning |
+|---|---|
+| `enabled` | **Required.** `false` parks the policy — kept and editable, but nothing is scanned. |
+| `repos.include` | Globs matched case-insensitively against `owner/name` and the bare `name`. **Empty means every repository the provider can see** — write it explicitly unless that is genuinely what you want. |
+| `repos.exclude` | Always beats `include`. |
+| `scanners` | Each engine is an explicit boolean; **at least one must be true**. There is no implicit "all on", and no engine implies another. `sast` and `secrets_history` are off unless you turn them on. |
+| `severity_floor` | `CRITICAL`…`HIGH`…`MEDIUM`. Findings below the floor are **not recorded at all** — see the note below. `LOW`, `INFO` and an empty value all mean no floor. |
+| `schedule` | `daily` (the default), `weekly`, or `manual`. |
+| `sast_ruleset` | Which static-analysis pack runs. Leave it empty for the curated default. |
+| `image_sources` | A **list**. Where the image lane looks: `dockerfile` (the default) or `workloads`. `registries` is accepted but does nothing — see [Not yet available](#not-yet-available). |
+| `autofix_registry_access` | Whether dependency AutoFix may make read-only package-registry metadata requests. Omitted means `true`; set it to `false` to keep AutoFix on the ordinary restricted scan lane. See [Dependency AutoFix](#dependency-autofix-pull-requests). |
+| `pr_checks`, `pr_comments`, `gating.fail_on` | The pull-request lane — see [below](#pull-request-checks-and-merge-gating). |
+
+!!! warning "`severity_floor` drops, it does not hide"
+    A finding under the floor is never synthesized, so it is absent rather than
+    filtered — it has no row, no history and no triage state. Lower the floor
+    later and it comes back as a **new** finding, with `first_seen` set to the
+    scan that recreated it, not to when the code was first vulnerable. Raising
+    the floor closes what is already open with `closed_reason:
+    below_severity_floor`.
+
+    The ladder starts at `MEDIUM`: `LOW`, `INFO` and an empty value are all "no
+    floor" and drop nothing. The floor composes across records as the **lowest**
+    of the records that select a repository, so an added record can widen
+    coverage but never narrow it.
+
+    If you want everything recorded and only your *view* narrowed, leave the
+    floor empty and filter the worklist by severity instead.
+
+An org may hold **several** `code_scanning` records and they compose, so you can
+scan a small set of sensitive repositories daily with every engine on, and the
+rest weekly with a narrower set. Composition takes the union of the enabled
+engines, the lowest `severity_floor` and the most frequent schedule, so a record
+can generally add coverage. `autofix_registry_access` is deliberately stricter:
+an explicit `false` in **any** matching record wins over `true` or an omitted
+field. This prevents a broader policy from silently widening registry access
+for a repository whose narrower policy disabled it.
+
+!!! note "The glob dialect is the shared Cloud Security one"
+    `*`, `?`, `[…]`, `{a,b}`, and a leading `!` for negation *within a list*.
+    Write negations in `include`; a `!` in `exclude` reads as "exclude
+    everything that is not this", which cancels your include list.
+
+`secrets_history` is its own switch rather than a modifier on `secrets` because
+it is the only thing that forces a full clone — on a large monorepo that is the
+difference between a fast scan and one that hits the clone cap.
+
+`image_sources: ["registries"]` is accepted and **not enumerated**: a policy
+asking for it gets the referenced images only. Registry enumeration is not
+implemented.
+
+### Force a rescan
+
+Bump the provider record's `sync_now` field to a new value, or ask for one
+repository directly:
+
+```bash
+limacharlie cloudsec code rescan acme/payments
+```
+
+The next pass picks up the repositories the policy selects, respecting the
+per-repository debounce.
+
+## Reading the results
 
 !!! note "CLI version"
-    The `cloudsec code` commands used on this page were added after CLI 5.6.2.
-    They require the first `limacharlie` release newer than 5.6.2. Check your
-    installation before using the examples:
+    The `cloudsec code` commands were added **after CLI 5.6.2** and require the
+    first `limacharlie` release newer than it. An older CLI has no `code`
+    command group at all and answers `No such command`, so upgrading is not
+    enough on its own until that release is out. Check with:
 
     ```bash
     limacharlie --version
     limacharlie cloudsec code scan --help
     ```
 
-## Before you begin
-
-You need:
-
-- a LimaCharlie organization subscribed to `ext-cloud-security`;
-- an enabled code-scanning policy that selects the repository;
-- an API key with `cloudsec.get` and `cloudsec.set`;
-- the current [LimaCharlie CLI](cli.md); and
-- Docker for local scans. Uploading an existing document does not require
-  Docker.
-
-Authenticate interactively with `limacharlie auth login`, or set `LC_OID` and
-`LC_API_KEY` in CI. Create and scope organization API keys as described in
-[API Keys](../7-administration/access/api-keys.md).
-
-To configure the required policy in the console, open **Cloud Security →
-Policies → Code scanning**, turn on **Enable code scanning**, and add the
-repository's `<owner>/<repository>` name under **Include**. Select at least one
-hosted scanning engine, then save the policy. The policy can select a repository
-even when it does not come from a connected source-control organization.
-
-Repository names use the `<owner>/<repository>` form, for example `acme/api`.
-If a checkout has a hosted Git remote, the local scan command can infer this
-name and the current commit. Pass `--repo` and `--commit` explicitly when the
-remote does not identify them unambiguously.
-
-## Scan a local checkout
-
-From the repository root, scan and send the result to Cloud Security:
-
 ```bash
-limacharlie --output yaml cloudsec code scan . \
-  --repo acme/api \
-  --commit "$(git rev-parse HEAD)" \
-  --ingest
+# Repositories, their scan state and open-finding rollups.
+limacharlie cloudsec code repos
+limacharlie cloudsec code repos --with-findings --all
+limacharlie cloudsec code repos -q payments
+
+# Has the lane run, and what happened last time?
+limacharlie cloudsec code status
+
+# The software bill of materials for one repository.
+limacharlie cloudsec code sbom --repo acme/payments -o payments-sbom.json.gz
 ```
 
-The default scan covers software dependencies, infrastructure as code, and
-licenses. To select supported scanners explicitly, pass a comma-separated
-list:
+`code repos` returns a `repo` key (`<owner>/<name>`) that the other commands and
+the `--repo` findings filter take. `code status` is the authoritative answer to
+"did it run" — an empty `code` list means the lane has **never** run in this org,
+which is not the same as the lane being off.
+
+The findings themselves are ordinary findings:
 
 ```bash
-limacharlie --output yaml cloudsec code scan . \
-  --repo acme/api \
-  --scanners sca,iac,sast,licenses,images \
-  --ingest
+limacharlie cloudsec finding list --repo acme/payments --class vulnerability
+limacharlie cloudsec finding list --class secret --severity CRITICAL
+
+# Which producer found it: the scan LimaCharlie ran, or a document you pushed.
+limacharlie cloudsec finding list --repo acme/payments --source hosted
+limacharlie cloudsec finding list --repo acme/payments --source ingest
 ```
 
-The CLI runs the published LimaCharlie scanner container. The checkout is
-mounted read-only. Nothing from the checkout is sent to LimaCharlie unless you
-add `--ingest`; in that case, only the generated report is uploaded.
+Each finding also carries the producing scanner on its `code` evidence as
+`detected_via` (`lc-code-scanner` for the hosted scan, `lc-code-scanner-byo` for
+a pushed local scan, `sarif-ingest`/`cyclonedx-ingest` for a converted
+document). Filter with `--source` rather than folding `detected_via` yourself:
+`--source` is applied inside the query, so the counts describe the estate, while
+folding a page at a time makes every count a count of one page. It takes
+`hosted`, `ingest`, `other` (the source control's own detectors), `none` (no
+code provenance at all) or `both`.
 
-To inspect or archive a report without uploading it, write it to a file:
+A repository row reports its own provenance the same way, as `hosted`, `ingest`
+or `both`.
+
+See the [CLI reference](cli.md) and the [API reference](api-reference.md) for the
+full surface.
+
+!!! note "Reading `scan_status`"
+    Each repository carries a `scan_status` of `scanned`, `partial` or `unknown`
+    with a machine-readable `scan_status_reason`. `unknown` with
+    `repo_not_scanned` means nothing has scanned it yet — check that it is
+    inside an enabled policy's include list, then let the next pass reach it.
+    `partial` means a cap or an unavailable engine truncated the scan, so the
+    finding list is a **lower bound** and must never be read as clean.
+
+    `code status` remains the authoritative answer about the *run* itself;
+    follow it when the two disagree.
+
+    An older `repo_scan_props_not_projected` reason was a bug, since fixed. If
+    you still see that spelling you are looking at a stale record.
+
+### The bill of materials
+
+Every scanned repository gets a CycloneDX SBOM, produced during the scan and
+retrievable on request through a short-lived signed link. It is **not** stored as
+inventory rows — a 2,000-package repository must not add 2,000 rows to your
+estate — so the graph carries the vulnerability matches while the SBOM stays a
+downloadable artifact.
+
+A repository that has not been scanned yet reports `sbom_not_generated_yet`
+rather than an empty document.
+
+## Rescanning on every push
+
+A daily schedule means a fix merged at 09:00 is still an open finding at 17:00.
+A push webhook closes that gap: one repository, rescanned within minutes,
+without waiting for or restarting the estate-wide pass.
+
+```text
+GitHub App webhook ──push──▶ LimaCharlie webhook adapter ──▶ D&R rule ──▶ rescan
+```
+
+1. **Create a webhook adapter** in your organization — a `cloud_sensor` record
+   with `sensor_type: webhook`. The secret in the URL is what authenticates the
+   hook, so make it long and random. See the
+   [webhook adapter tutorial](../2-sensors-deployment/adapters/tutorials/webhook-adapter.md)
+   for the record shape; the code lane's convention is the hostname
+   `github-code-webhook`.
+
+   ```bash
+   OID=<your organization id>
+   # An installation key for the org: `limacharlie --oid "$OID" installation-key list`,
+   # or Sensors -> Installation Keys in the web app.
+   INSTALLATION_KEY=<an installation key for that org>
+   SECRET=$(python3 -c "import secrets;print(secrets.token_urlsafe(32))")
+   cat > hook.json <<JSON
+   {
+     "sensor_type": "webhook",
+     "webhook": {
+       "secret": "$SECRET",
+       "client_options": {
+         "hostname": "github-code-webhook",
+         "identity": {"oid": "$OID", "installation_key": "$INSTALLATION_KEY"},
+         "platform": "json",
+         "sensor_seed_key": "github-code-webhook"
+       }
+     }
+   }
+   JSON
+   limacharlie hive set --hive-name cloud_sensor --key github-code-webhook \
+       --input-file hook.json --enabled
+   ```
+
+   The hook URL is `https://<your org's hook domain>/<oid>/github-code-webhook/<secret>`;
+   the domain comes from `GET /orgs/{oid}/urls`.
+
+2. **Point the GitHub App's webhook at that URL**, `push` events only.
+
+3. **Install the D&R rule.** It ships as a recipe rather than being installed for
+   you, so you can read what it does and fork it. The Cloud Security **Code**
+   page offers to write it under the name `cloudsec-code-push-rescan`; the
+   equivalent YAML is:
+
+   ```yaml
+   detect:
+     event: json
+     op: and
+     rules:
+       - op: is
+         path: routing/hostname
+         value: github-code-webhook
+       - op: exists
+         path: event/head_commit/id
+       - op: exists
+         path: event/repository/full_name
+       - op: starts with
+         path: event/ref
+         value: refs/heads/
+       - op: is
+         path: event/deleted
+         value: false
+   respond:
+     - action: extension request
+       extension name: ext-cloud-security
+       extension action: code_scan_now
+       extension request:
+         repo: '{{ .event.repository.full_name }}'
+         ref: '{{ .event.ref }}'
+   ```
+
+Pushes are coalesced: the first push arms a 10-minute window, everything inside
+it collapses into one scan of the head of the burst. **Every gate the schedule
+applies still applies** — the repository must be in your collected inventory,
+not archived, and selected by an enabled policy — and only the default branch is
+scanned, so a push to a feature branch is declined with a reason rather than
+scanned silently.
+
+A push-triggered scan does not update the estate-wide `code status` row. "Did my
+push get scanned" is answered by that repository's row in
+`limacharlie cloudsec code repos`.
+
+## Pull-request checks and merge gating
+
+A daily scan says what a repository *contains*. A pull-request check says what a
+change *introduces*, on the pull request, before the merge.
+
+This is the one part of the lane that writes to your organization, so it uses a
+credential nothing else here has: a **separate, opt-in App that you create**.
+The collection App is read-only forever and does not fall back into this role —
+without the write App the lane refuses with `write_app_not_configured`.
+
+### Create the "Code Actions" App
+
+Post this manifest to
+`https://github.com/organizations/<org>/settings/apps/new?state=lc-code-actions`
+as a form field named `manifest`, or create the App by hand with exactly these
+permissions and events:
+
+```json
+{
+  "name": "LimaCharlie Code Actions",
+  "url": "https://limacharlie.io",
+  "public": false,
+  "default_permissions": {
+    "checks": "write",
+    "pull_requests": "write",
+    "contents": "write",
+    "metadata": "read"
+  },
+  "default_events": ["pull_request"]
+}
+```
+
+That permission set is the **union** of what pull-request checks and
+[AutoFix](#dependency-autofix-pull-requests) need, so one App serves both. The
+App's permissions are not what any single call holds: the check-run writer asks
+for `checks + pull_requests + metadata` and deliberately **not** `contents`, so
+publishing a status can never carry the ability to rewrite your source; the
+AutoFix writer asks for `contents + pull_requests + metadata` and deliberately
+not `checks`.
+
+If you want **checks only**, use `"contents": "read"` (or drop it): everything
+below works and AutoFix refuses with `write_app_lacks_contents`, naming the one
+checkbox to add. If you want **AutoFix only**, `contents: write` +
+`pull_requests: write` is enough and you simply leave `pr_checks` off.
+
+Install it on the repositories you want checked — *Only select repositories* is
+the right answer for a trial — and note the App ID and the installation ID.
+
+### Wire it up
 
 ```bash
-limacharlie cloudsec code scan . \
-  --repo acme/api \
-  -o lc-code-report.json.gz
+# 1. The private key, as its own secret — never the read connection's.
+limacharlie secret set --key github-code-actions-key \
+    --value "$(python3 -c 'import json;print(json.dumps({"private_key":open("code-actions.private-key.pem").read()}))')" \
+    --enabled
 ```
 
-The output is a gzipped LimaCharlie `report/v1` document. A scan must use either
-`--ingest`, `-o`, or both, so a completed scan never discards its only copy of
-the report.
+```yaml
+# 2. Three more fields on the provider record, alongside the read connection's,
+#    which are left exactly as they are.
+provider_type: github
+github_org: "acme"
+github_app_id: "1234567"
+github_installation_id: "89012345"
+credentials: hive://secret/github-app-key
+github_actions_app_id: "7654321"
+github_actions_installation_id: "54321098"
+actions_credentials: hive://secret/github-code-actions-key
+```
 
-!!! info "Secret scanning uses the hosted lane"
-    Local scans do not accept the `secrets` or `secrets_history` scanners.
-    Secret findings require identity data held by the hosted service to merge
-    safely. Use hosted scanning for credentials and secret history.
+The record is refused if the write App is the same App, or points at the same
+secret, as the read connection.
 
-## Push an existing scanner result
+```yaml
+# 3. Turn it on in the code_scanning policy.
+pr_checks: true
+pr_comments: true
+gating:
+  fail_on: HIGH
+```
 
-Use `code ingest` when another tool already produced the result. The command
-accepts:
+Finally, add `pull_request` to the webhook you created above and install the
+second recipe rule, `cloudsec-code-pr-check`. It is the same shape as the push
+rule: it matches `event/action` in `opened`, `synchronize` and `reopened` and
+forwards `repo`, `pr`, `base_sha`, `head_sha` and `action` to the
+`code_pr_check` extension action. Everything else on a pull request — labels,
+assignments, reviews, closing — leaves the diff untouched and is refused, so a
+busy repository's chatter does not become scan traffic.
 
-- `sarif` for a SARIF results document;
-- `cyclonedx` for a CycloneDX bill of materials; or
-- `report` for a LimaCharlie `report/v1` document produced by `code scan`.
+### What the check says
 
-For example, push a SARIF file from the current commit:
+Both commits are scanned and the two results are diffed by **identity**, never by
+line number, so moving a finding within a file does not report it as introduced.
+
+| Outcome | Conclusion |
+|---|---|
+| nothing introduced, both scans complete | `success` — the only green |
+| findings introduced, none at or above the gate | `neutral` — it reports without blocking, and does not claim the pull request is clean |
+| something at or above `gating.fail_on` | `failure` |
+| either scan hit a limit | never `success` — a truncated scan has not looked everywhere |
+| the scan could not run | `neutral`, titled "could not complete" — our outage does not block your merge |
+
+`gating.fail_on` is `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` or `NONE`, and **absent
+means NONE**: turning `pr_checks` on never silently starts failing merges. `INFO`
+is deliberately not a value.
+
+The check carries a summary with the full counts and up to 50 annotations
+(GitHub's own per-request cap). The summary always states the full count, so a
+pull request introducing two hundred findings is never described by the fifty
+that fit, and only a finding that would *block* is annotated as a failure.
+
+With `pr_comments: true` you also get **one** comment, edited in place on every
+later push, never a second one.
+
+## Dependency AutoFix pull requests
+
+For a dependency finding with a published fixed version, the lane can open the
+pull request that raises it. It needs the same write App as above (with
+`contents: write`) and no extra policy switch: an enabled `code_scanning` record
+selecting the repository is the scope, and the write App being present is the
+opt-in.
+
+The edit happens **inside the sandbox**, from the finding LimaCharlie's own scan
+produced — you cannot ask for an arbitrary package to be raised to an arbitrary
+string. Three resolvable findings are still refused, each with its reason: a
+package flagged **malicious** (the remediation is removal and credential
+rotation, not an upgrade), a vulnerability with **no published fixed version**,
+and an ecosystem with no editor.
+
+**Be aware of the lockfile behavior, because it decides whether the pull
+request is complete:**
+
+| Ecosystem | What is edited | Is that the whole fix? |
+|---|---|---|
+| **maven** | `pom.xml` `<version>`, or the property it references | **Yes** — there is no lockfile |
+| **pip** | the pin in `requirements.txt` | **Yes** — there is no lockfile. A `--hash`-pinned requirement, or a lock file from another Python tool, is refused with the reason |
+| **npm** | `package.json`, range operator preserved; with registry metadata access, the corresponding `package-lock.json` entry | **Yes by default.** AutoFix uses the registry's published version, resolved tarball URL and integrity metadata to rewrite the lockfile entry alongside the manifest. With `autofix_registry_access: false`, it edits the manifest only and marks the lockfile stale |
+| **go** | the `require` line in `go.mod` | **Yes when there is no `go.sum`.** When one exists, it carries a hash of the module zip that cannot be computed without downloading it, so the pull request marks that lockfile stale |
+
+The sandbox carries no package manager, deliberately: running one would execute
+resolution code — and, for npm, lifecycle scripts — from the dependency graph
+under suspicion. Default-enabled npm AutoFix instead makes one read-only
+registry metadata request and rewrites the existing lockfile entry directly; it
+does not install or execute the package. The registry-enabled AutoFix job uses a
+separate, tightly scoped egress lane from ordinary scans.
+
+Set `autofix_registry_access: false` when even that metadata request is not
+acceptable. The npm pull request then raises `package.json` only and carries an
+unmissable stale-lockfile warning with
+`npm install --package-lock-only --ignore-scripts`. Go AutoFix remains
+manifest-only by design; when the repository has a `go.sum`, its pull request
+carries the corresponding `go mod tidy` warning. Merging either stale-lockfile
+pull request believing the lock moved would fix nothing, which is why the
+warning appears on the pull request rather than in a footnote.
+
+Nothing is written to your findings when the branch is pushed. A branch is a
+proposal: the finding closes when the merge lands and the next scan of the
+default branch no longer sees the package.
+
+There is one open AutoFix pull request per (repository, package) — the branch
+name is deterministic, so the open pull request *is* the open fix.
+
+Ask for one by finding id:
 
 ```bash
-limacharlie --output yaml cloudsec code ingest \
-  --repo acme/api \
-  --source sarif \
-  --file trivy.sarif \
-  --commit "$(git rev-parse HEAD)" \
-  --ref "$(git branch --show-current)"
+limacharlie cloudsec code autofix fnd_2290bab86c1b4d0374d1e2666f64aeca
 ```
 
-Or push an existing CycloneDX SBOM:
+The call **accepts and returns**; the clone, the edit and the pull request happen
+minutes later in the sandbox, so `accepted` does not mean a pull request exists —
+the pull request is the result. Every refusal above is a quiet no-op on this call
+for the same reason: it has already answered by the time the work runs. If no
+pull request appears, the reason is on the `cloudsec.code_autofix_refused`
+operational event.
+
+## Bring your own scanner
+
+Not everything worth knowing about a repository comes from the hosted scan. You
+may already run a scanner in CI, use an analyzer for a language the hosted lane
+does not cover, or want results for a repository before you connect the
+organization. So the lane takes results **you** produced:
 
 ```bash
-limacharlie --output yaml cloudsec code ingest \
-  --repo acme/api \
-  --source cyclonedx \
-  --file sbom.cdx.json \
-  --commit "$(git rev-parse HEAD)"
+limacharlie cloudsec code ingest --repo acme/payments --source sarif -f results.sarif
 ```
 
-Files ending in `.gz` stay compressed in transit. A document can be up to 20
-MiB; narrow the scan or split it into separate documents if it exceeds that
-limit.
+`--source` is `sarif` (SARIF 2.1.0, which nearly every scanner can emit),
+`cyclonedx` (a bill of materials, with or without its `vulnerabilities`
+section), or `report` — the LimaCharlie scanner's own document, which is what
+`code scan` below produces.
 
-A pushed repository does not need to come from a connected source-control
-organization. The push creates the repository entry with only the facts the
-document supplies. In that case, also pass `--default-branch` because no
-provider connection can supply it:
+### It is the same finding, not a copy of it
+
+A pushed finding is **deduplicated against the hosted scan by identity**. A
+dependency vulnerability is identified by its advisory, the package and the
+manifest that declares it — never by a line number — so when both lanes see
+`CVE-2021-23337` in `lodash` in `package-lock.json`, there is one finding, whose
+age and triage state survive. Pushing the same document twice writes nothing at
+all.
+
+Three rules follow from that, and they are worth knowing before you wire up a
+pipeline:
+
+- **A pushed document can only close findings it previously reported.** Fix a
+  dependency, push again, and that finding closes. It can never close something
+  the hosted scanner found — your dependency scan says nothing about the secrets
+  and misconfigurations the sandbox looked for. The reverse is also true: a
+  hosted scan will not close what you pushed.
+- **What the format cannot carry is reported, not guessed.** The response's
+  `notes` names it. `iac_resource_ref_absent`, for example, means the document
+  identified an infrastructure finding by file alone, because SARIF has no field
+  for the resource address — so those findings do not dedupe against the hosted
+  scan's, which identify the resource.
+- **Credential findings in a third-party document are refused**
+  (`secrets_not_ingestable`). A secret is identified here by a keyed digest of
+  the matched value, which no foreign format carries; what such a document *does*
+  routinely carry is the credential itself, in a snippet, and that is not
+  something to accept. Use the hosted lane for secrets.
+
+The repository does **not** have to come from a connected source-control
+organization. A push for a repository nothing collects creates the repository
+entry from the facts the document supplies — which is what makes this the path
+for code you scan but do not connect. In that case also pass
+`--default-branch`, because no provider connection can state it:
 
 ```bash
 limacharlie --output yaml cloudsec code ingest \
@@ -139,22 +598,54 @@ limacharlie --output yaml cloudsec code ingest \
   --commit "$COMMIT_SHA"
 ```
 
-The repository must still match an enabled code-scanning policy and counts
-toward the same repository quota as a connected repository.
+It must still match an enabled `code_scanning` policy — the same switch and the
+same globs the hosted lane uses — and it counts against the same repository
+quota as a connected one.
 
-## Run on every GitHub push
+A document can be up to **20 MiB**; files ending in `.gz` stay compressed in
+transit. Narrow the scan or split independent results into separate documents if
+you exceed it.
 
-Store the organization UUID as the `LC_OID` Actions secret and a least-privilege
-organization API key as `LC_API_KEY`. Then add
-`.github/workflows/limacharlie-code-scan.yml` to the repository:
+### Scanning locally
+
+`code scan` runs the LimaCharlie scanner over a checkout on your own machine —
+or in your CI — and, with `--ingest`, pushes the result:
+
+```bash
+# Look at the report without sending anything.
+limacharlie cloudsec code scan ~/src/payments -o report.json.gz
+
+# Scan and push.
+limacharlie cloudsec code scan ~/src/payments --repo acme/payments --ingest
+```
+
+Nothing about the checkout leaves the machine except the report. The scanner runs
+in a container by default (which carries the pinned engines and their databases);
+`--binary` runs an already-installed agent instead, which is what a CI image that
+ships one should do. `--scanners` defaults to `sca,iac,licenses`; `sast` and
+`images` also run locally.
+
+A scan must use `--ingest`, `-o`, or both, so a completed scan never discards its
+only copy of the report. The `-o` output is a gzipped LimaCharlie `report/v1`
+document, which is also what `code ingest --source report` takes.
+
+**Secret scanning cannot run locally**, and asking for it is an error rather than
+a quietly narrower scan: `--scanners sca,iac,secrets` fails. A secret's identity
+here is a digest keyed by a deployment-side value this command does not have, so
+locally-found credentials could not deduplicate against the hosted scan's — and
+the ingest refuses them for the same reason. Use the hosted lane for secrets.
+
+### A GitHub Actions recipe
+
+This runs on every push to the default branch, scans the checkout, and pushes the
+report. It uses no LimaCharlie CI minutes: the work happens in your runner.
 
 ```yaml
-name: LimaCharlie code scan
+name: Cloud Security code scan
 
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -163,77 +654,171 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
         with:
-          python-version: "3.12"
+          # The scanner reads the working tree. Full history is only needed if you
+          # scan git history for secrets, which the local scan does not do.
+          fetch-depth: 1
 
-      - name: Install LimaCharlie CLI
-        run: pip install --upgrade limacharlie
+      - name: Install the LimaCharlie CLI
+        run: pipx install limacharlie
 
-      - name: Scan and push results
+      - name: Scan and push
         env:
-          LC_API_KEY: ${{ secrets.LC_API_KEY }}
+          # A LimaCharlie API key with `cloudsec.set`, stored as a repository secret.
           LC_OID: ${{ secrets.LC_OID }}
+          LC_API_KEY: ${{ secrets.LC_API_KEY }}
         run: |
-          limacharlie --output yaml cloudsec code scan . \
+          limacharlie auth login --oid "$LC_OID" --api-key "$LC_API_KEY"
+          limacharlie cloudsec code scan . \
             --repo "$GITHUB_REPOSITORY" \
             --commit "$GITHUB_SHA" \
-            --ref "$GITHUB_REF" \
             --ingest
 ```
 
-The workflow grants GitHub only read access to repository contents. The
-LimaCharlie key controls the upload and should contain only the permissions
-listed in [Before you begin](#before-you-begin).
-
-If your existing scanner produces SARIF, replace the final step with that
-scanner followed by `cloudsec code ingest`. For example:
+To push results from a scanner you already run, replace the last step with an
+`ingest` of its output — most tools have a SARIF formatter:
 
 ```yaml
-      - name: Push SARIF results
-        env:
-          LC_API_KEY: ${{ secrets.LC_API_KEY }}
-          LC_OID: ${{ secrets.LC_OID }}
+      - name: Push existing results
         run: |
-          limacharlie --output yaml cloudsec code ingest \
+          limacharlie cloudsec code ingest \
             --repo "$GITHUB_REPOSITORY" \
             --source sarif \
-            --file results.sarif \
             --commit "$GITHUB_SHA" \
-            --ref "$GITHUB_REF"
+            -f results.sarif
 ```
 
-## Review the result
+`$GITHUB_REPOSITORY` is already `<owner>/<name>`, which is exactly the repository
+key the lane uses.
 
-Confirm that Cloud Security recorded the repository:
+## In your IDE
+
+The code lane is exposed to AI assistants over the Model Context Protocol, so a
+session in your editor can read repository findings and scan the working copy
+before anything is pushed. See [Cloud Security in your IDE](mcp.md).
+
+## The joins that make it worth doing
+
+Code findings are not a separate island. The repository is a node in the
+[security graph](graph.md), container images are nodes keyed by digest, and two
+edges connect them to the running estate: **`built-from`** (image → the
+repository that produced it) and **`runs-image`** (workload → the image it runs).
+
+That gives you questions no repository scanner can answer on its own, shipped in
+the [query pack](graph.md):
+
+| Query | Question |
+|---|---|
+| `vulnerable_packages_on_exposed_workloads` | which advisories are in images that internet-facing workloads actually run |
+| `images_with_kev_on_exposed_workloads` | the same, narrowed to known-exploited vulnerabilities |
+| `secrets_in_repos_with_cloud_oidc` | which federated pipeline identities can assume a cloud identity — the blast radius of a leaked repository credential |
+| `eol_runtimes_in_production_images` | which end-of-life runtimes reach a running workload |
+
+!!! note "Read an empty result carefully"
+    Three of the four need the **`runs-image`** link, and that link only covers
+    the image sources your policy's `image_sources` enables — `dockerfile` (the
+    default) links images a scanned repository declares, `workloads` links the
+    digest-pinned images your cloud inventory reports a workload running. So an
+    empty result can mean "that link was not collected here" rather than
+    "nothing is affected". Each query's `description` says exactly which.
+
+    `secrets_in_repos_with_cloud_oidc` anchors on every **federated** principal,
+    not only CI ones, so a directory federation into your cloud appears
+    alongside pipeline trusts — read the principal's subject to tell them apart.
+
+## Compliance
+
+Two frameworks are graded off the code lane, alongside the cloud benchmarks:
+
+- **`owasp-top10`** — OWASP Top 10:2021, mapped by CWE. All ten categories are
+  assessable once static analysis has run over at least one repository; with
+  `sast` off, the five categories that only static analysis can evidence report
+  **NOT_ASSESSED** with their mapping already written down.
+- **`cis-supply-chain`** — the CIS Software Supply Chain Security Guide's
+  *Source Code* and *Dependencies* sections in full (60 controls), 10 of which
+  have a detector. Every other control says in its own words *why* it is not
+  assessed.
 
 ```bash
-limacharlie --output yaml cloudsec code repos -q acme/api
+limacharlie cloudsec compliance report --framework owasp-top10
+limacharlie cloudsec compliance report --framework cis-supply-chain
 ```
 
-Then list its open pushed findings:
+**"NOT_ASSESSED — reason" is a statement, not a gap in the report.** It means
+this build has no detector for that control, or the signal a detector needs was
+never produced, and the alternative — reporting PASS because no finding exists —
+would be a false clean bill. Every such control carries its own reason, so the
+list doubles as a map of what the framework asks for and what is measured.
 
-```bash
-limacharlie --output yaml cloudsec finding list \
-  --repo acme/api \
-  --source ingest \
-  --status open
-```
+Both frameworks apply only when a source-code provider is connected; on an
+estate without one they report **NOT_APPLICABLE** rather than a vacuous pass. And
+every control that grades an *outcome* ("are there secrets in the source?")
+additionally waits for the lane to have **completed a scan pass**: a connected
+provider is not the same fact as a scanned repository. The six controls that
+depend on static analysis additionally wait for a static-analysis pass to have
+actually run — `sast` is off by default, and an empty `code_weakness` list from
+an engine that never started is not evidence of anything.
 
-Repository rows identify their source as `ingest`, `hosted`, or `both`.
-Pushed findings use the same triage, ownership, Cases, Outputs, and automation
-as hosted findings.
+Because most of `cis-supply-chain` is not auto-assessable, its report carries the
+low-coverage qualifier — read the coverage figure next to the score, never the
+score alone. See [Compliance](compliance.md) for how scoring and coverage work.
 
-Pushing the same document again is idempotent. When a newer document omits a
-finding previously reported by that pushed source, Cloud Security closes that
-finding. A pushed document never closes a finding owned by the hosted scanner.
-The ingest response also contains `notes` for results it could not safely
-import; for example, credential findings from third-party documents are
-deliberately skipped.
+!!! warning "These controls grade the outcome, not the configuration"
+    Several controls in both frameworks ask whether a *scanner is in place*.
+    What the finding store can answer is whether there are *findings*. The two
+    differ exactly where it matters: a repository your policy **excludes**
+    produces no findings and therefore cannot fail those controls. Read the
+    score next to the Code page's scan coverage. Each affected control says so
+    in its description.
+
+## Limits
+
+Free-tier organizations are capped on how much of an estate the lane covers:
+
+| Free-tier limit | Value |
+|---|---|
+| Repositories scanned | the first **10** by name, **per connected source-control organization** |
+| Container images scanned | the **5** most referenced, **per organization** |
+
+Held-back repositories and images are reported with a machine-readable reason
+(`free_tier_code_repos_cap`, `free_tier_code_images_cap`) rather than silently
+omitted, and the covered set is stable — it does not rotate, so you do not watch
+the same findings open and close.
+
+Everything else is a scale guard rather than a tier:
+
+| Limit | Value |
+|---|---|
+| Scan wall clock | 30 minutes per repository |
+| Concurrent scans per organization | 4 |
+| Repositories scanned per day, per connection | 500 |
+| Container images per pass | 50 |
+| Per-file size read by static analysis | 1 MiB (larger files are counted, not opened) |
+| Clone size | 2 GB |
+| Report size | 20 MiB compressed |
+| Pull-request writes per day, per connection | 500 |
+| AutoFix pull requests per day, per connection | 20 |
+
+When a cap truncates a scan, the code scan status carries what was hit. A partial
+scan **never closes findings** it did not have the chance to re-observe.
+
+## Not yet available
+
+Named here so their absence is not mistaken for a clean result:
+
+- **Custom static-analysis rule packs.** `sast_ruleset: custom:<ref>` is accepted
+  by the policy validator and **refused by the scanner**. The refusal is scoped
+  to static analysis alone: the repository reports `scan_status: partial` with
+  `sast_ruleset_unresolved`, and its dependency, secret, infrastructure and
+  licence findings are complete and still close normally. Clear the value to use
+  the curated pack.
+- **Container-registry enumeration** (`image_sources: ["registries"]`). The value
+  is accepted by the policy validator, but nothing enumerates a registry — this
+  is the expensive, unbounded half of the image lane and it is not built.
+- **Source-control platforms other than GitHub.** The scanner and the storage
+  model are source-control-agnostic by design, but GitHub is the only connector
+  today.
 
 ## Troubleshooting
 
@@ -245,7 +830,19 @@ deliberately skipped.
 | The repository is not recorded | Confirm that the repository matches an enabled code-scanning policy and is within the organization's repository quota. |
 | The document is rejected as too large | Keep it below 20 MiB by narrowing the scan or splitting independent results into separate documents. |
 | Secret results do not appear | Use hosted secret scanning; local and third-party secret findings are intentionally not ingested. |
-| Hosted scanning reports `github_app_missing_contents_permission` | The connected GitHub App cannot read repository contents, so nothing could be cloned. Add **Repository → Contents: Read-only** to the App, then approve the permission request on the organization's installation page: GitHub requires an owner to accept a permission increase on an existing installation, so editing the App alone is not enough. Nothing was scanned and no existing finding changed. |
+| Hosted scanning reports `github_app_missing_contents_permission` | The connected GitHub App cannot read repository contents, so nothing could be cloned. Add **Repository → Contents: Read-only** to the App, then approve the permission request on the organization's installation page: GitHub requires an owner to accept a permission increase on an existing installation, so editing the App alone is not enough. Nothing was cloned or code-scanned, and no existing finding changed — the provider's own sweep is unaffected. |
 | A repository reports `scan_status: partial` with `sast_ruleset_unresolved` | The code-scanning policy names a static-analysis rule pack that is not available, so static analysis did not run on that repository. Clear the custom `sast_ruleset` value to use the built-in pack. Nothing else about the repository is affected: its dependency, infrastructure, license and secret findings are complete and still close normally. |
 | A repository reports `scan_status: unknown` with `repo_not_scanned` | Nothing has scanned it yet. Confirm it is inside an enabled code-scanning policy's include list, then allow the next scheduled pass to reach it. `limacharlie cloudsec code status` is the authoritative answer about the scan run itself; follow it when the two disagree. |
 | A repository or image reports `free_tier_code_repos_cap` or `free_tier_code_images_cap` | The organization is on the free tier, which covers the first 10 repositories per connected source-control organization and the 5 most-referenced container images per organization. The covered set is stable rather than rotating, so findings do not appear and disappear between passes. Narrow the policy to the repositories you care about, or move off the free tier. A `_report` suffix means the limit is not being applied: everything was scanned, and the message reports what the limit would have done. |
+| A pull-request check or AutoFix does nothing, reporting `write_app_not_configured` or `write_app_lacks_contents` | Only the write was refused. Scanning and existing findings are unaffected. The write App is separate from the read connection and opt-in: the first message means no Code Actions App is configured, the second that it lacks `Contents: Read and write`. They are two different pages in GitHub's settings. |
+| An AutoFix pull request reports `lockfile_stale` | The pull request is real and correct; the lockfile still has to be regenerated. npm: `npm install --package-lock-only --ignore-scripts`. Go: `go mod tidy`. This is expected for Go whenever a `go.sum` exists, and for npm only under `autofix_registry_access: false`, a `yarn.lock`/`pnpm-lock.yaml`, or an entry that could not be rewritten safely. |
+| A finding you expected is absent entirely | Check the policy's `severity_floor`. A finding under the floor is never recorded, so it has no row to filter for. `LOW`, `INFO` and an empty value mean no floor. |
+
+## See also
+
+- [GitHub provider setup](provider-setup/github.md) — permissions, the App, and the credentials secret
+- [Findings & Triage](findings.md) — the worklist every code finding lands in
+- [Cloud Security in your IDE](mcp.md) — the MCP tools
+- [Security Graph & Queries](graph.md) — the query pack and the graph vocabulary
+- [Compliance](compliance.md) — scoring, coverage and evidence
+- [Configuration Reference](configuration.md) — every Cloud Security policy record

--- a/docs/cloud-security/compliance.md
+++ b/docs/cloud-security/compliance.md
@@ -15,11 +15,15 @@ limacharlie cloudsec compliance report --framework cis-gcp
 limacharlie cloudsec compliance frameworks
 ```
 
-Eleven frameworks ship today — `cis-aws`, `cis-azure`, `cis-gcp` (the default),
-`cis-m365`, `soc2`, `pci-dss`, `hipaa`, `iso-27001`, `nist-csf`, `nist-ai-rmf`,
-and `owasp-llm`. The last two are AI frameworks: they assess the OpenAI and
-Anthropic estate connected through the
-[AI providers](providers.md#ai-security-aispm). `cis-m365` is graded off the
+Thirteen frameworks ship today — `cis-aws`, `cis-azure`, `cis-gcp` (the
+default), `cis-m365`, `soc2`, `pci-dss`, `hipaa`, `iso-27001`, `nist-csf`,
+`nist-ai-rmf`, `owasp-llm`, `owasp-top10`, and `cis-supply-chain`. `nist-ai-rmf`
+and `owasp-llm` are AI frameworks: they assess the OpenAI and Anthropic estate
+connected through the [AI providers](providers.md#ai-security-aispm).
+`owasp-top10` (OWASP Top 10:2021, mapped by CWE) and `cis-supply-chain` (the CIS
+Software Supply Chain Security Guide's *Source Code* and *Dependencies*
+sections) are graded off [Code Scanning](code-scanning.md) and apply only when a
+source-code provider is connected. `cis-m365` is graded off the
 Microsoft Entra directory, so it covers the benchmark's Entra chapter and reports
 NOT_ASSESSED for the admin centers that are not collected (Defender, Purview,
 Exchange, SharePoint, Teams) — read each control's description for what it

--- a/docs/cloud-security/findings.md
+++ b/docs/cloud-security/findings.md
@@ -43,11 +43,18 @@ Each finding carries:
   same fingerprint across sweeps.
 - `finding_class` — one of `toxic_combination`, `public_exposure`,
   `ciem_risk`, `privilege_escalation`, `vulnerability`, `misconfig`,
-  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`
-  (`malware`, `secret`, and `scan_finding` are reserved for capabilities not
-  yet enabled). Cloud-workload coverage findings additionally carry
-  `workload_coverage_gap`, which is not part of the class list offered by the
-  suppression rule picker.
+  `malware`, `secret`, `scan_finding`, `coverage_gap`, `device_posture`,
+  plus `license_risk`, `eol_runtime` and `code_weakness` (`scan_finding` is
+  reserved for a capability not yet enabled). Cloud-workload coverage findings
+  additionally carry `workload_coverage_gap`, which is not part of the class
+  list offered by the suppression rule picker.
+
+    `secret`, `malware`, `license_risk`, `eol_runtime` and `code_weakness`, and
+    the `misconfig` findings whose rule id is an infrastructure-as-code check,
+    come from [Code Scanning](code-scanning.md). Those carry a `repo` key and a
+    `code` block with the file, the line range, the package and the fixed
+    version where one applies — and the **Repository** filter narrows the
+    worklist to one repository.
 - `severity` (`CRITICAL` … `INFO`), `lc_risk`, and the `risk_breakdown`
   above.
 - The affected resource (`resource_urn`, `resource_name`, `resource_type`,

--- a/docs/cloud-security/mcp.md
+++ b/docs/cloud-security/mcp.md
@@ -1,0 +1,195 @@
+# Cloud Security in your IDE (MCP)
+
+The [LimaCharlie MCP server](https://github.com/refractionPOINT/lc-mcp-server) exposes Cloud
+Security to any [Model Context Protocol](https://modelcontextprotocol.io/) client — Claude Code,
+Cursor, and others — so an AI assistant can read your cloud posture, triage findings, and, for the
+AppSec code lane, scan the working copy on your own machine before anything is pushed.
+
+This page covers the setup and the four code-lane tools. The rest of the Cloud Security tool surface
+mirrors the [command line interface](cli.md) one-for-one.
+
+## Setup — Claude Code
+
+```bash
+git clone https://github.com/refractionPOINT/lc-mcp-server
+cd lc-mcp-server
+go build -o lc-mcp-server ./cmd/server
+
+claude mcp add limacharlie-cloudsec \
+  --env LC_OID=<your-organization-id> \
+  --env LC_API_KEY=<your-api-key> \
+  --env MCP_MODE=stdio \
+  --env MCP_PROFILE=cloud_security \
+  -- /absolute/path/to/lc-mcp-server
+```
+
+`/mcp` in a session lists the server and its tools.
+
+## Setup — Cursor
+
+Add the server to `~/.cursor/mcp.json`, or to `.cursor/mcp.json` inside a project to scope the
+credential to one repository:
+
+```json
+{
+  "mcpServers": {
+    "limacharlie-cloudsec": {
+      "command": "/absolute/path/to/lc-mcp-server",
+      "args": [],
+      "env": {
+        "LC_OID": "<your-organization-id>",
+        "LC_API_KEY": "<your-api-key>",
+        "MCP_MODE": "stdio",
+        "MCP_PROFILE": "cloud_security",
+        "LOG_LEVEL": "warn"
+      }
+    }
+  }
+}
+```
+
+`LOG_LEVEL=warn` matters more than it looks: the server logs to stderr, and in stdio mode a chatty
+stderr is noise in the client's transport log.
+
+## Profiles
+
+`MCP_PROFILE` decides which tools the client is offered. For Cloud Security work:
+
+| Profile | What it exposes |
+|---|---|
+| `cloud_security` | Every Cloud Security tool, including the triage writes |
+| `cloud_security_readonly` | The reads only — for a session that must not be able to change anything |
+| `all` | The whole platform |
+
+A narrow profile is not just tidiness. An assistant chooses from what it is shown, so a session that
+only needs to read posture is both cheaper and safer with `cloud_security_readonly`.
+
+## Permissions
+
+Reads need `cloudsec.get`; the triage writes and the code ingest need `cloudsec.set`. The whole
+surface also requires the organization to be subscribed to the `ext-cloud-security` extension — a
+403 saying cloud security is not enabled means exactly that, and the tools say so in their errors.
+
+## The code-lane tools
+
+| Tool | What it does |
+|---|---|
+| `cloudsec_code_repos` | The repositories the code lane sees, with scan state and the open-finding rollup |
+| `cloudsec_code_findings` | Findings for one or more repositories, or the cross-filtered facet counts |
+| `cloudsec_code_scan_local` | Scans a working copy on your machine with the same scanner the hosted lane runs |
+| `cloudsec_code_autofix` | Opens the dependency fix pull request for an SCA finding |
+
+### Before they can return anything
+
+Code scanning is opt-in per organization, and two things must be true:
+
+1. A source-control provider is connected (a `cloudsec_provider` record).
+2. A `code_scanning` record exists in the `cloudsec_policy` hive, naming the repositories in scope
+   and the engines that run.
+
+Both are hive records — see [Code Scanning](code-scanning.md#turning-it-on) for the policy's
+fields. **An empty answer from a code tool
+usually means one of those two is missing, not that your code is clean**, and the tools say so
+rather than implying an all-clear.
+
+### Reading findings
+
+`cloudsec_code_findings` will not list without at least one `repo`. That is deliberate: the findings
+backend has no "any repository" selector, so dropping the constraint would return your whole
+findings worklist — cloud findings included — under a tool named for the code lane. Filtering by
+class does not scope it either, because `vulnerability`, `misconfig` and `malware` are shared with
+the cloud lane.
+
+The unscoped mode is `facets: true`, which is honest because the `repo` facet counts only findings
+that have a repository. So the natural order is:
+
+```text
+cloudsec_code_findings { "facets": true }        → which repositories carry what
+cloudsec_code_repos    { "has_findings": true }  → the same per repository, with scan state
+cloudsec_code_findings { "repo": ["owner/name"], "severity": ["CRITICAL", "HIGH"] }
+```
+
+`source` narrows the same read by producer — `hosted` for the scan LimaCharlie ran, `ingest` for a
+document your pipeline pushed, `other` for the source control's own detectors, `none` for a finding
+with no code provenance, or `both`. It is applied inside the query, so the facet counts describe the
+estate rather than the page you happen to be holding.
+
+`repo` is matched **exactly** against a key whose owner and name segments are both ASCII
+lower-cased, while a finding's `code.repo_name` is the source-control platform's display casing.
+The filter folds what you pass, so a key read straight off a finding now scopes the read rather
+than silently matching nothing. A key that is genuinely wrong still returns an empty page, and an
+empty page under a single `repo` filter carries a note saying which case you are in: the key is
+right and nothing matched, the key is wrong and here is the real one, or no such repository is in
+the inventory.
+
+### Scanning your working copy
+
+```text
+cloudsec_code_scan_local { "path": "/home/me/src/api" }
+```
+
+This runs on **your** machine, not in LimaCharlie: it needs Docker and the
+[`limacharlie` CLI](cli.md) on PATH, and it takes minutes rather than seconds. Nothing about the
+checkout leaves the machine, and without `ingest` nothing leaves it at all — the result says so
+explicitly, so a scan that found plenty is not misread as a clean estate.
+
+Because it runs a container locally, it is available only when the server is running in stdio mode.
+A hosted MCP deployment refuses it.
+
+`scanners` defaults to `sca,iac,licenses`; `sast` and `images` also run locally. **Secret scanning
+does not**, and asking for it is an error rather than a silent omission: a credential's identity in
+this pipeline is a digest keyed by a value only the hosted lane holds, so locally-found secrets
+would neither deduplicate against a hosted scan's nor be accepted by the ingest. Use the hosted lane
+for secrets.
+
+With `ingest: true` and a `repo`, the report is pushed to your organization, where it deduplicates
+against the hosted scan by identity — the report format is loss-free, so it lands on exactly the
+rows a hosted scan of the same repository would write, and re-pushing an identical report writes
+nothing. A pushed report can only close findings *it* previously reported, never one the hosted
+scanner found.
+
+Pass `output_path` alongside `ingest`. The report otherwise exists only for the duration of the
+scan, so a push that fails — not subscribed, no enabled `code_scanning` policy selecting the
+repository, a quota, a transient error — costs the whole scan again.
+
+### `cloudsec_code_autofix`
+
+Opens the pull request that raises a vulnerable dependency to its fixed version,
+for one finding:
+
+```text
+cloudsec_code_autofix { "finding_id": "fnd_..." }
+```
+
+`finding_id` is required and is the only input that decides anything: the
+backend resolves it against the dependency rows its own scan produced and raises
+that package to that advisory's fixed version, so there is no way to name a
+package or a version. `repo` and `provider` are optional search hints.
+
+It needs the separate, opt-in **Code Actions** App on the connection — the
+read-only collection App never gains write access.
+
+The tool answers as soon as the request is **accepted**; the clone, the edit and
+the pull request happen minutes later in a sandbox, so **the pull request is the
+result**. Read it in the repository rather than in the tool's reply.
+
+!!! warning "A refusal does not come back on this call"
+    Because the call has already answered, every reason a fix does not happen is
+    a quiet no-op here: no Code Actions App (`write_app_not_configured`) or one
+    lacking `Contents: Read and write` (`write_app_lacks_contents`), a package
+    flagged malicious, no published fixed version, an unsupported ecosystem, a
+    repository outside the policy scope or over the free-tier quota, a pull
+    request already open for that package, or the daily limit.
+
+    None of these appear in the reply. They surface as the
+    `cloudsec.code_autofix_refused` operational event — that is where to look
+    when no pull request appears.
+
+See [Code Scanning](code-scanning.md#dependency-autofix-pull-requests) for the
+setup, the npm registry-metadata policy, and the Go lockfile caveat that decide
+whether the pull request is complete on its own.
+
+## See also
+
+- [Code Scanning](code-scanning.md) — the lane these tools read
+- [Command Line Interface](cli.md) — the same surface, without an assistant

--- a/docs/cloud-security/provider-setup/github.md
+++ b/docs/cloud-security/provider-setup/github.md
@@ -33,6 +33,7 @@ Create the App with **read-only** access on the following. All are
 | **Secrets** | Organization | Organization Actions-secret inventory (**names only**, never values) | `org_secrets` |
 | **Administration** | Repository | Branch-protection posture and deploy-key inventory (deploy keys are also the one activity signal — see [Known limitations](#known-limitations)) | *(collected during the sweep)* |
 | **Secrets** | Repository | Whether a repository has Actions secrets at all — an existence flag, not a name list (org-level secrets are the ones inventoried by name) | *(collected during the sweep)* |
+| **Contents** | Repository | [Code Scanning](../code-scanning.md) — dependencies, secrets, infrastructure-as-code, container images, code weaknesses and licenses. Without it the connector inventories repositories but cannot read them | `code_contents` |
 | **Dependabot alerts** | Repository | GitHub's own **Dependabot** alerts, ingested as findings and deduplicated against LimaCharlie's own dependency scanning; and whether each repository has Dependabot alerts **enabled** | `dependabot_alerts` |
 | **Code scanning alerts**, **Secret scanning alerts** | Repository | GitHub's own **code-scanning** and **secret-scanning** alerts, ingested as findings and deduplicated against LimaCharlie's own analysis | `security_events` |
 
@@ -181,3 +182,31 @@ limacharlie cloudsec provider test --input-file provider.yaml
   public-profile emails only. Organization-level SSO is read normally.
 - An **Actions OIDC trust** with no corresponding cloud-side role is reported
   as a dangling trust rather than a fabricated "can assume" edge.
+
+## Scanning repository contents
+
+Granting **Contents → Read-only** turns on [Code Scanning](../code-scanning.md)
+for the repositories a `code_scanning` policy selects. The permission is an
+increase on an existing installation, so GitHub requires an organization owner to
+**approve the permission request** on the installation page before it takes
+effect; until then, selected repositories report
+`github_app_missing_contents_permission` on the code scan status rather than
+failing silently.
+
+Code is read inside an ephemeral sandbox and never persisted — only the
+normalized finding report leaves it, and discovered secrets are stored as a
+salted hash. **This App stays read-only.** Nothing in the collection or scanning
+path writes to your repositories.
+
+### The separate write App, if you want checks or fix pull requests
+
+Publishing a pull-request check, commenting on a pull request or opening a
+dependency fix pull request needs write access, and that is deliberately **not**
+this App. It is a second, opt-in App — "LimaCharlie Code Actions" — that you
+create, install on the repositories you choose, and name on the provider record
+with `github_actions_app_id`, `github_actions_installation_id` and
+`actions_credentials`. The record is refused if it points at the same App, or the
+same secret, as the read connection.
+
+Its manifest, the permission union it needs and the wiring are in
+[Code Scanning](../code-scanning.md#pull-request-checks-and-merge-gating).

--- a/docs/cloud-security/providers.md
+++ b/docs/cloud-security/providers.md
@@ -165,6 +165,12 @@ settings/members/teams (identities), repositories (data stores), installed Apps 
 webhooks / deploy keys / Actions secrets (non-human identities), and the Actions
 OIDC subject configuration.
 
+With the **Contents → Read-only** permission added, the same connection also
+drives [Code Scanning](code-scanning.md) — dependencies, secrets,
+infrastructure-as-code, container images and licenses, scanned in an ephemeral
+sandbox and filed as ordinary findings. It is opt-in per repository through a
+`code_scanning` policy; nothing is scanned until you write one.
+
 ## AI security (AISPM)
 
 AI providers bring your model-platform organizations into the estate as

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -610,7 +610,7 @@ nav:
       - Overview: cloud-security/index.md
       - Getting Started: cloud-security/getting-started.md
       - Connecting Providers: cloud-security/providers.md
-      - Code Scanning & Pushed Results: cloud-security/code-scanning.md
+      - Code Scanning: cloud-security/code-scanning.md
       - Provider Setup:
           - Overview: cloud-security/provider-setup/index.md
           - Google Cloud: cloud-security/provider-setup/gcp.md
@@ -634,6 +634,7 @@ nav:
       - Custom Posture Rules: cloud-security/custom-rules.md
       - Configuration Reference: cloud-security/configuration.md
       - Command Line Interface: cloud-security/cli.md
+      - IDE & MCP: cloud-security/mcp.md
       - API Reference: cloud-security/api-reference.md
       - Automation & IaC: cloud-security/automation.md
 


### PR DESCRIPTION
**Draft, and it stays a draft** — this repo is public and the code lane is not
announced. It supersedes four in-flight branches; it is here so the docs round
is reviewable as one thing rather than as a stack.

## What this replaces

| PR | State | Folded in |
|---|---|---|
| #355 code lane | open draft | the page, the findings/compliance/providers/nav edits |
| #357 alert permissions | **already merged** | built on, not restated |
| #360 bring your own scanner | open draft, stacked on #355 | the BYO section and the Actions recipe |
| #361 IDE & MCP | open draft | `mcp.md`, with the autofix tool corrected |

All three open ones are left open with a comment pointing here; closing them is
yours.

## Where the branches and the code disagreed

Every claim was checked against `legion_cloudsec_host/docs/CODE-LANE.md`,
`go-cloudsec/docs/API-CONTRACT.md`, the hive schema and the tracker rows. The
code won each time. Nine differences, worth reading before approving:

1. **Static analysis ships.** #360's "Not yet available" listed SAST as
   unshipped. It landed with a curated CWE-mapped rule pack; it is off by
   default in the policy, which is a different statement, and the page makes it.
2. **Push-triggered rescans ship.** Also listed as unavailable. The webhook
   adapter, the shipped D&R recipe and the debounce are documented.
3. **Pull-request checks and merge gating ship**, via the separate opt-in write
   App. #360 said they "need write access, which the read-only connector does
   not have and will not gain" — the second half is right and load-bearing, the
   conclusion was not.
4. **Dependency AutoFix ships**, with the npm / go lockfile limitation stated in
   the table rather than implied.
5. **`severity_floor` does not filter.** Both branches said it "drops code
   findings below this severity". It is validated, stored and composed; nothing
   applies it yet. Now carries an explicit note.
6. **`scan_status` reads `unknown`** for every repository today — the
   per-repository scan props live on the lane's own status document and are not
   merged onto the inventory row, so the field reports
   `repo_scan_props_not_projected`. Documented as a known state with the
   authoritative alternative (`code status`) named, rather than described as if
   it worked.
7. **OWASP Top 10 is fully assessable now** (ten of ten once static analysis has
   run over a repository), not five of ten.
8. **`image_sources: ["registries"]`** is accepted and not enumerated. Named in
   "Not yet available" instead of listed as a working option.
9. **`sast_ruleset: custom:<ref>`** is accepted by the policy validator and
   refused by the scanner — and because the scan then reports an error, that
   repository's *unrelated* findings stop being swept. Documented as a thing not
   to set, with the consequence.

## What the review then caught

Every command on the page was run against the CLI's own source rather than read,
which found seven copy-paste failures — all fixed in the second commit:
`--finding-class` is `--class`; the Actions recipe invented `limacharlie login`
and `--alias` (the group is `auth`, and there is no alias option), so the
workflow died before it scanned; local secret scanning is **refused**, not "off
by default", which the MCP page in this same PR already said correctly; the
webhook heredoc used `$OID` and `$INSTALLATION_KEY` without defining them, in an
unquoted heredoc, so a reader wrote an empty identity; `image_sources` is a list
and appeared twice as a bare scalar.

## Two things that gate merging, beyond the rollout

- **`mcp.md` documents tools that do not exist yet.** `lc-mcp-server` #58, #59
  and #60 are open and unmerged — none of the four `cloudsec_code_*` tools is on
  that repo's master. Adding `- IDE & MCP: cloud-security/mcp.md` to `mkdocs.yml`
  *is* publication, so if this merges first, **drop that nav line and the two
  links to the page**.
- **No published CLI release carries the `cloudsec code` group.** It is newer
  than the newest tag, so every `limacharlie cloudsec code …` line here answers
  `No such command` to a reader who installs today. A `python-limacharlie`
  release is a prerequisite; the page says to upgrade, which is only true once
  one exists.

Both are tracked as go-cloudsec roadmap 15 §10 items 35b and 36 (PR
go-cloudsec#240).

## Deliberately not here

- **No competitor or vendor names.** Scanner engines, rule-pack vendors and
  other source-control platforms are described by what they do. One consequence:
  the `sast_ruleset` alternative pack value is not documented — only the curated
  default and the fact that `custom:` does not work.
- **The webhook adapter page is not edited.** The code lane links to the existing
  tutorial and carries only the record shape it needs; none of the four branches
  touched that page either.
- **No release-note entry.** That is legion_deployments#5197, held for the
  production rollout.


## D3 registry-policy follow-up

The latest commit reconciles this branch with current master and documents the shipped code_scanning.autofix_registry_access contract: omission defaults to registry metadata access, an explicit false disables it, and false wins when matching policy records compose. Default-enabled npm AutoFix updates package-lock.json from registry version, resolved URL and integrity metadata; explicit false produces a manifest-only pull request with a stale-lock warning. Go remains manifest-only when a go.sum must be regenerated.

The merge conflict was the older, shorter Code Scanning page added to master. The consolidated page remains the intentional replacement, while unrelated current-master documentation and least-privilege workflow permissions were retained.