### PR TITLE
docs: Email Security CLI and AI triage

### DIFF
--- a/docs/cloud-security/provider-setup/google-workspace.md
+++ b/docs/cloud-security/provider-setup/google-workspace.md
@@ -110,12 +110,43 @@ service-account key:
     classification list and does not restrict collection.
 
 !!! danger "Do not flatten the wrapper"
-    Do **not** place `admin_email` / `domain` at the top level next to the
-    service-account-key fields. A secret that looks like a bare service-account
-    key is read as the **no-delegation** form: the impersonation admin is
-    ignored, the token is minted with no subject, and Google returns
-    **`HTTP 400: Invalid Input`** on the first directory call — unless the
-    service account itself holds a Workspace admin role.
+    `admin_email` and `domain` are siblings of `service_account_json`, **not**
+    fields inside it and **not** extra keys alongside `type` / `private_key` /
+    `client_email` at the top level.
+
+    A secret whose top level looks like a service-account key is read as the
+    **no-delegation** form. `admin_email` is then ignored *wherever it sits* —
+    no error, no warning — the token is minted with no subject, and every call
+    goes to Google as the service account itself. The domain-wide delegation
+    you registered is never used.
+
+    The symptom is **not** a validation error. Tokens mint normally, and every
+    Google surface answers with an authorization denial instead:
+
+    ```text
+    core   HTTP 403: Not Authorized to access this resource/api
+    groups HTTP 403: Not Authorized to access this resource/api
+    ```
+
+    That reads exactly like a missing scope, which sends people back to
+    re-audit a delegation setup that is already correct.
+
+!!! tip "Check which form your secret is in"
+    Before storing it, look at the **top-level** keys:
+
+    ```bash
+    jq 'keys' gw-secret.json
+    # want:  ["admin_email", "service_account_json"]   (+ "domain" if you set it)
+    # wrong: [..., "client_email", ..., "private_key", ..., "type", ...]
+    ```
+
+    If `type`, `private_key` or `client_email` appear at the **top** level, the
+    secret is the no-delegation form no matter what else is in it.
+
+    Reusing the same *service account* as the GCP provider is fine. Reusing the
+    same *secret* is not — the GCP provider takes the raw key verbatim, so
+    pointing the Workspace record at it lands in exactly this case. Give
+    Workspace its own secret.
 
 Store it:
 
@@ -131,6 +162,14 @@ Or in the web app: **Organization Settings → Secrets Manager → Add**, name i
 `gw-credentials`, and paste the JSON.
 
 ### Alternative: no delegation
+
+!!! warning "Only if you chose this deliberately"
+    This form is accepted, but it is not the recommended setup and it is the
+    one operators land in **by accident** — it is what a raw service-account
+    key, pasted verbatim, is read as. If `core` is failing with
+    `HTTP 403: Not Authorized to access this resource/api` and you did not set
+    this up on purpose, you are in this form by accident: go back to the
+    [wrapper envelope](#create-the-credentials-secret).
 
 If you would rather not register domain-wide delegation, the **raw
 service-account key JSON** is accepted as the secret on its own — the file GCP
@@ -225,9 +264,26 @@ limacharlie cloudsec provider test --input-file provider.yaml
 | `provider test` error | Cause | Fix |
 |---|---|---|
 | `HTTP 400: Bad Request` on the user check, with every other check failing too | `workspace_customer_id` is not a customer ID Google recognizes — most often the organization's **name** rather than the ID. Google returns this same opaque 400 for every customer-aimed call, which reads as a permission problem and sends people back to re-audit delegation and scopes that are already correct | Set `workspace_customer_id` to `my_customer`, or to the ID from **Admin console → Account → Account settings → Profile**. `provider test` names this explicitly when it can confirm it: the same read is retried against `my_customer`, and if that succeeds the check reports the real customer ID to use |
-| `HTTP 400: Invalid input` on the user check | Secret is missing or mis-nested the impersonation admin → token has no subject → `my_customer` unresolvable | Use the **wrapper** envelope above: nest the key under `service_account_json`, with `admin_email` as a sibling. If you meant the no-delegation setup, grant the service account a Workspace admin role instead |
 | Users or groups from a secondary domain are missing | `domain` is set in the secret, narrowing collection to that one domain | Remove `domain` from the secret; declare internal domains with `internal_domains` on the record |
 | `token mint failed (HTTP 401): scope not granted to the delegated admin` | DWD missing scopes (all-or-nothing mint), a non-`.readonly` variant, or not yet propagated | Register the **full** scope list exactly; wait for propagation; confirm the service account's client ID matches |
-| `core` fails: `HTTP 403: Not Authorized to access this resource/api` | A token **was** minted (so the scopes are registered) but the caller has no Workspace admin authority. Almost always the secret is a **raw service-account key with no `admin_email`** — typically the GCP provider's secret reused verbatim — so nothing is impersonated and the delegation you configured is never used. It is silently accepted as the no-delegation form. Otherwise, `admin_email` names a user who is not a Super Admin | Give Workspace its **own** secret in the wrapper envelope with `admin_email`; leave the GCP provider's secret untouched. Reusing the same *service account* is fine — reusing the same *secret* is not |
+| `core` fails: `HTTP 403: Not Authorized to access this resource/api` | A token **was** minted (so the scopes are registered) but the caller has no Workspace admin authority. Almost always the secret is a **raw service-account key with no `admin_email`** — typically the GCP provider's secret reused verbatim, or the wrapper flattened — so nothing is impersonated and the delegation you configured is never used. It is silently accepted as the no-delegation form. Otherwise, `admin_email` names a user who is not a Super Admin | Give Workspace its **own** secret in the wrapper envelope with `admin_email`; leave the GCP provider's secret untouched. Reusing the same *service account* is fine — reusing the same *secret* is not. Confirm the form with the `jq 'keys'` check [above](#create-the-credentials-secret) |
 | `HTTP 403: … API has not been used in project …` | Admin SDK / Cloud Identity API not enabled | Enable the named API in the service account's project |
 | `reports` fails: `HTTP 401: Access denied. You are not authorized to read activity records.` | The token minted (so the DWD registration itself is fine) but the impersonated admin cannot read the Reports audit stream — either `admin.reports.audit.readonly` is missing from the DWD scope list, or `admin_email` names an admin without the *Reports* privilege | Add the scope to the delegation and impersonate a Super Admin. Optional surface: leaving it as-is drops only Gemini-in-Workspace usage — but it does leave the connection's **Last Sync** badge on Failed, per the note above |
+
+!!! tip "A changed error means you fixed something"
+    These failures **mask each other**, and the **Last Sync** badge says only
+    *Failed* either way — so a real fix can look like no fix at all.
+
+    Google validates the customer ID *before* it checks authorization, so a
+    wrong `workspace_customer_id` answers `400` on every surface and hides
+    whatever the credential would have said. Correct the customer ID and the
+    same connection starts answering `403` instead. That is not a new problem
+    and not a regression: it is the next one, previously unreachable.
+
+    Read the *error text*, not the badge, and re-diagnose against the table
+    above after each change. `provider test` is the fastest way to see it —
+    it reports one check per surface rather than a single verdict.
+
+    Both misconfigurations can be present at once, so budget for two rounds:
+    an unrecognized customer ID and a flattened secret are independent, and
+    fixing either one alone still leaves the connection Failed.

--- a/docs/email-security/ai-triage.md
+++ b/docs/email-security/ai-triage.md
@@ -1,0 +1,239 @@
+# AI Triage
+
+Email Security produces an explainable verdict for every message. AI triage is the
+optional second pass: an agent that reads the message the way an analyst would, looks up
+what else it can find, and writes a conclusion with the evidence behind it.
+
+Nothing on this page is installed for you. It is a set of worked examples you adapt —
+the agent's playbook, what it is allowed to do, and when it runs are all decisions that
+belong to you, and they differ enough between organizations that a default would be
+wrong more often than right.
+
+## How it works
+
+Triage is an ordinary [AI Session](../9-ai-sessions/index.md) driving the LimaCharlie
+CLI. There is no email-specific AI integration to configure:
+
+- The agent is an `ai_agent` Hive record — the same kind used everywhere else.
+- It reaches Email Security through `limacharlie mailsec ...`, the same commands you
+  use.
+- A D&R rule starts it, using the standard `start ai agent` response action.
+- Budgets, turn limits and model selection are the session's, enforced by AI Sessions.
+
+That choice is deliberate. Because the agent is a normal API client, you can bring your
+own model or provider, run the same playbook by hand to see what it does, and reason
+about its access with the tools you already use for every other integration.
+
+!!! important "What the agent may do is a permission, not a setting"
+    There is no triage "mode". The agent authenticates with an API key, and that key
+    either carries `mailsec.act` or it does not.
+
+    A read-only triage agent — one that investigates and reports but never touches
+    mail — is simply an agent whose key lacks `mailsec.act`. The API refuses the action;
+    the agent cannot talk its way past it. **Do not rely on the prompt for this.** A
+    prompt is a request, not a control.
+
+## Before you start
+
+1. The org is subscribed to `ext-email-security` and has at least one connected mail
+   provider.
+2. You have an AI provider credential (Anthropic, Bedrock, Vertex, OpenAI, …). See
+   [AI Sessions providers](../9-ai-sessions/providers.md).
+3. You have decided whether this agent may act. That is the first real decision, and
+   the rest of the page assumes you have made it.
+
+## Step 1 — Create the API key the agent will use
+
+The key's permissions are the agent's ceiling. Start read-only; you can widen later.
+
+=== "Investigate only (recommended to start)"
+
+    ```bash
+    limacharlie api-key create --oid $OID \
+      --name mailsec-triage \
+      --permissions "mailsec.get,org.get"
+    ```
+
+    The agent can read the queue, the message drawer, campaigns, sender profiles and
+    the audit trail. If it tries to quarantine anything the API returns 403.
+
+=== "Investigate and remediate"
+
+    ```bash
+    limacharlie api-key create --oid $OID \
+      --name mailsec-triage \
+      --permissions "mailsec.get,mailsec.act,org.get"
+    ```
+
+    Adds live remediation. Every action still passes through the same choke point as a
+    human's: your `alert_only` / `enforce` mode applies, and an audit row is written
+    naming the agent as the actor.
+
+Add `mailsec.get.eml` only if you want the agent to read raw message bytes. That
+permission is separate because it takes the original mail out of your tenant, and every
+use is written to the access audit with a justification.
+
+Store the key as a secret so the agent record can reference it rather than embed it:
+
+```bash
+echo '{"secret": "<the-api-key-value>"}' | \
+  limacharlie hive set --hive-name secret --key mailsec-triage-key --oid $OID --enabled
+```
+
+## Step 2 — Write the agent
+
+An `ai_agent` record holds the playbook and the session's limits. This example is a
+starting point — the prompt is the part you should expect to edit.
+
+```bash
+cat > triage-agent.json <<'EOF'
+{
+  "prompt": "You are an email security analyst triaging a single message. You have the LimaCharlie CLI.\n\nStart with:\n    limacharlie mailsec message get <msg_uuid> --output yaml\n\nThat returns the index row and the parsed message model: sender, recipients, subject, links, attachments, authentication results (SPF/DKIM/DMARC), delivery hops, and the verdict the scoring engine already reached with the signals that fired.\n\nUseful follow-ups, roughly in order of value:\n    limacharlie mailsec message similar <msg_uuid>      who else received this\n    limacharlie mailsec sender get <address-or-domain>  has this sender written before\n    limacharlie mailsec campaign get <campaign_id>      the wider attack, if clustered\n    limacharlie mailsec message list --link-domain <d>  who else got mail linking there\n\nDecide three things:\n1. Is this malicious, suspicious, graymail, benign, or genuinely unclear?\n2. WHY, in terms a responder can verify. Name the evidence: the authentication result, the lookalike domain and what it imitates, the attachment type, the sender's history or lack of one.\n3. How far it reached: how many mailboxes, and whether it clusters into a campaign.\n\nRules for your conclusion:\n- Say what the evidence supports and no more. 'The sending domain was registered four days ago and DMARC failed' is useful. 'This is a targeted APT campaign' is not, unless you can point at what shows it.\n- If you cannot tell, say so and escalate. An honest 'unclear, needs a human, here is what I checked' is a good outcome. A confident wrong verdict is what destroys trust in the whole product.\n- A message a HUMAN reported deserves more care than its score suggests. Someone chose to report it; that is evidence in itself.\n- Never claim you performed an action you did not perform.\n\nIf your key carries mailsec.act you may remediate:\n    limacharlie mailsec message action <msg_uuid> --action quarantine_message --reason \"...\"\n    limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <campaign_id>\nOnly when the evidence is clear-cut. Campaign actions preview unless you pass --confirm; read the preview first. If your key lacks the permission the API will refuse you: that is the organization's decision, not an error to work around. Report your verdict and stop.\n\nFinish with a short structured summary: verdict, the evidence, reach, and what you did or recommend.",
+
+  "name": "Email triage: {{ .msg_uuid }}",
+  "debounce_key": "mailsec-triage-{{ .msg_uuid }}",
+
+  "max_turns": 20,
+  "max_budget_usd": 0.50,
+  "one_shot": true,
+
+  "plugins": ["lc-essentials"],
+
+  "lc_api_key_secret": "hive://secret/mailsec-triage-key",
+  "anthropic_secret": "hive://secret/anthropic-key"
+}
+EOF
+
+limacharlie hive set --hive-name ai_agent --key mailsec-triage \
+  --oid $OID --input-file triage-agent.json --enabled
+```
+
+What each of the non-obvious fields buys you:
+
+| Field | Why it is there |
+|---|---|
+| `debounce_key` | One session per message. A redelivered notification or a second rule firing on the same message queues behind the first instead of paying twice to reach the same conclusion. |
+| `max_budget_usd` | A per-session ceiling, enforced by AI Sessions. This is the real cost control — there is no separate Email Security budget to keep in sync. |
+| `one_shot` | The session ends when the task is done rather than idling. |
+| `plugins` | `lc-essentials` is what puts the `limacharlie` CLI in the session. Without it the agent has no way to reach anything. |
+| `lc_api_key_secret` | The key from Step 1 — the agent's permission ceiling. |
+
+## Step 3 — Decide when it runs
+
+The agent does nothing until something starts it. These are two rules worth having, and
+they answer different questions, so keep them separate — you may well want one without
+the other.
+
+### On a suspicious message
+
+```bash
+cat > triage-suspicious.json <<'EOF'
+{
+  "detect": {
+    "target": "log",
+    "event": "EMAIL_MESSAGE",
+    "op": "is",
+    "path": "event/verdict/verdict",
+    "value": "suspicious"
+  },
+  "respond": [{
+    "action": "start ai agent",
+    "definition": "mailsec-triage",
+    "debounce_key": "mailsec-triage-{{ .msg_uuid }}",
+    "data": { "msg_uuid": "event/msg_uuid" }
+  }]
+}
+EOF
+
+limacharlie hive set --hive-name dr-general --key mailsec-triage-suspicious \
+  --oid $OID --input-file triage-suspicious.json --enabled
+```
+
+`suspicious` rather than `malicious` is the interesting choice. A malicious verdict is
+already actionable and your automations handle it. The value of triage is the band where
+the score did **not** settle the question — which is also the band that produces the
+analyst toil.
+
+### On a user report
+
+```bash
+cat > triage-report.json <<'EOF'
+{
+  "detect": {
+    "target": "log",
+    "event": "EMAIL_USER_REPORT",
+    "op": "exists",
+    "path": "event/report_id"
+  },
+  "respond": [{
+    "action": "start ai agent",
+    "definition": "mailsec-triage",
+    "debounce_key": "mailsec-triage-report-{{ .report_id }}",
+    "data": {
+      "msg_uuid": "event/original_msg_uuid",
+      "report_id": "event/report_id"
+    }
+  }]
+}
+EOF
+
+limacharlie hive set --hive-name dr-general --key mailsec-triage-user-report \
+  --oid $OID --input-file triage-report.json --enabled
+```
+
+Note there is **no verdict filter** here. Someone took the trouble to report a message,
+which is evidence the scorer did not have. Filtering these by score would discard the
+signal exactly when it disagrees with you — the only time it is interesting.
+
+!!! warning "A report can arrive without an original"
+    `original_msg_uuid` is empty when the reported message was never indexed — the mail
+    predates the connection, or landed in a mailbox outside your scope. The report is
+    still real and still queued. If your prompt assumes an original exists, say what the
+    agent should do when it does not: read the forwarded copy and say the original was
+    not found.
+
+## Step 4 — Try it by hand first
+
+Run the playbook yourself against a real message before letting a rule fire it. It takes
+a minute and it is the difference between finding out now and finding out from a bill:
+
+```bash
+limacharlie mailsec message list --verdict suspicious --limit 5 --oid $OID --output yaml
+limacharlie mailsec message get <msg_uuid> --oid $OID --output yaml
+limacharlie mailsec message similar <msg_uuid> --oid $OID --output yaml
+```
+
+If those give you what you would want an analyst to see, the agent will have it too. If
+they do not, fix the prompt before wiring the trigger — a session that has to guess is a
+session that will assert.
+
+## Controlling cost
+
+Everything here is the session's, not Email Security's:
+
+- `max_budget_usd` caps one run.
+- `max_turns` caps how long it can go round.
+- `debounce_key` stops duplicate work on the same message.
+- The trigger rule is what controls **volume**. Widening it from `suspicious` to every
+  message is the single largest cost decision on this page.
+
+To see what you are actually spending, use the AI Sessions
+[cost tracking](../9-ai-sessions/cost-tracking.md) surface. Email Security does not
+meter this separately — one budget in one place, rather than two that can disagree.
+
+## Turning it off
+
+Disable the trigger rules. The agent record can stay; it costs nothing when nothing
+starts it.
+
+```bash
+limacharlie hive set --hive-name dr-general --key mailsec-triage-suspicious \
+  --oid $OID --input-file triage-suspicious.json --disabled
+```
+
+## What the agent writes back
+
+A triage verdict is recorded like any other, with `mode: ai` and the rationale attached,
+so the queue shows what was decided and why. The
+explainability contract applies to the agent exactly as it does to the scoring engine: a
+verdict a responder cannot check is not a verdict they can act on.

--- a/docs/email-security/ai-triage.md
+++ b/docs/email-security/ai-triage.md
@@ -1,5 +1,17 @@
 # AI Triage
 
+!!! warning "Private beta"
+    Email Security is in **private beta**. It is not generally available, and
+    access is enabled per organization — if the `ext-email-security` extension
+    is not in your catalog, this product is not turned on for you yet.
+
+    While it is in beta, expect the surface described here to move: commands,
+    fields and event shapes may change between releases, and they may change in
+    ways that are not backwards compatible. Pin a CLI version if you script
+    against it, and re-read this page after upgrading.
+
+    Talk to us before relying on it in production.
+
 Email Security produces an explainable verdict for every message. AI triage is the
 optional second pass: an agent that reads the message the way an analyst would, looks up
 what else it can find, and writes a conclusion with the evidence behind it.

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -1,0 +1,211 @@
+# Command Line Interface
+
+The `limacharlie mailsec` command group covers the whole Email Security API
+surface: the coverage screen, the message index and drawer, the audited raw-EML
+download, campaigns and campaign-wide sweeps, sender profiles, the action audit
+trail, the abuse-mailbox report queue, retro-hunts, custom-rule validation and
+backtest, the connection preflight, and the served onboarding guide.
+
+Commands take the global options (`--oid`,
+`--output json|yaml|toon|csv|table|jsonl`, `--filter <jmespath>`,
+`--fields <names>`), and every command and subgroup answers `--ai-help` with
+task-oriented guidance.
+
+```bash
+limacharlie mailsec --help
+```
+
+Every command requires the org to be subscribed to the extension:
+
+```bash
+limacharlie extension subscribe --name ext-email-security --oid $OID
+```
+
+Provider connections and policy are Hive records — manage them with the
+standard `limacharlie hive` commands (`mailsec_provider`, `mailsec_policy`,
+`dr-mail`). This group is the query, triage and remediation surface.
+
+## Permissions
+
+Four, rather than the usual get/set pair, because Email Security asks to be
+trusted with four separable things:
+
+| Permission | Covers |
+|---|---|
+| `mailsec.get` | Read the product's own view: queue, drawer, campaigns, senders, audit trail |
+| `mailsec.set` | Change detection behaviour and triage state |
+| `mailsec.act` | Remediate live mail at the provider |
+| `mailsec.get.eml` | Download the original bytes of a message; requires a logged justification |
+
+`mailsec.get.eml` is separate on purpose: opening the drawer shows you the
+product's structured view of a message, while downloading the EML takes a
+person's actual mail out of your tenant. Gating them identically would mean
+typing a justification to look at the queue.
+
+## At a glance
+
+```bash
+# Coverage
+limacharlie mailsec coverage --window-days 30
+
+# The triage queue
+limacharlie mailsec message list --verdict suspicious --verdict malicious
+limacharlie mailsec message list --mailbox cfo@corp.example --since 2026-08-01
+limacharlie mailsec message list --user-reported            # a human flagged these
+limacharlie mailsec message list --link-domain evil.example # IOC pivot
+limacharlie mailsec message list --attachment-sha256 <sha>  # IOC pivot
+limacharlie mailsec message get <msg_uuid>
+limacharlie mailsec message similar <msg_uuid>              # who else got it
+limacharlie mailsec message eml <msg_uuid> --justification "INC-4471"
+
+# Remediation
+limacharlie mailsec message action <msg_uuid> --action quarantine_message --reason "confirmed phish"
+limacharlie mailsec message action <msg_uuid> --action restore_message
+
+# Campaigns: one attack, triaged once
+limacharlie mailsec campaign list --min-members 3
+limacharlie mailsec campaign get <campaign_id>
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message           # preview
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <campaign_id>
+
+# Senders and the audit trail
+limacharlie mailsec sender get cfo@corp.example
+limacharlie mailsec sender get domain:corp.example
+limacharlie mailsec action get <action_id>
+
+# Abuse-mailbox reports
+limacharlie mailsec report list --status open --oldest-first
+limacharlie mailsec report get <report_id>
+limacharlie mailsec report resolve <report_id> --disposition true_positive
+
+# Custom rules
+limacharlie mailsec rule validate --file rule.json --rule-id custom-lookalike
+limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
+
+# Hunts
+limacharlie mailsec hunt create --detect-file detect.json --since 2026-07-01
+limacharlie mailsec hunt get <hunt_id>
+limacharlie mailsec hunt remediate <hunt_id> --action quarantine_message --confirm <hunt_id>
+
+# Analysis and setup
+limacharlie mailsec analyze --file suspect.eml --org-domain corp.example
+limacharlie mailsec connection test gws-exp
+limacharlie mailsec onboarding --provider gworkspace
+```
+
+## Things worth knowing before you script this
+
+### Actions preview by default
+
+`campaign action` and `hunt remediate` report what they *would* do and change
+nothing unless you pass `--confirm`. That is deliberate for an operation whose
+blast radius is every mailbox that received an attack.
+
+```bash
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message            # dry run
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <campaign_id>
+```
+
+### `alert_only` is a success, not a failure
+
+An action's `result` can come back as `alert_only`, meaning the action was
+**decided and deliberately not performed** because your organization is not in
+enforce mode. Do not treat it as an error — it is the product doing what you
+configured, reported honestly rather than dressed up as `ok`.
+
+### Filters are tri-state
+
+Leaving a boolean filter unset means the dimension is *unconstrained*, which is
+not the same as `false`:
+
+```bash
+limacharlie mailsec message list                      # every message
+limacharlie mailsec message list --user-reported      # only reported mail
+limacharlie mailsec message list --no-user-reported   # only unreported mail
+```
+
+### The EML download is audited
+
+`message eml` requires `--justification`, and it is written to the access audit
+with your identity. There is no way to fetch raw mail without leaving a record
+of why.
+
+```bash
+limacharlie mailsec message eml <msg_uuid> \
+  --justification "INC-4471, user reported credential harvest" \
+  --out-file suspect.eml
+```
+
+### Reports have an SLA ordering
+
+`--oldest-first` is what makes the report queue an SLA surface rather than a
+feed. "The oldest thing nobody has looked at" is the question a queue exists to
+answer, and it is not answerable from a newest-first page.
+
+Each report also carries `original_found`. A report whose original was never
+indexed is a real state — the mail predates the connection, or landed in a
+mailbox outside your scope — and it is shown as a gap rather than as a blank
+field.
+
+### Backtest tells you what it could not see
+
+`rule backtest` reports `skipped_no_raw`, `skipped_unparse` and `truncated`
+alongside the match count, because a precision figure whose denominator quietly
+shrank is a number that looks like a measurement and is not one. Its
+`coverage_note` states the window it actually examined.
+
+`precision` comes back as **null**, not `0`, when nothing it matched has an
+analyst disposition yet. Zero would read as "everything it matched was wrong"
+and would have you discard a good rule.
+
+```bash
+limacharlie mailsec rule backtest --file rule.json --output yaml
+```
+
+## Filtering and pagination
+
+Repeatable filters OR within a key and AND across keys:
+
+```bash
+# suspicious OR malicious, AND delivered to that mailbox
+limacharlie mailsec message list \
+  --verdict suspicious --verdict malicious \
+  --mailbox cfo@corp.example
+```
+
+Cursors are opaque and are passed back verbatim. They encode which index the
+walk is pinned to and are bound to the filter set that minted them — changing a
+filter mid-walk is an error rather than a page that silently means something
+else.
+
+```bash
+PAGE=$(limacharlie mailsec message list --limit 100 --output json)
+NEXT=$(echo "$PAGE" | jq -r .next_cursor)
+[ -n "$NEXT" ] && limacharlie mailsec message list --limit 100 --cursor "$NEXT"
+```
+
+An empty `next_cursor` means the last page.
+
+## Scripting
+
+```bash
+# Every suspicious message that reached a VIP mailbox in the last day
+limacharlie mailsec message list \
+  --verdict suspicious \
+  --mailbox ceo@corp.example \
+  --since "$(date -d '1 day ago' +%s)" \
+  --output json --filter 'messages[].{id: msg_uuid, subject: subject}'
+
+# Quarantine every member of a campaign, after reading the preview
+limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message --output yaml
+limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message --confirm "$CAMPAIGN"
+
+# Resolve the oldest open report
+REPORT=$(limacharlie mailsec report list --status open --oldest-first --limit 1 \
+  --output json | jq -r '.reports[0].report_id')
+limacharlie mailsec report resolve "$REPORT" --disposition true_positive
+```
+
+Because the CLI is the whole surface, it is also how an
+[AI triage agent](ai-triage.md) reaches Email Security — there is no separate
+integration for agents to learn.

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -1,5 +1,17 @@
 # Command Line Interface
 
+!!! warning "Private beta"
+    Email Security is in **private beta**. It is not generally available, and
+    access is enabled per organization — if the `ext-email-security` extension
+    is not in your catalog, this product is not turned on for you yet.
+
+    While it is in beta, expect the surface described here to move: commands,
+    fields and event shapes may change between releases, and they may change in
+    ways that are not backwards compatible. Pin a CLI version if you script
+    against it, and re-read this page after upgrading.
+
+    Talk to us before relying on it in production.
+
 The `limacharlie mailsec` command group covers the whole Email Security API
 surface: the coverage screen, the message index and drawer, the audited raw-EML
 download, campaigns and campaign-wide sweeps, sender profiles, the action audit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -584,7 +584,7 @@ nav:
           - Case-Reviewer Agent: 9-ai-sessions/compliance/case-reviewer-agent.md
           - Gap Analysis: 9-ai-sessions/compliance/gap-analysis.md
 
-  - Email Security:
+  - Email Security (Private Beta):
       - Command Line Interface: email-security/cli.md
       - AI Triage: email-security/ai-triage.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -585,6 +585,7 @@ nav:
           - Gap Analysis: 9-ai-sessions/compliance/gap-analysis.md
 
   - Email Security:
+      - Command Line Interface: email-security/cli.md
       - AI Triage: email-security/ai-triage.md
 
   - Cloud Security:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -584,6 +584,9 @@ nav:
           - Case-Reviewer Agent: 9-ai-sessions/compliance/case-reviewer-agent.md
           - Gap Analysis: 9-ai-sessions/compliance/gap-analysis.md
 
+  - Email Security:
+      - AI Triage: email-security/ai-triage.md
+
   - Cloud Security:
       - Overview: cloud-security/index.md
       - Getting Started: cloud-security/getting-started.md


### PR DESCRIPTION
Two pages for a new Email Security section.

## CLI

The whole `limacharlie mailsec` surface, plus the five behaviours that bite a script author if nobody states them:

- **Actions preview until `--confirm`** — right default for an operation whose blast radius is every mailbox that received an attack.
- **`alert_only` is a success, not a failure** — the action was decided and deliberately not performed because the org is not in enforce mode.
- **Filters are tri-state** — an unset boolean means *unconstrained*, not `false`.
- **The EML download is audited** and requires a justification, because it takes a person's actual mail out of the tenant.
- **Backtest reports what it could not examine** (`skipped_no_raw`, `truncated`, and `precision: null` rather than `0`), so a precision figure is never read as covering more than it did.

## AI triage

Worked examples rather than anything installed for you. An earlier draft had the extension write these records on subscribe — disabled and deliberately incomplete — which left an operator hunting for records they never asked for while the extension had already made shape decisions that belong to them. Documented examples an operator adapts is the honest form.

The reasoning survives as *why the example looks this way*: what the agent may **do** is the `mailsec.act` permission on its key rather than a product setting (a prompt is a request, not a control); budgets and turn limits belong to the session; the user-report trigger has no verdict filter because a human reporting something is evidence the scorer did not have; and the message trigger fires on `suspicious` rather than `malicious` because the undecided band is where the analyst toil is.

## Verification

Commands and flags checked against the CLI rather than written from memory — all 22 documented commands resolve. Doing that surfaced a real bug: `message eml`'s file option was `--output`, shadowing the global `--output <format>`, so `--output yaml` would have silently written a file named `yaml`. Fixed in [python-limacharlie#344](https://github.com/refractionPOINT/python-limacharlie/pull/344) and documented here as `--out-file`.

**Note:** the `limacharlie mailsec` CLI ships in that PR and is not in a released package yet, so these pages describe a surface that lands with it.