### PR TITLE
docs(cloud-security): document pushed code results

### DIFF
--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -88,7 +88,7 @@ limacharlie cloudsec caasm ingest --source okta --records-file users.json
 limacharlie cloudsec provider test --input-file provider.json
 limacharlie cloudsec provider manifest --type gcp        # "what you get" for a provider
 
-# Code scanning and pushed results
+# Code scanning and pushed results (requires a CLI release newer than 5.6.2)
 limacharlie cloudsec code repos --with-findings --all
 limacharlie cloudsec code scan . --repo acme/api --ingest
 limacharlie cloudsec code ingest --repo acme/api --source sarif --file results.sarif

--- a/docs/cloud-security/cli.md
+++ b/docs/cloud-security/cli.md
@@ -20,6 +20,9 @@ standard `limacharlie hive` commands — see
 [Configuration](configuration.md); this group is the query and triage
 surface.
 
+For the complete local-scanning, SARIF/CycloneDX ingest, and CI workflow, see
+[Code Scanning & Pushed Results](code-scanning.md).
+
 ## At a glance
 
 ```bash
@@ -84,6 +87,11 @@ limacharlie cloudsec caasm ingest --source okta --records-file users.json
 # Provider preflight + coverage manifest
 limacharlie cloudsec provider test --input-file provider.json
 limacharlie cloudsec provider manifest --type gcp        # "what you get" for a provider
+
+# Code scanning and pushed results
+limacharlie cloudsec code repos --with-findings --all
+limacharlie cloudsec code scan . --repo acme/api --ingest
+limacharlie cloudsec code ingest --repo acme/api --source sarif --file results.sarif
 
 # Policy authoring aids + read-only matcher previews
 limacharlie cloudsec policy vocabulary

--- a/docs/cloud-security/code-scanning.md
+++ b/docs/cloud-security/code-scanning.md
@@ -1,0 +1,241 @@
+# Code Scanning and Pushed Results
+
+Cloud Security can analyze source code in two ways:
+
+- **Hosted scanning** checks repositories selected by your source-control
+  connection and code-scanning policy.
+- **Pushed results** let a developer or CI pipeline scan a checkout locally, or
+  upload an existing SARIF or CycloneDX document.
+
+Both paths write to the same findings worklist. Use pushed results when source
+code must stay in your environment, when you already run another scanner, or
+when you want scan feedback on every push instead of waiting for a scheduled
+hosted scan.
+
+!!! note "CLI version"
+    The `cloudsec code scan` and `cloudsec code ingest` commands were added
+    after CLI 5.6.2. They require the first `limacharlie` release newer than
+    5.6.2. Check your installation before using the examples:
+
+    ```bash
+    limacharlie --version
+    limacharlie cloudsec code scan --help
+    ```
+
+## Before you begin
+
+You need:
+
+- a LimaCharlie organization subscribed to `ext-cloud-security`;
+- an enabled code-scanning policy that selects the repository;
+- an API key with `cloudsec.get` and `cloudsec.set`;
+- the current [LimaCharlie CLI](cli.md); and
+- Docker for local scans. Uploading an existing document does not require
+  Docker.
+
+Authenticate interactively with `limacharlie auth login`, or set `LC_OID` and
+`LC_API_KEY` in CI. Create and scope organization API keys as described in
+[API Keys](../7-administration/access/api-keys.md).
+
+Repository names use the `<owner>/<repository>` form, for example `acme/api`.
+If a checkout has a hosted Git remote, the local scan command can infer this
+name and the current commit. Pass `--repo` and `--commit` explicitly when the
+remote does not identify them unambiguously.
+
+## Scan a local checkout
+
+From the repository root, scan and send the result to Cloud Security:
+
+```bash
+limacharlie --output yaml cloudsec code scan . \
+  --repo acme/api \
+  --commit "$(git rev-parse HEAD)" \
+  --ingest
+```
+
+The default scan covers software dependencies, infrastructure as code, and
+licenses. To select supported scanners explicitly, pass a comma-separated
+list:
+
+```bash
+limacharlie --output yaml cloudsec code scan . \
+  --repo acme/api \
+  --scanners sca,iac,sast,licenses,images \
+  --ingest
+```
+
+The CLI runs the published LimaCharlie scanner container. The checkout is
+mounted read-only. Nothing from the checkout is sent to LimaCharlie unless you
+add `--ingest`; in that case, only the generated report is uploaded.
+
+To inspect or archive a report without uploading it, write it to a file:
+
+```bash
+limacharlie cloudsec code scan . \
+  --repo acme/api \
+  -o lc-code-report.json.gz
+```
+
+The output is a gzipped LimaCharlie `report/v1` document. A scan must use either
+`--ingest`, `-o`, or both, so a completed scan never discards its only copy of
+the report.
+
+!!! info "Secret scanning uses the hosted lane"
+    Local scans do not accept the `secrets` or `secrets_history` scanners.
+    Secret findings require identity data held by the hosted service to merge
+    safely. Use hosted scanning for credentials and secret history.
+
+## Push an existing scanner result
+
+Use `code ingest` when another tool already produced the result. The command
+accepts:
+
+- `sarif` for a SARIF results document;
+- `cyclonedx` for a CycloneDX bill of materials; or
+- `report` for a LimaCharlie `report/v1` document produced by `code scan`.
+
+For example, push a SARIF file from the current commit:
+
+```bash
+limacharlie --output yaml cloudsec code ingest \
+  --repo acme/api \
+  --source sarif \
+  --file trivy.sarif \
+  --commit "$(git rev-parse HEAD)" \
+  --ref "$(git branch --show-current)"
+```
+
+Or push an existing CycloneDX SBOM:
+
+```bash
+limacharlie --output yaml cloudsec code ingest \
+  --repo acme/api \
+  --source cyclonedx \
+  --file sbom.cdx.json \
+  --commit "$(git rev-parse HEAD)"
+```
+
+Files ending in `.gz` stay compressed in transit. A document can be up to 20
+MiB; narrow the scan or split it into separate documents if it exceeds that
+limit.
+
+A pushed repository does not need to come from a connected source-control
+organization. The push creates the repository entry with only the facts the
+document supplies. In that case, also pass `--default-branch` because no
+provider connection can supply it:
+
+```bash
+limacharlie --output yaml cloudsec code ingest \
+  --repo acme/private-api \
+  --source sarif \
+  --file results.sarif \
+  --default-branch main \
+  --commit "$COMMIT_SHA"
+```
+
+The repository must still match an enabled code-scanning policy and counts
+toward the same repository quota as a connected repository.
+
+## Run on every GitHub push
+
+Store the organization UUID as the `LC_OID` Actions secret and a least-privilege
+organization API key as `LC_API_KEY`. Then add
+`.github/workflows/limacharlie-code-scan.yml` to the repository:
+
+```yaml
+name: LimaCharlie code scan
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install LimaCharlie CLI
+        run: pip install --upgrade limacharlie
+
+      - name: Scan and push results
+        env:
+          LC_API_KEY: ${{ secrets.LC_API_KEY }}
+          LC_OID: ${{ secrets.LC_OID }}
+        run: |
+          limacharlie --output yaml cloudsec code scan . \
+            --repo "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --ref "$GITHUB_REF" \
+            --ingest
+```
+
+The workflow grants GitHub only read access to repository contents. The
+LimaCharlie key controls the upload and should contain only the permissions
+listed in [Before you begin](#before-you-begin).
+
+If your existing scanner produces SARIF, replace the final step with that
+scanner followed by `cloudsec code ingest`. For example:
+
+```yaml
+      - name: Push SARIF results
+        env:
+          LC_API_KEY: ${{ secrets.LC_API_KEY }}
+          LC_OID: ${{ secrets.LC_OID }}
+        run: |
+          limacharlie --output yaml cloudsec code ingest \
+            --repo "$GITHUB_REPOSITORY" \
+            --source sarif \
+            --file results.sarif \
+            --commit "$GITHUB_SHA" \
+            --ref "$GITHUB_REF"
+```
+
+## Review the result
+
+Confirm that Cloud Security recorded the repository:
+
+```bash
+limacharlie --output yaml cloudsec code repos -q acme/api
+```
+
+Then list its open pushed findings:
+
+```bash
+limacharlie --output yaml cloudsec finding list \
+  --repo acme/api \
+  --source ingest \
+  --status open
+```
+
+Repository rows identify their source as `ingest`, `hosted`, or `both`.
+Pushed findings use the same triage, ownership, Cases, Outputs, and automation
+as hosted findings.
+
+Pushing the same document again is idempotent. When a newer document omits a
+finding previously reported by that pushed source, Cloud Security closes that
+finding. A pushed document never closes a finding owned by the hosted scanner.
+The ingest response also contains `notes` for results it could not safely
+import; for example, credential findings from third-party documents are
+deliberately skipped.
+
+## Troubleshooting
+
+| Problem | What to check |
+|---|---|
+| `No such command 'scan'` or `No such command 'ingest'` | Upgrade to a CLI release newer than 5.6.2. |
+| The CLI cannot identify the repository | Pass `--repo <owner>/<repository>` explicitly. |
+| Docker is not found | Install and start Docker, or upload a document produced by an existing scanner with `code ingest`. |
+| The repository is not recorded | Confirm that the repository matches an enabled code-scanning policy and is within the organization's repository quota. |
+| The document is rejected as too large | Keep it below 20 MiB by narrowing the scan or splitting independent results into separate documents. |
+| Secret results do not appear | Use hosted secret scanning; local and third-party secret findings are intentionally not ingested. |

--- a/docs/cloud-security/code-scanning.md
+++ b/docs/cloud-security/code-scanning.md
@@ -13,9 +13,9 @@ when you want scan feedback on every push instead of waiting for a scheduled
 hosted scan.
 
 !!! note "CLI version"
-    The `cloudsec code scan` and `cloudsec code ingest` commands were added
-    after CLI 5.6.2. They require the first `limacharlie` release newer than
-    5.6.2. Check your installation before using the examples:
+    The `cloudsec code` commands used on this page were added after CLI 5.6.2.
+    They require the first `limacharlie` release newer than 5.6.2. Check your
+    installation before using the examples:
 
     ```bash
     limacharlie --version
@@ -36,6 +36,12 @@ You need:
 Authenticate interactively with `limacharlie auth login`, or set `LC_OID` and
 `LC_API_KEY` in CI. Create and scope organization API keys as described in
 [API Keys](../7-administration/access/api-keys.md).
+
+To configure the required policy in the console, open **Cloud Security →
+Policies → Code scanning**, turn on **Enable code scanning**, and add the
+repository's `<owner>/<repository>` name under **Include**. Select at least one
+hosted scanning engine, then save the policy. The policy can select a repository
+even when it does not come from a connected source-control organization.
 
 Repository names use the `<owner>/<repository>` form, for example `acme/api`.
 If a checkout has a hosted Git remote, the local scan command can infer this
@@ -233,7 +239,7 @@ deliberately skipped.
 
 | Problem | What to check |
 |---|---|
-| `No such command 'scan'` or `No such command 'ingest'` | Upgrade to a CLI release newer than 5.6.2. |
+| A `cloudsec code` command is missing | Upgrade to a CLI release newer than 5.6.2. |
 | The CLI cannot identify the repository | Pass `--repo <owner>/<repository>` explicitly. |
 | Docker is not found | Install and start Docker, or upload a document produced by an existing scanner with `code ingest`. |
 | The repository is not recorded | Confirm that the repository matches an enabled code-scanning policy and is within the organization's repository quota. |

--- a/docs/cloud-security/index.md
+++ b/docs/cloud-security/index.md
@@ -26,6 +26,7 @@ rules, Cases, and Outputs you already use.
 | **CAASM** | A merged third-party asset inventory (EDR / IdP / MDM / scanner sources, including LimaCharlie's own sensors) with coverage-gap and device-posture findings — "seen by the identity provider, no EDR". |
 | **Security graph & topology** | An explorable graph of resources, identities, and their relationships (`can_reach`, `exposed_to`, `has_permission_on`, `can_assume`, …) plus an aggregated estate topology view, with a query language and saved queries. |
 | **Runtime fusion** | Bidirectional resolution between LimaCharlie sensors and the cloud assets they run on — pivot from a cloud finding to the live endpoint and back. |
+| **Code security** | Scan connected repositories in the hosted service, run the LimaCharlie scanner inside your own environment, or push existing SARIF and CycloneDX results into the same findings worklist. |
 | **Your own detections** | Author your own CSPM rules — in the same detection format as the built-in pack — and disable, re-severity, or replace any built-in rule for your organization. |
 | **Remediation SLAs** | Declare how long a finding may stay open, per severity, class, account, or owner, and work the worklist by deadline as well as by risk. |
 | **MSSP fleet** | A cross-tenant fleet board that rolls up risk across every organization you manage. |
@@ -84,6 +85,7 @@ map onto the capabilities above:
 | **Attack Surface** | The toxic-combination paths, grouped by shared fix, on an interactive graph canvas — plus a **Query console** tab for ad-hoc graph queries and saved queries. |
 | **Identity & Access** | CIEM — who can reach what, with a per-identity drill-down (**Grants** and **Access map** tabs). |
 | **Data Security** | DSPM — data-store posture and exposure. |
+| **Code** | Repository scan status, code findings, SBOM downloads, and results from hosted or customer-run scanners. |
 | **Inventory** | The estate itself, in four views: **Topology** (the landing view — an aggregated diagram of the estate), **Resources** (the resource system-of-record), **Third-party assets**, and **Sensor coverage** (CAASM). |
 | **Compliance** | Per-control framework assessment and scoped assignments. |
 | **Report** | A print-optimized posture report over the current estate, also reachable from **Overview → View report**. |
@@ -118,6 +120,8 @@ organization you manage.
   provider, run your first sweep.
 - [Connecting Providers](providers.md) — the thirteen connectors, their
   credentials, and what each collects.
+- [Code Scanning & Pushed Results](code-scanning.md) — scan a local checkout,
+  ingest SARIF or CycloneDX, and run the workflow in GitHub Actions.
 - [Provider Setup](provider-setup/index.md) — onboarding walkthrough for every
   platform: exact scopes, how to create the credential, credential-secret
   formats, and first-run troubleshooting.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -592,6 +592,7 @@ nav:
       - Overview: cloud-security/index.md
       - Getting Started: cloud-security/getting-started.md
       - Connecting Providers: cloud-security/providers.md
+      - Code Scanning & Pushed Results: cloud-security/code-scanning.md
       - Provider Setup:
           - Overview: cloud-security/provider-setup/index.md
           - Google Cloud: cloud-security/provider-setup/gcp.md


### PR DESCRIPTION
## Summary

- add a customer-facing guide for local code scans and SARIF/CycloneDX ingestion
- include complete GitHub Actions examples, result semantics, and troubleshooting
- link the guide from the Cloud Security overview, CLI reference, and navigation

## Release dependency

The public CLI implementation is merged, but `cloudsec code scan` and `cloudsec code ingest` are newer than the latest released CLI (5.6.2). This PR is intentionally a draft until the next CLI release is available. The guide calls out that version requirement explicitly and was validated against the public `python-limacharlie` command definitions.

## Validation

- `mkdocs build --strict`
- `npx --yes markdownlint-cli2@0.19.0 docs/cloud-security/code-scanning.md docs/cloud-security/index.md docs/cloud-security/cli.md`
- `pytest tests/ -q` (210 passed)