### PR TITLE
Add the Email Security product documentation section

### DIFF
--- a/docs/email-security/ai-triage.md
+++ b/docs/email-security/ai-triage.md
@@ -1,16 +1,6 @@
 # AI Triage
 
-!!! warning "Private beta"
-    Email Security is in **private beta**. It is not generally available, and
-    access is enabled per organization — if the `ext-email-security` extension
-    is not in your catalog, this product is not turned on for you yet.
-
-    While it is in beta, expect the surface described here to move: commands,
-    fields and event shapes may change between releases, and they may change in
-    ways that are not backwards compatible. Pin a CLI version if you script
-    against it, and re-read this page after upgrading.
-
-    Talk to us before relying on it in production.
+--8<-- "includes/email-security-beta.md"
 
 Email Security produces an explainable verdict for every message. AI triage is the
 optional second pass: an agent that reads the message the way an analyst would, looks up

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -1,0 +1,112 @@
+# API Reference
+
+--8<-- "includes/email-security-beta.md"
+
+All Email Security routes live under
+`https://api.limacharlie.io/v1/mailsec/{oid}/…` and appear in the public OpenAPI
+spec at [`/openapi`](https://api.limacharlie.io/openapi). Authentication is the
+standard `Authorization: Bearer <JWT>` header.
+
+!!! info "Permissions & enable gate"
+    Every route requires the organization to be subscribed to
+    `ext-email-security` — a `403` on any route means subscribe first. The `oid`
+    is always taken from the authorized path.
+
+    Reads and the read-only `POST`s (`analyze`, `rules/validate`,
+    `rules/backtest`) require `mailsec.get`. Resolving a report requires
+    `mailsec.set`. Anything that touches live mail — the action routes and the
+    connection test — requires `mailsec.act`. Downloading raw message bytes
+    requires `mailsec.get` **and** `mailsec.get.eml`.
+
+    Connections, policy and custom rules are **not** `/mailsec` routes: their CRUD
+    goes through Hive (`mailsec_provider`, `mailsec_policy`, `dr-mail`).
+
+Shared behaviours:
+
+- **Repeatable filters** are passed as repeated query keys —
+  `?verdict=malicious&verdict=suspicious`. OR within a key, AND across keys.
+- **Boolean selectors are tri-state.** An absent parameter means "not filtered",
+  which is *not* the same as passing `false`.
+- **Keyset pagination.** Pages carry `next_cursor`; pass it back as `?cursor=`.
+  An empty `next_cursor` is the last page. A cursor is **bound to the filter set
+  that minted it** — changing a filter mid-walk fails the next page rather than
+  resuming at a position that means something else. Restart the walk.
+- **Times** are RFC3339 or unix seconds on input.
+- **A miss is not an error.** An unknown or expired message, campaign or report
+  id returns a null object rather than a `404`: the index has a 35-day retention
+  and a miss is a normal outcome.
+
+## Reads
+
+| Route | Returns |
+|---|---|
+| `GET /coverage` | Mailboxes discovered / protected / excluded / in error, message volume and the verdict funnel over the window, the parse-degradation rate, backfill progress, the emission backlog, per-connection health, and the `overview` block (open reports, active campaigns, resolved automation mode). Params: `since`, `until`. With no window the default period is served from a short-lived server-side memo; naming an explicit range always computes that exact range |
+| `GET /messages` | `{messages, next_cursor}` — the message index. Filters: `mailbox`, `sender_email`, `sender_root_domain`, `campaign_id`, `link_domain`, `attachment_sha256`, `verdict[]`, `state[]`, `direction[]`, `user_reported`, `min_score`, `q`, `since`, `until`, `cursor`, `limit` |
+| `GET /messages/{msg_uuid}` | `{message, mdm, mdm_source}` — the index row, the full signal rationale, the action timeline, and the Message Data Model. `mdm_source` is `stored` (the model the collector judged with, enrichments included) or `eml_reparse` (a fresh parse of the original bytes, no enrichments). `mdm_unavailable_reason` replaces the model when neither is available |
+| `GET /messages/{msg_uuid}/similar` | `{messages, since}` — recent messages sharing at least one clustering key, each with the `matched_keys` that matched, plus the lookback window that was searched. Candidates, not a cluster |
+| `GET /campaigns` | `{campaigns, next_cursor}`. Filters: `state[]`, `verdict[]`, `min_members`, `since`, `until`, `cursor`, `limit` |
+| `GET /campaigns/{campaign_id}` | `{campaign}` — span, membership, verdict, and the keys that bound the messages together |
+| `GET /reports` | The user-report queue. Params: `status[]` (`open`, `triaging`, `resolved`), `oldest_first`, `cursor`, `limit` |
+| `GET /reports/{report_id}` | One report: who reported it, the message they reported, the original once located across the tenant's mailboxes, and its triage state |
+| `GET /senders/{key}` | The accumulated profile for one correspondent. `key` is qualified (`email:someone@corp.example` or `domain:corp.example`) or a bare address or domain. A key with no profile says so explicitly rather than returning a zeroed profile |
+| `GET /actions/{action_id}` | `{action}` — one audit entry expanded, **including the JSON request payload the message timeline omits**. For a raw-message download that payload carries the access justification. Gated on `mailsec.get`: reading who did what to a message is part of reading the product |
+| `GET /onboarding` | `{scopes, steps, script}` — the setup steps, OAuth scopes and `gcloud` commands for connecting a tenant, for rendering in a setup flow. Each step carries a `console` and, where verifiable, a `verified_by` naming the connection-test check that proves it. Params: `provider` (`gworkspace` default, or `m365`), `project_id`, `sa_email`, `topic`, `subscription` — supply them and the commands come back ready to run rather than templated |
+
+### `GET /messages/{msg_uuid}/eml`
+
+The justified raw download. Requires `mailsec.get` **and** `mailsec.get.eml`, and
+the `justification` query parameter is **required**.
+
+| Param | |
+|---|---|
+| `justification` | Why these bytes are being accessed. Recorded against your authenticated identity in the organization's action audit and retained for 400 days — a failed attempt is recorded too. Stored verbatim; the backend enforces a minimum and a maximum length and refuses an over-long reason rather than truncating |
+
+Raw copies expire 35 days after delivery (longer for flagged messages), after
+which this returns a typed expiry error while the index row stays readable.
+
+## Writes
+
+| Route | Does |
+|---|---|
+| `POST /messages/{msg_uuid}/actions` | Perform a typed action on one message. Body: `action` (`quarantine_message`, `trash_message`, `move_to_spam`, `restore_message`, `banner_message`, `unbanner_message`), optional `reason`, optional `attempt` (idempotency token — omit to collapse onto the existing attempt), optional `banner` (the banner HTML). Requires `mailsec.act` |
+| `POST /campaigns/{campaign_id}/actions` | Sweep a campaign. Same body plus `confirm`. **Without `confirm` this previews** and changes nothing, returning the member ids, the distinct mailboxes, the counts and a `confirm` token derived from that exact member set. With `confirm` it executes exactly that set; a campaign that grew since the preview is refused. Capped at 500 members. Requires `mailsec.act` |
+| `POST /reports/{report_id}/resolve` | Record a triage outcome. Body: `disposition` — one of `true_positive`, `false_positive`, `benign`. Resolving an already-resolved report succeeds and reports `already_resolved`, so two analysts clicking at once is not an error. Requires `mailsec.set` |
+| `POST /connections/{record}/test` | Probe a configured connection and report each requirement independently: the credential, each scope, a real directory read, and — for Google Workspace — the notification subscription and topic. Every check carries `id`, `name`, `required`, `status`, and on failure `detail` and `remediation`. A failed **optional** check leaves `ok` true. Body: `include_watch` (Workspace only; the one probe with a side effect — it establishes an idempotent, self-expiring push watch). Takes a **record name, not a credential**. Requires `mailsec.act` |
+
+### Read-only `POST`s
+
+| Route | Does |
+|---|---|
+| `POST /analyze` | Parse a raw message into the Message Data Model and judge it with the packaged rules against default policy. **Nothing is ingested or stored**: no index row is written, no raw copy kept, and the organization's mail history is unchanged. Body: `eml_b64` (preferred) or `eml`, plus optional `org_domains` and `direction`. Tenant context it cannot have — your sender history, your VIP list — is named explicitly in the payload rather than silently missing. Requires `mailsec.get` |
+| `POST /rules/validate` | Compile a candidate `dr-mail` rule and report its errors without saving it. Body: `rule` (object), optional `rule_id`. Runs the **same** validation the `dr-mail` Hive applies on save, so a rule this accepts is a rule that will save. An invalid rule is a `200` carrying `valid: false` and the reason, not an error response. Requires `mailsec.get` |
+| `POST /rules/backtest` | Replay a candidate rule over the organization's indexed message window and report what it would have matched. Body: `rule`, optional `rule_id`, `since`, `until`. Every response carries a `coverage_note` and counts what it could not examine (`skipped_no_raw`, `skipped_unparse`, `truncated`). `precision` is `null` — not `0` — when nothing it matched has an analyst disposition yet. Requires `mailsec.get` |
+
+## Action results
+
+Action routes report the outcome honestly rather than flattening it into
+success/failure:
+
+| `result` | Meaning |
+|---|---|
+| `ok` | The provider was changed |
+| `skipped` | The desired state already held; no provider write happened |
+| `alert_only` | Decided and deliberately not performed, because the organization is not in enforce mode. **Not an error** |
+| `failed` | The provider refused or errored; `error` carries the reason |
+| `pending` | In flight |
+
+A campaign sweep returns `attempted`, `succeeded`, `alert_only` and a per-member
+`failed` map. It does not abort on the first error.
+
+## Attribution
+
+`actor` and `source` on every audit row are stamped by the server from the
+caller's verified claims — a user token keeps its stable user id, and an
+authorized organization API key is attributed as `api-key:<key-id>`. A request
+body **cannot** supply `by`, `actor` or `source`: an audit trail is only worth
+having if it names who really asked.
+
+## SDK and CLI
+
+The Python SDK exposes the same surface, and the CLI wraps it — see
+[Command Line Interface](cli.md). Both are generated against these routes, so
+anything documented here is reachable from either.

--- a/docs/email-security/automation.md
+++ b/docs/email-security/automation.md
@@ -1,0 +1,171 @@
+# Events & Automation
+
+--8<-- "includes/email-security-beta.md"
+
+Email Security is not a side-car product with its own event bus. Everything it
+sees becomes ordinary LimaCharlie telemetry, in the same lake as your endpoint,
+cloud and identity data — which is what makes "a phish was delivered, and then
+that user's endpoint ran a new binary" one rule instead of two products and a
+spreadsheet.
+
+## The sensor
+
+Each mail connection appears as **one cloud sensor** on platform `email`. The
+mailbox is a field on the event, not an identity: a ten-thousand-mailbox tenant
+is one sensor, not ten thousand.
+
+## The events
+
+| Event | Emitted when |
+|---|---|
+| `EMAIL_MESSAGE` | Once per message, at ingest. Carries the whole parsed model — headers, sender, recipients, body, links, attachments, authentication, hops — plus the enrichments and the verdict. It is the record that this mail arrived |
+| `EMAIL_ACTION` | On every remediation outcome, including failures and skips. Who asked, what was attempted, what happened |
+| `EMAIL_USER_REPORT` | When a message reaches the abuse mailbox and becomes a report |
+| `EMAIL_INGEST_ERROR` | When a message could not be fetched or processed. Coverage honesty: failures are visible, never silent |
+
+`EMAIL_MESSAGE` is emitted once and is immutable.
+
+!!! info "Everything the rule needs is in the event"
+    The verdict, the top signals and the enrichments the pipeline resolved are
+    all *in* `EMAIL_MESSAGE`. A rule never has to call back for enrichment, and a
+    replay of the event sees exactly what the pipeline saw.
+
+Events arrive on the **default D&R target**, so a rule matching them needs no
+`target:` line.
+
+## Acting on mail from a D&R rule
+
+```yaml
+# Detect
+op: and
+rules:
+  - op: is
+    path: routing/event_type
+    value: EMAIL_MESSAGE
+  - op: is
+    path: event/verdict/verdict
+    value: malicious
+  - op: is
+    path: event/direction
+    value: inbound
+```
+
+```yaml
+# Respond
+- action: report
+  name: email-malicious-delivered
+- action: extension request
+  extension name: ext-email-security
+  extension action: quarantine_message
+  extension request:
+    msg_uuid: '{{ .event.msg_uuid }}'
+```
+
+The typed actions available to `extension request` are the same six the console
+and the CLI use: `quarantine_message`, `trash_message`, `move_to_spam`,
+`restore_message`, `banner_message`, `unbanner_message`. They route to the same
+executor, so the organization's `alert_only` / `enforce` mode, the audit row and
+idempotency all apply unchanged — there is exactly one remediation path in this
+product.
+
+Actions dispatched this way are attributed with `source: dr` in the audit trail.
+
+!!! tip "Which seat should this rule sit in?"
+    A rule that should **change the verdict** belongs in `dr-mail` as a
+    `pre_verdict` signal — see [Custom Rules](custom-rules.md). A rule that
+    should **do something once the verdict exists** can sit in either seat: in
+    `dr-mail` as `post_verdict` if it only needs mail actions, or here as an
+    ordinary D&R rule if it needs the platform's full response arsenal, Outputs,
+    Cases, or correlation with non-mail telemetry.
+
+## Reacting to a user report
+
+```yaml
+# Detect
+op: is
+path: routing/event_type
+value: EMAIL_USER_REPORT
+```
+
+```yaml
+# Respond
+- action: report
+  name: user-reported-phish
+  priority: 3
+```
+
+From there the detection flows into Cases, Outputs and everything else that
+consumes detections. A report is the highest-signal thing your users will ever
+hand you, so treating it as a first-class detection is usually right.
+
+## Watching your own coverage
+
+`EMAIL_INGEST_ERROR` is the event to alert on. A mail security product that
+quietly stops seeing a mailbox is worse than one that is visibly down, so
+failures are emitted rather than swallowed:
+
+```yaml
+op: is
+path: routing/event_type
+value: EMAIL_INGEST_ERROR
+```
+
+Pair it with the `coverage` call, which reports mailboxes in `error`, the
+parse-degradation rate and the emission backlog. See
+[Getting Started](getting-started.md#6-watch-coverage-fill-in).
+
+## Querying mail with LCQL
+
+`EMAIL_*` events are queryable like any other telemetry in the Query Console and
+through `limacharlie search`, over the platform's normal retention rather than
+the 35-day product index. That makes it the right tool for questions that reach
+further back than the queue does.
+
+Use `limacharlie ai generate-query` to build the query and
+`limacharlie search validate` before running it — LCQL is validated against
+org-specific schemas and hand-written queries fail or mislead. See
+[Data & Queries](../4-data-queries/index.md).
+
+For the everyday "who else got this" question, the
+[message index pivots](messages.md#the-two-ioc-pivots) are faster and are
+purpose-built.
+
+## Outputs
+
+Because the events are ordinary telemetry, every
+[Output](../5-integrations/outputs/index.md) works without any mail-specific
+configuration: stream `EMAIL_MESSAGE` to a data lake, forward detections to a
+SIEM, or push `EMAIL_ACTION` into an audit pipeline.
+
+## Configuration as code
+
+Every piece of Email Security configuration is a Hive record, so a tenant's whole
+mail posture is a directory of YAML:
+
+| Hive | Holds |
+|---|---|
+| `secret` | The provider credential |
+| `mailsec_provider` | The connection |
+| `mailsec_policy` | Automations, exclusions, VIPs, thresholds, banners, retention, reporter replies |
+| `dr-mail` | Custom mail rules |
+| `lookup` | VIP lists referenced by `vips.list_refs` |
+| `dr-general` | The D&R rules on `EMAIL_*` events |
+
+```bash
+limacharlie hive set --hive-name mailsec_policy --key 50-finance-vips \
+  --input-file policy/50-finance-vips.yaml --enabled --oid $OID
+
+limacharlie hive list --hive-name mailsec_policy --oid $OID --output yaml
+limacharlie hive get  --hive-name mailsec_policy --key 50-finance-vips --oid $OID
+```
+
+Two conventions make this pleasant to keep in git:
+
+- **Records compose in name order**, so number your records (`00-baseline`,
+  `50-team-x`, `99-override`) when precedence matters.
+- **Unknown fields are refused**, so a typo fails the write rather than silently
+  disabling a control. Validate a rule with `limacharlie hive validate` or
+  `limacharlie mailsec rule validate` before committing it.
+
+Onboarding a new tenant is then: subscribe the extension, write the secret, write
+the provider record, apply the policy directory, run the connection test.

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -1,0 +1,140 @@
+# Campaigns
+
+--8<-- "includes/email-security-beta.md"
+
+An attack that reached forty mailboxes is one thing that happened, not forty. A
+campaign is the cluster of messages the engine attributed to one attack, so it is
+triaged once and remediated once.
+
+## How clustering works
+
+Every message contributes cluster keys at ingest time:
+
+| Key | How it is built |
+|---|---|
+| **Normalized subject** | Lowercased, reply/forward prefixes stripped (`Re:`, `Fwd:`, `AW:`, `SV:` …), then the parts an attacker varies per recipient collapsed — runs of two or more digits, UUIDs and long hex tokens all fold to a placeholder. "Invoice 88213" and "Invoice 88214" are one campaign, and a key that distinguished them would defeat the feature |
+| **Link root domains** | The sorted, deduplicated set of *registrable* root domains the message links to, fingerprinted. Root domains rather than URLs, because a phishing kit gives every recipient a unique path or tracking parameter while the domain is what the attacker had to register. Sorting means link order, which varies with templating, cannot split one campaign in two |
+| **Attachment hashes** | The set of attachment SHA-256s |
+
+A message **joins an open campaign when at least two keys agree** with a
+candidate. One key is too easy to hit by accident — two unrelated messages with
+the same generic subject are not a campaign — and requiring three would miss real
+campaigns that vary one dimension deliberately.
+
+An **empty key never matches**. Two messages with no subject, or with no links,
+are not evidence of anything, and treating empty as agreement would cluster the
+whole tenant into one campaign.
+
+!!! note "Body similarity is not currently a clustering key"
+    Near-identical bodies do not group on their own. Two messages that differ
+    only in wording, with different links and no attachments, will not cluster.
+    That is the conservative failure and the deliberate one — the alternative
+    collapses every body-less message into one cluster.
+
+Candidates are considered newest first, bounded, and the first one reaching the
+threshold wins. Joining an existing campaign always beats seeding a new one.
+
+Campaigns close after **72 hours of silence**. Only open campaigns absorb new
+members, so an attacker re-using a subject three months later starts a new
+campaign rather than resurrecting an old one.
+
+A campaign's verdict is the strongest verdict among its members.
+
+## Working campaigns
+
+```bash
+limacharlie mailsec campaign list --min-members 3 --oid $OID
+limacharlie mailsec campaign get <campaign_id> --oid $OID
+```
+
+Filters: `state` (`open`, `closed`), `verdict`, `min_members`, `since`/`until`,
+all repeatable where it makes sense and keyset-paginated like every other list.
+
+The detail view gives the campaign's span, its membership, its verdict and the
+keys that bound its messages together. From a message, `campaign_id` is on the
+index row; from a campaign, `message list --campaign-id` gives the members.
+
+In the console, **Campaigns** has the list, the detail, and the sweep controls.
+
+## Sweeping a campaign
+
+A campaign-wide action applies a **per-message action** to every member:
+`quarantine_message`, `trash_message` or `restore_message`. Three protections
+apply, and none of them is optional.
+
+### 1. Preview, then confirm
+
+A sweep with no confirmation token **changes nothing**. It returns exactly what
+it would do — the member ids, the distinct mailboxes affected, and the counts —
+plus a `confirm` token.
+
+```bash
+# Preview. Nothing is touched.
+limacharlie mailsec campaign action <campaign_id> \
+  --action quarantine_message --oid $OID --output yaml
+```
+
+```yaml
+preview: true
+campaign_id: <campaign_id>
+action: quarantine_message
+member_count: 38
+mailbox_count: 31
+confirm: <token>
+```
+
+`mailbox_count` is the number that matters. "38 messages" and "31 people's
+inboxes" feel very different, and only one of them is the real blast radius.
+
+```bash
+# Execute exactly the set the preview described.
+limacharlie mailsec campaign action <campaign_id> \
+  --action quarantine_message --confirm "<token>" --oid $OID
+```
+
+!!! warning "The token is derived from the member set, not from the campaign id"
+    Passing the campaign id as `--confirm` is **refused**. The token is a
+    function of the exact members the preview showed you, so a campaign that
+    absorbed new messages while you were reading the preview fails the
+    confirmation rather than sweeping a set nobody approved. Re-run the preview
+    and confirm the current set.
+
+### 2. A cap
+
+A sweep refuses outright above **500 members** rather than asking again. An
+operator confirming a four-thousand-message sweep from a dialog has not really
+consented to four thousand mailboxes changing; that needs a person deciding.
+
+### 3. The executor still decides
+
+Every member goes through the same remediation path as a single-message action,
+so `alert_only`, the audit row and idempotency all apply unchanged. A sweep is
+many ordinary actions, never a bulk write that skips them.
+
+Members are routed **per message**, so a campaign that spans a Microsoft 365
+connection and a Google Workspace connection sweeps correctly across both.
+
+### The result
+
+```yaml
+campaign_id: <campaign_id>
+action: quarantine_message
+attempted: 38
+succeeded: 36
+alert_only: 0
+failed:
+  <msg_uuid>: "<provider error>"
+```
+
+A sweep does **not** abort on the first error. Stopping halfway leaves a campaign
+half-remediated, which is the worst of both states: the attacker still has reach
+and the operator believes it is handled. Every member is attempted and every
+failure is named.
+
+Re-running a sweep is idempotent per message and action, so clicking twice does
+not produce two audit rows claiming two quarantines.
+
+## Permissions
+
+Previewing needs `mailsec.act`, the same as executing — a preview reaches the
+collector and enumerates members. Reading campaigns needs only `mailsec.get`.

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -1,22 +1,12 @@
 # Command Line Interface
 
-!!! warning "Private beta"
-    Email Security is in **private beta**. It is not generally available, and
-    access is enabled per organization — if the `ext-email-security` extension
-    is not in your catalog, this product is not turned on for you yet.
+--8<-- "includes/email-security-beta.md"
 
-    While it is in beta, expect the surface described here to move: commands,
-    fields and event shapes may change between releases, and they may change in
-    ways that are not backwards compatible. Pin a CLI version if you script
-    against it, and re-read this page after upgrading.
-
-    Talk to us before relying on it in production.
-
-The `limacharlie mailsec` command group covers the whole Email Security API
-surface: the coverage screen, the message index and drawer, the audited raw-EML
-download, campaigns and campaign-wide sweeps, sender profiles, the action audit
-trail, the abuse-mailbox report queue, retro-hunts, custom-rule validation and
-backtest, the connection preflight, and the served onboarding guide.
+The `limacharlie mailsec` command group covers the Email Security API surface:
+the coverage screen, the message index and drawer, the audited raw-EML download,
+campaigns and campaign-wide sweeps, sender profiles, the action audit trail, the
+abuse-mailbox report queue, custom-rule validation and backtest, the connection
+preflight, and the served onboarding guide.
 
 Commands take the global options (`--oid`,
 `--output json|yaml|toon|csv|table|jsonl`, `--filter <jmespath>`,
@@ -35,7 +25,9 @@ limacharlie extension subscribe --name ext-email-security --oid $OID
 
 Provider connections and policy are Hive records — manage them with the
 standard `limacharlie hive` commands (`mailsec_provider`, `mailsec_policy`,
-`dr-mail`). This group is the query, triage and remediation surface.
+`dr-mail`). This group is the query, triage and remediation surface. See
+[Policy Reference](policy.md) for the record contracts and
+[API Reference](api-reference.md) for the routes these commands call.
 
 ## Permissions
 
@@ -45,7 +37,7 @@ trusted with four separable things:
 | Permission | Covers |
 |---|---|
 | `mailsec.get` | Read the product's own view: queue, drawer, campaigns, senders, audit trail |
-| `mailsec.set` | Change detection behaviour and triage state |
+| `mailsec.set` | Change triage state — resolving a user report |
 | `mailsec.act` | Remediate live mail at the provider |
 | `mailsec.get.eml` | Download the original bytes of a message; requires a logged justification |
 
@@ -77,8 +69,8 @@ limacharlie mailsec message action <msg_uuid> --action restore_message
 # Campaigns: one attack, triaged once
 limacharlie mailsec campaign list --min-members 3
 limacharlie mailsec campaign get <campaign_id>
-limacharlie mailsec campaign action <campaign_id> --action quarantine_message           # preview
-limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <campaign_id>
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message              # preview
+limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <token>
 
 # Senders and the audit trail
 limacharlie mailsec sender get cfo@corp.example
@@ -94,11 +86,6 @@ limacharlie mailsec report resolve <report_id> --disposition true_positive
 limacharlie mailsec rule validate --file rule.json --rule-id custom-lookalike
 limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
 
-# Hunts
-limacharlie mailsec hunt create --detect-file detect.json --since 2026-07-01
-limacharlie mailsec hunt get <hunt_id>
-limacharlie mailsec hunt remediate <hunt_id> --action quarantine_message --confirm <hunt_id>
-
 # Analysis and setup
 limacharlie mailsec analyze --file suspect.eml --org-domain corp.example
 limacharlie mailsec connection test gws-exp
@@ -107,16 +94,30 @@ limacharlie mailsec onboarding --provider gworkspace
 
 ## Things worth knowing before you script this
 
-### Actions preview by default
+### Campaign actions preview by default
 
-`campaign action` and `hunt remediate` report what they *would* do and change
-nothing unless you pass `--confirm`. That is deliberate for an operation whose
-blast radius is every mailbox that received an attack.
+`campaign action` reports what it *would* do and changes nothing unless you pass
+`--confirm`. That is deliberate for an operation whose blast radius is every
+mailbox that received an attack.
+
+The preview returns the members, the distinct mailboxes it would touch, and a
+`confirm` **token derived from that exact member set**. Pass the token back —
+**not** the campaign id, which is refused — so a campaign that absorbed new
+members while you were reading the preview fails the confirmation rather than
+sweeping a set nobody approved.
 
 ```bash
-limacharlie mailsec campaign action <campaign_id> --action quarantine_message            # dry run
-limacharlie mailsec campaign action <campaign_id> --action quarantine_message --confirm <campaign_id>
+PREVIEW=$(limacharlie mailsec campaign action "$CAMPAIGN" \
+  --action quarantine_message --output json)
+echo "$PREVIEW" | jq '{member_count, mailbox_count}'
+
+TOKEN=$(echo "$PREVIEW" | jq -r .confirm)
+limacharlie mailsec campaign action "$CAMPAIGN" \
+  --action quarantine_message --confirm "$TOKEN"
 ```
+
+Sweeps are capped at 500 members: above that the answer is a person deciding,
+not a bigger dialog. See [Campaigns](campaigns.md#sweeping-a-campaign).
 
 ### `alert_only` is a success, not a failure
 
@@ -209,8 +210,9 @@ limacharlie mailsec message list \
   --output json --filter 'messages[].{id: msg_uuid, subject: subject}'
 
 # Quarantine every member of a campaign, after reading the preview
-limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message --output yaml
-limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message --confirm "$CAMPAIGN"
+PREVIEW=$(limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message --output json)
+limacharlie mailsec campaign action "$CAMPAIGN" --action quarantine_message \
+  --confirm "$(echo "$PREVIEW" | jq -r .confirm)"
 
 # Resolve the oldest open report
 REPORT=$(limacharlie mailsec report list --status open --oldest-first --limit 1 \

--- a/docs/email-security/custom-rules.md
+++ b/docs/email-security/custom-rules.md
@@ -1,0 +1,186 @@
+# Custom Rules
+
+--8<-- "includes/email-security-beta.md"
+
+Your own mail rules live in the `dr-mail` Hive. They are ordinary D&R detect
+blocks evaluated against the [Message Data Model](detections.md#what-the-rules-can-read),
+and they compound with the managed pack in the same scoring pass — so a custom
+rule is evidence in the same verdict, not a parallel opinion.
+
+## A rule
+
+```yaml
+# hive: dr-mail, record name: custom-vendor-bank-change
+name: Payment-detail change from a first-contact sender
+phase: pre_verdict
+class: signal
+weight: 70
+confidence: 75
+tags: [bec, finance]
+attack_types: [bec]
+fp_notes: >
+  Fires on genuine new vendors during onboarding. Intended to compound with
+  auth failures rather than to stand alone.
+detect:
+  op: and
+  rules:
+    - op: is
+      path: enrichments/sender_profile/prevalence
+      value: none
+    - op: matches
+      path: body/current_thread/text
+      re: "(?i)(bank details|remittance|update our account)"
+```
+
+```bash
+limacharlie hive set --hive-name dr-mail --key custom-vendor-bank-change \
+  --input-file rule.yaml --enabled --oid $OID
+```
+
+### Fields
+
+| Field | Required | Meaning |
+|---|:--:|---|
+| *(record name)* | ✅ | **The record name is the rule id.** It must start with `custom-`, which is what keeps your rules from ever colliding with a packaged one. It is also what an exclusion or a rule override names, which is why the id is the name rather than a field inside the body — a body field could be duplicated across two records |
+| `phase` | ✅ | `pre_verdict` or `post_verdict` — see below |
+| `detect` | ✅ | A standard D&R detect block over the MDM |
+| `class` | — | `signal` (default), `detection` or `graymail` |
+| `weight` | ✅ for `signal` and `detection` | 0–100. Must be **0** for `graymail`, because the graymail lane bypasses the score entirely and a weight there would never be read |
+| `confidence` | — | 0–100, **default 100**. An author who does not express a confidence means "when this fires, it is right" |
+| `respond` | — | `post_verdict` only |
+| `name`, `tags`, `attack_types`, `fp_notes` | — | Documentation and grouping. `fp_notes` is not required of your own rules — that discipline is ours, for the pack we ship |
+
+### The two phases
+
+| Phase | Sees | May do |
+|---|---|---|
+| `pre_verdict` | The message and its enrichments, before the verdict exists | Contribute weighted evidence to the verdict. **No `respond` block** — there is no verdict yet to respond to, and a rule with one is refused |
+| `post_verdict` | The whole message *and* its verdict | `respond` — dispatch a mail action, or raise a detection |
+
+### What a `post_verdict` rule may respond with
+
+| Action | |
+|---|---|
+| `extension request` naming `ext-email-security` | The way a rule reaches remediation. The typed action goes to the same executor every other action uses, which is where `alert_only` / `enforce` is decided |
+| `report` | Raise a detection into the platform's detection stream |
+
+```yaml
+phase: post_verdict
+class: signal
+weight: 1
+detect:
+  op: and
+  rules:
+    - op: is
+      path: verdict/verdict
+      value: malicious
+    - op: is
+      path: mailbox/address
+      value: cfo@corp.example
+respond:
+  - action: extension request
+    extension name: ext-email-security
+    extension action: quarantine_message
+    extension request:
+      msg_uuid: "{{ .msg_uuid }}"
+```
+
+Everything sensor-shaped — task, tag, isolate, seal, re-enroll, set variable —
+**fails loudly** in a mail rule with a message saying so. There is no sensor
+behind a message, and remediation goes through `extension request`.
+
+!!! note "This is the same machinery your automations compile to"
+    A `mailsec_policy/automations` rule is compiled into exactly this shape: a
+    `post_verdict` rule whose respond block is an `extension request` naming the
+    action, bound to the message that matched. Policy is the easy path; a
+    `dr-mail` rule is the escape hatch when your condition does not fit the
+    match fields.
+
+## Validation
+
+A `dr-mail` record is validated at **write time** by compiling it on the real
+engine, so a record that exists has already been proven to compile. Validate a
+candidate before you save it — the check calls the *same* function the Hive runs
+on save, so "valid here" means "savable there":
+
+```bash
+limacharlie mailsec rule validate --file rule.json --rule-id custom-vendor-bank-change --oid $OID
+```
+
+An invalid rule is a **200 carrying `valid: false` and the reason**, not an error
+response: you asked whether the rule is valid and found out that it is not. The
+reason is the validator's own wording, because an author acts on the message and
+not on a status code.
+
+Omitting `--rule-id` validates against a placeholder in the `custom-` namespace,
+so a rule you have not named yet does not fail on its name.
+
+`limacharlie hive validate --hive-name dr-mail --key <name> --input-file rule.yaml`
+performs the same check through the generic Hive path.
+
+### Rules fail loudly, never quietly
+
+A `dr-mail` record that cannot be decoded or converted **fails the whole rule
+load** for that organization rather than being skipped. That is the opposite of
+how a bad *policy* record is handled, and deliberately so: a dropped policy record
+costs one setting, while a dropped rule is a detection the organization believes
+exists and does not — silently reduced protection, which no report after the fact
+undoes.
+
+Records are loaded in record-name order so the rule set is assembled identically
+on every pass, and a **disabled** record is honoured as your own off switch.
+
+## Backtesting
+
+Before you enable a rule, find out what it would have matched.
+
+```bash
+limacharlie mailsec rule backtest --file rule.json --since "$(date -d '14 days ago' +%s)" \
+  --oid $OID --output yaml
+```
+
+The response is deliberately honest about its own limits:
+
+| Field | Meaning |
+|---|---|
+| `coverage_note` | What was actually examined |
+| `skipped_no_raw` | Messages whose raw copy had expired |
+| `skipped_unparse` | Messages that could not be re-parsed |
+| `truncated` | The run hit its bound |
+| `precision` | **`null`, not `0`**, when nothing it matched has an analyst disposition yet |
+
+A precision figure whose denominator quietly shrank is a number that looks like a
+measurement and is not one — hence the skip counts. And `0` would read as
+"everything it matched was wrong" and would have you discard a good rule, so the
+absence of labels is reported as absence.
+
+Backtests are bounded to the window this product retains rather than the full
+message history. Both `rule validate` and `rule backtest` are gated on
+`mailsec.get`: they reveal only messages you can already read, and a rule author
+should be able to check their work with the grant that lets them see what the
+rule would be matching.
+
+## Tuning the managed pack
+
+You do not need a custom rule to change a packaged one. Disable it, or replace
+its weight, for your organization:
+
+```yaml
+policy_type: thresholds
+rule_overrides:
+  ms-link-unranked-domain:
+    weight: 15
+  ms-sender-first-contact:
+    disabled: true
+```
+
+And to suppress a rule for a specific sender, domain or mailbox rather than
+everywhere, use an [exclusion](policy.md#exclusions) — which carries a reason and
+an optional expiry, so the hole in detection is reviewable.
+
+## Rules that act on emitted events
+
+A `dr-mail` rule is one of two seats. The other is an ordinary D&R rule in
+`dr-general` matching the `EMAIL_*` events, which gets the platform's full
+response arsenal and can correlate mail with the rest of your telemetry. See
+[Events & Automation](automation.md).

--- a/docs/email-security/detections.md
+++ b/docs/email-security/detections.md
@@ -1,0 +1,194 @@
+# Detections & Verdicts
+
+--8<-- "includes/email-security-beta.md"
+
+Every message gets exactly one verdict, and the verdict always carries its
+reasons. This page explains how the reasons are produced, what the rules can see,
+and how to tune it.
+
+## The verdict
+
+| Verdict | Meaning |
+|---|---|
+| `malicious` | Score at or above the malicious threshold |
+| `suspicious` | Score at or above the suspicious threshold |
+| `graymail` | Bulk or marketing mail: neither an attack nor wanted |
+| `benign` | Below the suspicious threshold, and nothing said "graymail" |
+| `unknown` | No judgement was reached |
+| `error` | Judging failed |
+
+The verdict object on a message carries:
+
+| Field | Meaning |
+|---|---|
+| `verdict` | The class above |
+| `score` | 0–100 |
+| `top_signals` | Up to five contributing rules, heaviest first, each with `rule_id`, `name` and `weight`. This is the "why this verdict" block |
+| `matched_signals` | Every rule id that matched, including suppressed ones — the hunting surface |
+| `tags` | The deduplicated, sorted tags of the rules that actually contributed |
+| `engine_version` | The rule-pack version that decided it |
+| `decided_at` | When |
+| `mode` | `auto` (the rule pack), `analyst` (a human override) or `ai` |
+| `campaign_id` | The campaign this message was clustered into, if any |
+
+!!! info "A number alone is never the answer"
+    A non-benign verdict always populates `top_signals`. The console renders it
+    as **Why this verdict** in the message drawer, and the API returns it on both
+    the index row (the single heaviest signal) and the detail response (the full
+    list). A score with no explanation would not be actionable and is not
+    offered.
+
+## Scoring
+
+Each matching rule carries a **weight** (0–100, how much this evidence is worth)
+and a **confidence** (0–100, how often it is right when it fires). The score
+combines them with diminishing returns rather than a sum:
+
+```text
+score = 100 × ( 1 − Π (1 − wᵢ/100 × cᵢ/100) )
+```
+
+Each signal removes a fraction of the *remaining* headroom. A sum would let five
+weak signals outscore one strong one and would need clamping at 100, which makes
+every heavily-signalled message look identical. One rule at weight *N* and
+confidence 100 scores exactly *N*, which is the identity every threshold is
+reasoned about against.
+
+| Threshold | Default | Where to change it |
+|---|---|---|
+| `malicious_min` | 85 | [`mailsec_policy/thresholds`](policy.md#thresholds) |
+| `suspicious_min` | 45 | [`mailsec_policy/thresholds`](policy.md#thresholds) |
+
+`malicious_min` must stay above `suspicious_min`. Composed policy that inverts
+the pair is refused, and an inverted pair reaching the scorer any other way falls
+back to the defaults rather than making every suspicious message malicious.
+
+### The graymail lane
+
+Graymail is a **lane, not a score band**. Rules classed `graymail` contribute no
+score at all; they set the verdict to `graymail` only when the score did not
+reach `suspicious_min` **and** no `detection`-class rule fired.
+
+That last clause is the point: a newsletter that also carries a credential-phish
+link is a phish that happens to look like a newsletter, and filing it under
+"marketing" is filing it where nobody looks.
+
+### Exclusions
+
+Exclusions are applied **before** scoring, so a suppressed rule contributes
+nothing to the score and never appears in `top_signals`. It still appears in
+`matched_signals`, so a suppression is auditable rather than invisible.
+
+Exclusions can be scoped by rule id, sender address, sender domain or mailbox,
+require a written reason, and can carry an expiry — after which they become inert
+without anyone deleting them. See
+[Policy Reference → Exclusions](policy.md#exclusions).
+
+## What the rules can read
+
+Rules are standard D&R detect blocks evaluated against the **Message Data
+Model** — the parsed message — plus the enrichments the pipeline stamped onto it.
+Because the enrichments are *in the message*, a rule reads them as ordinary paths
+and a re-evaluation later sees exactly what the pipeline saw.
+
+### The parsed message
+
+`headers` (including the raw header list, decomposed sender and recipient
+addresses, and every domain and IP found), `sender` (with `reply_to_mismatch`,
+free-mail and disposable flags), `recipients`, `subject`, `body` (HTML and plain,
+extracted display text, thread segmentation into the current reply and previous
+quoted threads, hidden-text detection), `links`, `attachments`, `auth` (parsed
+SPF / DKIM / DMARC / ARC results with alignment) and `hops` (the parsed `Received`
+chain).
+
+### Enrichments
+
+| Path | What it carries |
+|---|---|
+| `enrichments/sender_profile` | This organization's history with the sender **address**: `first_seen_ts`, `days_known`, `msg_count_30d`, `flagged_count_180d`, `prevalence` (`none` / `new` / `rare` / `common`) |
+| `enrichments/domain_profile` | The same, keyed on the sender's registrable **domain** |
+| `enrichments/sender_domain` | The sender domain's registration age, from RDAP with a bounded global cache |
+| `enrichments/link_features[]` | Per link, aligned with `links[]`: `domain`, `domain_age_days`, `popularity_bucket` (`top1k` / `top100k` / `top1m` / `unranked`), `in_urlhaus`, `mixed_script` (a homograph label mixing writing systems), `credentials_in_url` (the `https://apple.com@evil.example/` trick) |
+| `enrichments/lookalike` | `vip_hit` (`display_name:<name>` when the display name matches a VIP whose address does not, `email:<addr>` when the sender *is* the VIP), `org_domain_distance` and `brand_domain_distance` — edit distances against your own domains and known brands |
+| `attachments[].explode` | Attachment explosion: recursive `children` with their own names, hashes, magic types and depth; `archive` (`encrypted`, `file_count`, `max_depth_hit`); `vba` (`auto_exec`, `suspicious`, `hex_strings`); `qr[].url`; `ocr_excerpt`; `yara_matches`; the `scanners` that ran |
+
+Attachment explosion is bounded — a per-message time budget and size and event
+caps — and can only ever fail toward "not scanned". `explode.scanners` names what
+actually ran for that attachment, so a rule that depends on a particular kind of
+evidence can tell "the scanner found nothing" from "that scanner did not run".
+
+!!! warning "Absent is not benign"
+    An enrichment that could not be resolved is **absent**, never a reassuring
+    value. `domain_age_days` is missing when the registry lookup was unavailable,
+    rate-limited or a cache miss — which is common — and a
+    newly-registered-domain rule must therefore test *presence* as well as a
+    threshold. Likewise `popularity_bucket` is empty when the lookup did not run,
+    which is a different fact from `unranked`, a positive finding that the domain
+    really is not in the list. A missing lookup must never become a suspicion.
+
+### The sender-history feedback loop, and why it is closed
+
+Sender profiles are read **before** the message is counted, so the stamp answers
+"what did this organization know about this sender *before* this message
+arrived". Counting first would make `msg_count_30d` never zero and first contact
+indistinguishable from second contact.
+
+More importantly, the profile's `flagged_count_180d` counter is only incremented
+for verdicts that flag **independently of prevalence signals**. Rules whose
+evidence *is* the accumulated history carry a `prevalence` tag, and the counter
+is computed with those rules removed.
+
+The reason is a loop observed live before the contract existed: the sender-history
+rule alone can cross the suspicious threshold, and if a flagged verdict fed the
+counter, one false positive would re-flag that sender forever — each flag
+re-incrementing the counter that caused it, never decaying, and in enforce mode
+quarantining a legitimate sender silently. Counting only the independent lane
+makes a history rule an amplifier of *other* evidence and never of itself.
+
+## The managed rule pack
+
+A packaged, versioned set of rules ships with the product and its version is
+stamped into every verdict as `engine_version`. The current pack:
+
+| Rule id | Class | Weight | What it says |
+|---|---|:--:|---|
+| `ms-sender-first-contact` | signal | 30 | First message ever from this sender (`prevalence: none`) |
+| `ms-sender-known-bad-history` | signal | 65 | This sender has been independently flagged before |
+| `ms-sender-domain-newly-registered` | signal | 45 | The sender's domain was registered in the last week |
+| `ms-auth-dmarc-fail` | signal | 50 | DMARC failed |
+| `ms-auth-spf-fail-inbound` | signal | 40 | SPF failed on inbound mail |
+| `ms-impersonation-vip-display-name` | signal | 55 | Display name matches a VIP but the address does not |
+| `ms-impersonation-org-domain-lookalike` | signal | 70 | Sender domain is one or two edits from one of your domains |
+| `ms-impersonation-exact-org-domain-external` | **detection** | 85 | Claims one of your domains but arrived from outside |
+| `ms-impersonation-reply-to-mismatch` | signal | 35 | `Reply-To` points at a different organization than `From` |
+| `ms-link-display-href-mismatch` | signal | 60 | A link's visible text names a different site than its destination |
+| `ms-link-credentials-in-url` | signal | 75 | A link embeds credentials before the host |
+| `ms-link-mixed-script-domain` | **detection** | 80 | A link's domain mixes writing systems within one label |
+| `ms-link-unranked-domain` | signal | 30 | A link points at a domain absent from the top-1M list |
+| `ms-link-known-malicious-url` | **detection** | 95 | A link matches the managed malicious-URL feed |
+| `ms-graymail-list-unsubscribe` | graymail | — | Bulk mail carrying `List-Unsubscribe` |
+| `ms-graymail-precedence-bulk` | graymail | — | The message declares itself bulk |
+
+Rule ids are stable and are never renamed — that is the only reason an exclusion
+or a per-rule override can be persisted at all.
+
+You can disable a packaged rule or replace its weight for your organization
+without forking anything, through
+[`mailsec_policy/thresholds` → `rule_overrides`](policy.md#thresholds).
+
+!!! tip "Judge a message without ingesting it"
+    `POST /mailsec/{oid}/analyze` (`limacharlie mailsec analyze --file
+    suspect.eml`) parses a raw message you supply and runs the enrichers and the
+    packaged rules against default policy. **Nothing is ingested or stored**: no
+    index row is written, no raw copy is kept, and the organization's mail
+    history is unchanged. It is how you test a rule change, or analyze a sample
+    that was never in the tenant. The tenant-specific context it cannot have —
+    your sender history, your VIP list — is named explicitly in the response
+    rather than silently missing.
+
+## Two seats for rules
+
+Signal rules run in the collector, before the verdict is emitted. Platform D&R
+rules run afterwards, on the emitted events, with the whole response arsenal.
+Same syntax, different seat. See [Custom Rules](custom-rules.md) and
+[Events & Automation](automation.md).

--- a/docs/email-security/getting-started.md
+++ b/docs/email-security/getting-started.md
@@ -1,0 +1,228 @@
+# Getting Started with Email Security
+
+--8<-- "includes/email-security-beta.md"
+
+This guide takes an organization from zero to a populated Email Security queue:
+enable the product, connect a mail tenant, verify the connection, and read the
+first judged message. You can do all of it in the console or entirely as code —
+both are shown.
+
+## 1. Enable Email Security
+
+Email Security is enabled per organization by subscribing to the
+`ext-email-security` extension. The subscription is the enable gate: without it
+every `/v1/mailsec/*` route is refused, and the console shows a subscribe screen
+instead of the product.
+
+```bash
+limacharlie extension subscribe --name ext-email-security --oid $OID
+```
+
+Confirm it:
+
+```bash
+limacharlie extension list --oid $OID
+```
+
+Subscribing also seeds the recommended policy records — all in `alert_only`
+mode, so nothing moves mail until you say so. See [Policy Reference](policy.md).
+
+## 2. Grant the permissions
+
+Email Security ships four permissions. A user or API key that will triage mail
+typically needs `mailsec.get`, `mailsec.set` and `mailsec.act`; a read-only
+analyst needs only `mailsec.get`. `mailsec.get.eml` is an escalation on top of
+`mailsec.get` and should be granted deliberately — see
+[Overview → Permissions](index.md#permissions).
+
+Managing the connection itself additionally needs the Hive permissions for
+`mailsec_provider` and `secret`.
+
+## 3. Prepare the provider credential
+
+The credential is created in your mail provider's admin console and stored in
+the LimaCharlie [secret](../7-administration/config-hive/secrets.md) Hive. It is
+always referenced, never inlined into the connection record.
+
+| Provider | What you create | Full walkthrough |
+|---|---|---|
+| Microsoft 365 | An Entra ID app registration with **application** permissions and a client secret | [Microsoft 365](provider-setup/microsoft-365.md) |
+| Google Workspace | A Google Cloud service account with **domain-wide delegation**, plus a Pub/Sub topic and subscription in the same project | [Google Workspace](provider-setup/google-workspace.md) |
+
+!!! tip "The console renders your own setup guide"
+    The setup steps, OAuth scopes and `gcloud` commands are served by the
+    product rather than transcribed here, so they cannot go stale: the
+    connection wizard renders them with **your** project id and service-account
+    address already substituted, and each step names the connection-test check
+    that proves it was done. These pages carry the narrative — what each grant
+    buys and what breaks without it — and the wizard carries the values.
+
+    The same guide is available headless:
+
+    ```bash
+    limacharlie mailsec onboarding --provider gworkspace --oid $OID
+    limacharlie mailsec onboarding --provider m365 --oid $OID
+    ```
+
+## 4. Connect the mail tenant
+
+### In the console
+
+Open **Email Security → Settings** and add a connection. The wizard collects the
+provider, the credential, the mailbox scope and — for Google Workspace — the
+Pub/Sub topic and subscription, shows the personalized setup guide alongside,
+and runs **Test Connection** against the real provider before you finish.
+Failed saves are reported inline on the review step, with the validator's own
+wording rather than a generic error.
+
+Editing an existing connection is patch-preserving: fields the form does not
+manage are left exactly as they were.
+
+### As code
+
+One `mailsec_provider` Hive record per connection. The record's existence (and
+its Hive `enabled` flag) *is* the connection — there is no separate on switch.
+
+```bash
+cat > m365-credential.json <<'JSON'
+{"tenant_id": "<tenant-id>", "client_id": "<application-client-id>", "client_secret": "<the-secret-value>"}
+JSON
+
+limacharlie secret set --key m365-mail \
+  --value "$(cat m365-credential.json)" --enabled --oid $OID
+```
+
+`secret set` wraps the value into the secret record's `{"secret": "..."}`
+envelope for you.
+
+```yaml
+# m365.yaml
+provider: m365
+credentials: hive://secret/m365-mail
+ingest:
+  mode: auto
+  backfill_days: 14
+features:
+  outbound_observation: true
+  reports_mailbox: phishing@corp.example
+```
+
+```bash
+limacharlie hive set --hive-name mailsec_provider --key m365-prod \
+  --input-file m365.yaml --enabled --oid $OID
+```
+
+!!! warning "New Hive records are created disabled"
+    `hive set` creates a record disabled unless you pass `--enabled`. A
+    disabled `mailsec_provider` record is not a connection — nothing is
+    discovered, subscribed or ingested — so a first connection that appears to
+    do nothing is usually this.
+
+The full field reference — scope, ingest modes, features — is in
+[Connecting Providers](providers.md).
+
+## 5. Verify the connection
+
+The connection test uses the credential the only way a credential can be
+verified: by using it. Each requirement is reported independently, so a failure
+names the step to fix rather than saying "connection failed".
+
+```bash
+limacharlie mailsec connection test m365-prod --oid $OID --output yaml
+```
+
+```yaml
+ok: true
+summary: Connection is fully configured.
+checks:
+  - id: credential
+    name: Authenticate to Microsoft Graph
+    required: true
+    status: passed
+  - id: mailbox_read
+    name: List mailboxes in the tenant (24 found)
+    required: true
+    status: passed
+  - id: mail_write
+    name: "Modify mail (Mail.ReadWrite): quarantine, restore, banner"
+    required: true
+    status: passed
+  - id: mail_send
+    name: "Send mail (Mail.Send): reporter auto-replies"
+    required: false
+    status: skipped
+    detail: Mail.Send is not granted; reporter auto-replies will be refused by name until it is
+```
+
+A failed **optional** check is not an error and `ok` stays `true`: a tenant that
+deliberately declined the optional grant has a working connection, and the
+product tells you by name which capability it does not have rather than
+pretending it does. Every failed check carries a `remediation` string naming the
+exact fix.
+
+For Google Workspace, add `--include-watch` to verify notification delivery end
+to end. It is the one probe with a side effect: it establishes a real Gmail
+watch, which is idempotent and expires on its own.
+
+## 6. Watch coverage fill in
+
+```bash
+limacharlie mailsec coverage --oid $OID --output yaml
+```
+
+Coverage is the product's honesty surface. It reports mailboxes in four separate
+states — `protected`, `discovered`, `excluded`, `error` — and never collapses
+them, because a broken subscription hiding behind a deliberate exclusion is
+exactly how a coverage number starts lying. `connections.state` summarizes to
+the **worst** connection, and an organization with no connection at all reads
+`unconfigured`, never `ok`.
+
+The same call reports message volume and the verdict funnel over a window, the
+parse-degradation rate, backfill progress, the emission backlog, open reports,
+active campaigns, and the effective automation mode.
+
+!!! note "Backfill is metadata-only"
+    On connection, the collector walks up to `ingest.backfill_days` (14 by
+    default) of existing mail to seed sender profiles and campaign statistics.
+    It computes **no verdicts and takes no actions** on that history — its
+    purpose is that "we have never heard from this sender" is a true statement
+    on day two instead of day ninety. Progress is reported in `coverage`.
+
+## 7. Read the first judged message
+
+```bash
+limacharlie mailsec message list --oid $OID --limit 10 --output table
+limacharlie mailsec message get <msg_uuid> --oid $OID --output yaml
+```
+
+In the console, **Email Security → Messages** is the queue and the row opens a
+drawer with the verdict, the signals that produced it, authentication results,
+links, attachments, the sender profile, the action timeline and the remediation
+controls. See [Messages & Triage](messages.md).
+
+## 8. Decide whether the product may act
+
+Everything up to here is read-only. Automations ship in `alert_only`, which
+means a rule is evaluated, its intent is recorded, and **the mailbox is not
+touched**. Analyst-initiated actions from the console, CLI or API always execute
+— `alert_only` withholds automation, not people.
+
+Turning enforcement on is a deliberate edit to a `mailsec_policy/automations`
+record. Read [Policy Reference](policy.md#automations) before you do, in
+particular this consequence:
+
+!!! danger "Enforcement is currently an organization-level switch"
+    The remediation executor authorizes automated action when **any** automation
+    rule in the organization is in `enforce` mode. Which rule dispatches an
+    action is still decided per rule, but the executor's consent check is not
+    per rule — so putting one rule into `enforce` enables automated action for
+    the organization's automated paths generally. Enable it when you mean the
+    organization to start moving mail.
+
+## Next steps
+
+- Tune what is judged: [Detections & Verdicts](detections.md)
+- Write your own rules: [Custom Rules](custom-rules.md)
+- Turn the abuse mailbox into an SLA queue: [User Reports](user-reports.md)
+- Correlate mail with the rest of your telemetry:
+  [Events & Automation](automation.md)

--- a/docs/email-security/index.md
+++ b/docs/email-security/index.md
@@ -1,0 +1,112 @@
+# Email Security
+
+--8<-- "includes/email-security-beta.md"
+
+LimaCharlie Email Security protects Microsoft 365 and Google Workspace mailboxes
+from inside the same tenant, permission model, telemetry lake and automation
+surface as the rest of LimaCharlie. It connects to your mail provider's API —
+**no MX change, no mail routing change, nothing in the delivery path** — reads
+every message that arrives, judges it, explains the judgement, and can remediate
+it at the provider.
+
+!!! tip "In one sentence"
+    Connect a mail tenant with an API credential, and every message is parsed,
+    judged with an explainable verdict, indexed for search, and one click (or one
+    D&R rule) away from being quarantined, trashed or bannered — with the whole
+    thing available as events, API and Infrastructure-as-Code.
+
+## What it does
+
+| Capability | What you get |
+|---|---|
+| **Ingestion** | Every delivered message in every protected mailbox, fetched as raw MIME and parsed into a normalized **Message Data Model (MDM)**: headers, decomposed sender and recipients, thread-segmented body, links, attachments, authentication results and the `Received` chain. Sent mail is ingested as observation-only. |
+| **Verdicts** | One explainable verdict per message — `malicious`, `suspicious`, `graymail` or `benign` — from a weighted managed rule pack plus your own rules. Every non-benign verdict carries the signals that produced it and their weights. |
+| **Enrichments** | Sender and sender-domain history, VIP and lookalike-domain impersonation, sender-domain registration age, static link features, and attachment explosion — archives unpacked recursively, macros extracted, embedded QR codes decoded, and files identified by content rather than by the extension the sender claimed. |
+| **Remediation** | Typed, idempotent, audited actions performed at the provider: quarantine, trash, move to spam, restore, apply and remove a warning banner. Available by policy automation, from the console, from a D&R rule, from the API and from the CLI. |
+| **Campaigns** | Messages the engine attributed to one attack are clustered, so a campaign that hit forty mailboxes is triaged once and swept once. |
+| **User reports** | An abuse mailbox becomes an SLA queue: reports are joined back to the original message across the whole tenant, robots that mail the abuse address are auto-resolved out of the queue, and reporters can be sent a templated acknowledgement. |
+| **Telemetry** | `EMAIL_MESSAGE`, `EMAIL_VERDICT`, `EMAIL_ACTION`, `EMAIL_USER_REPORT` and `EMAIL_INGEST_ERROR` land in the same lake as your EDR, cloud and identity telemetry — so "phish delivered, then that user's endpoint ran a new binary" is one D&R rule. |
+| **Configuration as data** | Connections, policy and custom rules are Hive records, so everything is API-first and git-syncable from day one. |
+
+## What it does not do
+
+Stated plainly, because a mail security product's boundaries decide how you
+deploy it:
+
+- **It is post-delivery.** Messages are analyzed after the provider delivers
+  them, typically within seconds. Nothing is held, and mail is never blocked
+  before it lands. Remediation removes a message from the inbox after the fact.
+- **It does not replace your provider's own filtering.** It sits behind Exchange
+  Online Protection / Defender or Gmail's own filters and judges what they let
+  through.
+- **It does not modify mail by default.** Automations ship in `alert_only` mode,
+  banners are off, and reporter replies are off. See
+  [Policy Reference](policy.md).
+
+## How it works
+
+1. **Enable** the organization for the `ext-email-security` extension — the
+   subscription is the product's enable gate, and every `/v1/mailsec/*` route is
+   refused without it.
+2. **Connect a mail tenant**: one `mailsec_provider` Hive record per connection,
+   referencing a credential held in the [secret](../7-administration/config-hive/secrets.md)
+   Hive. A connection test probes every permission the collector needs and
+   reports each one independently. See [Connecting Providers](providers.md).
+3. **Mailboxes are discovered and subscribed.** The collector enumerates the
+   directory, subscribes to change notifications (Microsoft Graph subscriptions,
+   Gmail watch → your own Pub/Sub topic), and runs a metadata-only historical
+   backfill so sender-history signals work on day two rather than day ninety.
+4. **Each message is judged.** Fetch → parse → enrich → evaluate signal rules →
+   score → verdict → campaign clustering → policy automations → persist and emit.
+5. **You work the queue** in **Messages**, **Campaigns** and **User Reports**,
+   or you automate it with policy automations and D&R rules.
+
+## Two seats for rules
+
+This distinction is worth learning early, because it decides where you write
+what:
+
+| | Signal rules | Platform D&R rules |
+|---|---|---|
+| **Where they run** | In the collector, *before* the verdict is emitted | In the platform, on the emitted `EMAIL_*` events |
+| **What they do** | Contribute weighted evidence to the verdict, or dispatch a mail action right after it | The full response arsenal: `report`, `extension request`, `start ai agent`, Outputs, cross-domain correlation |
+| **Where they live** | The `dr-mail` Hive, plus the managed pack | The `dr-general` Hive, like every other detection you write |
+| **Syntax** | Standard D&R detect blocks over the MDM | Standard D&R rules over `EMAIL_*` events |
+
+See [Custom Rules](custom-rules.md) and [Events & Automation](automation.md).
+
+## Permissions
+
+Four permissions rather than the usual get/set pair, because the product asks to
+be trusted with four separable things:
+
+| Permission | Covers |
+|---|---|
+| `mailsec.get` | Read the product's own view: the message queue and drawer, campaigns, sender profiles, the action audit, reports, coverage, rule validation and backtests |
+| `mailsec.set` | Change triage state — resolving a user report |
+| `mailsec.act` | Remediate live mail at the provider, and run the connection test |
+| `mailsec.get.eml` | Download a message's original bytes. Requires `mailsec.get` **as well**, plus a logged justification |
+
+`mailsec.get.eml` is separate on purpose: opening the drawer shows you the
+product's structured view of a message, while downloading the EML takes a
+person's actual mail out of your tenant. Gating them identically would mean
+typing a justification to look at the queue.
+
+Managing connections and policy uses the ordinary Hive permissions for the
+`mailsec_provider`, `mailsec_policy`, `dr-mail`, `secret` and `lookup` hives.
+
+## Where to go next
+
+| | |
+|---|---|
+| [Getting Started](getting-started.md) | Subscribe, connect a tenant, see the first judged message |
+| [Connecting Providers](providers.md) | The connection record, credentials, scope, ingest modes and the connection test |
+| [Microsoft 365](provider-setup/microsoft-365.md) · [Google Workspace](provider-setup/google-workspace.md) | Per-provider setup |
+| [Messages & Triage](messages.md) | The queue, the drawer, actions and the audit trail |
+| [Campaigns](campaigns.md) | Clustering and campaign-wide sweeps |
+| [User Reports](user-reports.md) | The abuse mailbox and the report SLA queue |
+| [Detections & Verdicts](detections.md) | How a verdict is produced, and what the rules can read |
+| [Custom Rules](custom-rules.md) | Writing, validating and backtesting your own mail rules |
+| [Policy Reference](policy.md) | Every `mailsec_policy` record type |
+| [Events & Automation](automation.md) | The `EMAIL_*` events and wiring them to D&R |
+| [Command Line Interface](cli.md) · [API Reference](api-reference.md) | The programmable surface |

--- a/docs/email-security/messages.md
+++ b/docs/email-security/messages.md
@@ -1,0 +1,230 @@
+# Messages & Triage
+
+--8<-- "includes/email-security-beta.md"
+
+**Messages** is the queue: every message the product has seen, filtered down to
+the ones that need a person. This page covers the queue, the drawer, the actions
+and the audit trail they leave.
+
+## The queue
+
+Filtering is **entirely server-side** — every filter below narrows the query in
+the backend, so a filtered page is a statement about your whole mail history, not
+about the rows a browser happened to have loaded.
+
+| Filter | Notes |
+|---|---|
+| `verdict` | Repeatable: `malicious`, `suspicious`, `graymail`, `benign`, `unknown` |
+| `state` | Repeatable: `delivered`, `quarantined`, `trashed`, `restored`, `bannered`, `spam` |
+| `direction` | Repeatable: `inbound`, `outbound`, `internal` |
+| `mailbox` | One protected mailbox address |
+| `sender_email` | One sender address |
+| `sender_root_domain` | One sender registrable domain |
+| `campaign_id` | The members of one campaign |
+| `link_domain` | Messages linking to this **registrable root** domain (`evil.example`, not `login.evil.example`) |
+| `attachment_sha256` | Messages carrying an attachment with this hash |
+| `user_reported` | Tri-state — see below |
+| `min_score` | Messages scoring at least this much |
+| `q` | Free-text over the message's identifying fields |
+| `since` / `until` | RFC3339 or unix seconds |
+
+Repeatable filters **OR within a key and AND across keys**: `verdict=suspicious`
+plus `verdict=malicious` plus `mailbox=cfo@corp.example` means "suspicious or
+malicious, delivered to that mailbox".
+
+```bash
+limacharlie mailsec message list --verdict suspicious --verdict malicious \
+  --mailbox cfo@corp.example --since "$(date -d '7 days ago' +%s)" --oid $OID
+```
+
+!!! warning "Tri-state booleans: absent is not `false`"
+    Omitting `user_reported` means the dimension is *unconstrained*. Setting it
+    to `false` selects mail **nobody reported**, which is a different and much
+    larger set than "all mail".
+
+### The two IOC pivots
+
+`link_domain` and `attachment_sha256` are the incident-response pivots, and they
+are the reason the queue is not just a mailbox view. Given one confirmed phish,
+they answer **"who else received this"** across every protected mailbox — which
+is the question that decides whether you are handling one message or an incident.
+
+```bash
+limacharlie mailsec message list --link-domain evil.example --oid $OID
+limacharlie mailsec message list --attachment-sha256 <sha256> --oid $OID
+```
+
+### Pagination
+
+Pages are keyset-paginated. `next_cursor` is opaque and is passed back verbatim;
+an empty one is the last page.
+
+A cursor is **bound to the filter set that minted it**. The backend chooses its
+read index from the filters and stamps that choice into the cursor, so changing a
+filter mid-walk fails the next page rather than silently resuming at a position
+that means something else. Restart the walk instead.
+
+### Retention
+
+The searchable message index keeps **35 days**. Flagged messages — and their
+stored evidence — are retained longer, up to **400 days**, tunable through
+[`mailsec_policy/retention`](policy.md#retention). A miss on an older id is a
+normal outcome and returns a null message rather than an error.
+
+## The drawer
+
+Opening a row shows what the engine decided and why:
+
+- **Why this verdict** — the top signals with their weights, from the same
+  `top_signals` the API returns.
+- **The message itself** — a sanitized rendering plus the parsed model: sender
+  and recipients, authentication results, the links table with display/href
+  mismatches highlighted, attachments and their explosion tree, and the thread
+  segmentation.
+- **The sender profile card** — this organization's history with the sender.
+- **The action timeline** — every audited action on this message.
+- **Remediation controls**, driven by the message's current placement: the
+  actions offered are the ones that make sense for where the message actually is.
+
+### Which model you are looking at
+
+The detail response labels its source, because the two are not equivalent:
+
+| `mdm_source` | What it is |
+|---|---|
+| `stored` | The model the collector actually judged with — the enrichments it resolved at ingest (sender prevalence, lookalike distances, link features, domain age) and the verdict as stamped |
+| `eml_reparse` | Today's parser reading the original bytes. The same message, a different parse, and **no enrichments at all** |
+
+`stored` is served when it exists; `eml_reparse` is the fallback for mail
+ingested before stored models existed. An analyst deciding whether the engine was
+right needs to know which one they are reading, so the field is always present.
+
+Neither requires a justification. The model is the product's own structured view;
+the *original bytes* are what is gated.
+
+### Similar messages
+
+`GET /messages/{id}/similar` (`limacharlie mailsec message similar <msg_uuid>`)
+returns recent messages sharing at least one
+[clustering key](campaigns.md#how-clustering-works) with this one, each row
+carrying the `matched_keys` that matched. These are **candidates, not a
+cluster** — deciding that two messages are the same attack belongs to the
+clustering engine. The response echoes the lookback window, because "no similar
+messages" only means something alongside the window it looked at.
+
+## Actions
+
+Six typed actions apply to a single message. Each is idempotent, performed at the
+provider, and audited.
+
+| Action | Effect |
+|---|---|
+| `quarantine_message` | Out of the inbox into a product-owned quarantine location — restorable, invisible to the user |
+| `trash_message` | To the provider's recoverable trash |
+| `move_to_spam` | To the provider's junk/spam location |
+| `restore_message` | Back to where it was before we moved it, falling back to the Inbox when that is unknown |
+| `banner_message` | Prepend the sanitized warning banner |
+| `unbanner_message` | Remove it |
+
+The per-provider mechanics differ and are documented in
+[Connecting Providers](providers.md#capability-differences-between-providers).
+
+```bash
+limacharlie mailsec message action <msg_uuid> \
+  --action quarantine_message --reason "confirmed credential phish" --oid $OID
+```
+
+Actions require `mailsec.act`.
+
+### Outcomes are reported honestly
+
+| `result` | Meaning |
+|---|---|
+| `ok` | The provider was changed |
+| `skipped` | The desired state already held, so nothing was written. Recording this as success would make the audit claim a provider write that never happened |
+| `alert_only` | The action was **decided and deliberately not performed**, because the organization is not in enforce mode. Not an error |
+| `failed` | The provider refused or errored; `error` carries the reason |
+| `pending` | In flight |
+
+!!! note "`unbanner_message` does not change placement"
+    A message's `state` is a **placement**. Bannering is a modification, so a
+    message that was quarantined and then un-bannered is still quarantined —
+    writing `delivered` there would move it back in the UI without moving it at
+    the provider.
+
+### Idempotency
+
+Repeating an action collapses onto the existing attempt, so a redelivery, a
+double-click or a rule firing twice on one event is a no-op rather than two
+quarantines. To deliberately act *again* — re-running a quarantine after a
+provider outage — pass a new `attempt` token.
+
+### Enforcement
+
+Analyst-initiated actions from the console, CLI or API **always execute**.
+`alert_only` withholds *automation*, not people: a human clicking quarantine has
+already made the decision the mode exists to withhold from a rule, and refusing
+them would make the product unusable during the incident it was bought for.
+
+Automated actions are governed by [policy](policy.md#automations).
+
+## The audit trail
+
+Every action writes an audit row — including failures and skips, because
+"quarantined 412 of 418, 6 failed" is only answerable if the six are recorded —
+and emits an `EMAIL_ACTION` event.
+
+| Field | Meaning |
+|---|---|
+| `action_id` | The row's identity and its idempotency key |
+| `action`, `ts`, `result`, `error` | What was attempted, when, and what happened |
+| `actor` | **Who asked** — stamped by the server from the caller's authenticated claims. A request body cannot supply it |
+| `source` | `analyst`, `automation`, `ai`, `api` or `dr` |
+| `provider` | Which mail tenant it hit |
+
+The per-message timeline is deliberately narrow and does **not** carry the action's
+request payload. Expand one row to read it:
+
+```bash
+limacharlie mailsec action get <action_id> --oid $OID --output yaml
+```
+
+A `null` request on a timeline row means **"not read"**, never "no parameters
+recorded" — an auditor asking whether a justification exists must expand the row
+rather than infer absence from the list.
+
+## Downloading the original message
+
+This is a privileged read of a person's mail, and it is gated separately from the
+rest of the product. It requires **both** `mailsec.get` and `mailsec.get.eml`,
+plus a justification.
+
+```bash
+limacharlie mailsec message eml <msg_uuid> \
+  --justification "INC-4471, user reported credential harvest" \
+  --out-file suspect.eml --oid $OID
+```
+
+- The justification is **required**. A blank or whitespace-only reason is
+  refused.
+- It is recorded against your authenticated identity in the organization's action
+  audit and retained for 400 days. **A failed attempt is recorded too.**
+- It is stored verbatim. The backend enforces a minimum and a maximum length, and
+  refuses an over-long reason rather than truncating — silently clipping the
+  record the gate exists to produce would corrupt it.
+- Raw copies expire 35 days after delivery (longer for flagged messages), after
+  which this returns a typed expiry error while the index row stays readable.
+
+Read a justification back with `mailsec action get <action_id>`.
+
+## Sender profiles
+
+```bash
+limacharlie mailsec sender get cfo@corp.example --oid $OID
+limacharlie mailsec sender get domain:corp.example --oid $OID
+```
+
+A key with no profile means **no history at all**, and the response says so
+explicitly rather than returning a zeroed profile that would read as a
+known-but-quiet sender. Keys are lowercased, and a bare address or domain is
+resolved for you.

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -1,0 +1,397 @@
+# Policy Reference
+
+--8<-- "includes/email-security-beta.md"
+
+Email Security is configured through Hive records. Anything the console can
+configure, `limacharlie hive set` can configure — so tenant onboarding and
+fleet-wide policy are a script, not a UI workflow.
+
+| Hive | Records | Purpose |
+|---|---|---|
+| `mailsec_provider` | one per mail connection | which tenant to protect, with which credential — see [Connecting Providers](providers.md) |
+| `mailsec_policy` | many, discriminated by `policy_type` | automations, exclusions, VIPs, thresholds, banners, retention, reporter replies, hunt defaults |
+| `dr-mail` | one per custom rule | your own mail detection rules — see [Custom Rules](custom-rules.md) |
+
+## How `mailsec_policy` records work
+
+Every record carries a `policy_type` discriminator. There may be **many records
+of each type**, and they compose into one resolved policy.
+
+### Composition is by record name
+
+Records compose in **record-name order**. The name is not decoration: it is the
+only thing that makes composition deterministic when two records set the same
+field. An organization that needs a specific precedence names its records
+accordingly — `00-baseline`, `50-team-x`, `99-override` — the same convention as
+every other ordered configuration surface.
+
+How each type composes:
+
+| Type | Composition |
+|---|---|
+| `automations` | Concatenated in name order; evaluated as an ordered list |
+| `exclusions` | Concatenated — a set of independent suppressions |
+| `vips` | Union, deduplicated and sorted |
+| `thresholds` | Last writer wins per field, with the ordering invariant re-checked afterwards |
+| `banners`, `reporter_reply`, `hunt_defaults` | Last writer wins per field |
+| `retention` | **Maximum** wins — see [Retention](#retention) |
+
+### Unknown fields are refused
+
+Every record body is decoded strictly. A key the contract does not define is a
+**rejected record**, not an ignored field. A policy is a security control, and a
+typo'd key that silently does nothing is the worst available failure mode: the
+operator believes mail is being quarantined and it is not. A rejected record is
+visible; an ignored field is not.
+
+The validator's own wording is what you get back — in the CLI, in the API, and
+verbatim in the console's Policy page.
+
+### Editing preserves what you did not touch
+
+The console's **Policy** page edits every record type, and saves are
+**patch-preserving**: fields the form does not manage are written back exactly as
+they were. Editing a policy record in the UI never silently drops a field you set
+through the API or through git-sync.
+
+### Defaults
+
+An organization that has written no policy still has one. Every type below states
+its default, and the defaults are deliberately inert: nothing moves mail, nothing
+modifies mail, and nothing sends mail until you say so.
+
+---
+
+## `automations`
+
+The ordered list of `{match → actions}` rules that decide what happens to a
+message automatically.
+
+```yaml
+policy_type: automations
+automations:
+  - name: malicious-quarantine
+    match:
+      verdicts: [malicious]
+    actions: [quarantine_message]
+    mode: alert_only
+  - name: reported-mail-quarantine
+    match:
+      user_reported: true
+      min_score: 45
+    actions: [quarantine_message]
+    mode: alert_only
+```
+
+### `match`
+
+| Field | Meaning |
+|---|---|
+| `verdicts` | Any of `malicious`, `suspicious`, `graymail`, `benign`, `unknown`, `error`. An unrecognized verdict is refused rather than silently never matching |
+| `tags` | Verdict tags contributed by the rules that fired |
+| `directions` | `inbound`, `outbound`, `internal` |
+| `min_score` | 0–100 |
+| `user_reported` | Tri-state: omit to ignore, `true` for mail a human flagged, `false` for mail nobody reported |
+
+An **empty match matches everything**. An enforcing rule with an empty match is
+refused at save — "quarantine all mail" is never what someone meant to write.
+
+### `actions`
+
+| Action | |
+|---|---|
+| `quarantine_message` | Out of the inbox, restorable |
+| `trash_message` | To recoverable trash |
+| `move_to_spam` | To the junk/spam location |
+| `banner_message` | Prepend the warning banner |
+
+Deliberately **not** automatable: the campaign-wide sweeps (an automation acting
+on one message must not fan out to hundreds without a human — that is an explicit
+action), `restore_message` (undoing is a human decision), and the disposition
+labels (labels are evidence, and a machine writing them would poison the data set
+that measures the machine).
+
+!!! warning "Two further action names validate but do not execute"
+    Policy validation accepts `submit_to_triage` and `crawl_link` as automatable,
+    but the remediation executor implements neither, so an automation that
+    dispatches one records a failed action rather than doing anything. Use only
+    the four actions in the table above.
+
+### `mode`
+
+| Mode | |
+|---|---|
+| `alert_only` | **The default.** The rule is evaluated and its intent recorded; the mailbox is not touched. Actions report `alert_only` as their result |
+| `enforce` | The action is performed at the provider |
+
+The default is load-bearing. A rule whose mode is missing, misspelled, or written
+by an older tool falls back to the harmless behaviour — falling back to `enforce`
+would mean a typo silently deletes mail. An unrecognized mode is refused at
+save, and anything that ever slipped past decoding still behaves as
+`alert_only`.
+
+!!! danger "Enforcement is currently organization-wide at the executor"
+    The remediation executor authorizes *automated* action when **any** resolved
+    automation rule is in `enforce` mode. Which rule dispatches which action is
+    still decided per rule, but the executor's consent check is not per rule — so
+    putting one rule into `enforce` enables the organization's automated paths
+    generally. Treat the first `enforce` as the decision that this organization
+    now moves mail automatically.
+
+    Analyst-initiated actions are unaffected: a human clicking quarantine always
+    executes.
+
+**Default:** subscribing seeds a recommended preset entirely in `alert_only` —
+malicious → quarantine and graymail → move to spam among them. Nobody is
+surprise-quarantined on day one. Review the seeded records before switching any
+of them to `enforce`.
+
+---
+
+## `exclusions`
+
+Suppress signals **before** scoring, so an excluded rule contributes nothing to
+the score and never appears in the verdict's reasons. It still appears in
+`matched_signals`, so a suppression is auditable rather than invisible.
+
+```yaml
+policy_type: exclusions
+exclusions:
+  - rule_id: ms-sender-first-contact
+    sender_domain: newsletters.partner.example
+    reason: "Marketing partner onboarded 2026-08; every send is a first contact"
+    expires_at: "2026-12-31T00:00:00Z"
+```
+
+| Field | |
+|---|---|
+| `rule_id`, `sender_email`, `sender_domain`, `mailbox` | The scope. **At least one is required** |
+| `reason` | **Required.** An exclusion is a permanent hole in detection, and one whose rationale nobody recorded is one nobody can ever safely remove |
+| `created_by` | Optional attribution |
+| `expires_at` | Optional. After it, the exclusion is inert without anyone deleting it — which is what makes a time-boxed exclusion safe to grant |
+
+Addresses and domains are lowercased on save.
+
+**Default:** none.
+
+---
+
+## `vips`
+
+The protected identities that impersonation detection compares against — the
+display names and addresses a `Finance` request is most damaging in the name of.
+
+```yaml
+policy_type: vips
+vips:
+  - name: Ada Lovelace
+    email: ada@corp.example
+    title: CFO
+list_refs:
+  - hive://lookup/execs
+```
+
+| Field | |
+|---|---|
+| `vips[]` | Inline entries. Each needs a `name` **or** an `email`; `title` is context for an analyst, not a matching key |
+| `list_refs[]` | References to `lookup` Hive records, so the executive list lives in one place — the same lookup your D&R rules and your HR export already feed — instead of being copied into policy where it drifts |
+
+A `list_ref` must be of the form `hive://lookup/<name>`.
+
+### The two accepted lookup shapes
+
+A LimaCharlie lookup record is a map of key → metadata. Both forms are read, and
+both are normalized into the same VIP:
+
+```yaml
+# (a) the key is the email address, metadata is optional context
+"ada@corp.example":
+  name: Ada Lovelace
+  title: CFO
+```
+
+```yaml
+# (b) the key is the display name, the address (if known) is in the metadata
+"Ada Lovelace":
+  email: ada@corp.example
+  title: CFO
+```
+
+In shape (a) the **key wins** over any `email` in the metadata: in a lookup the
+key is the indicator, and that is what every other consumer of the record matches
+on. A disagreeing metadata field must not make mail security protect a different
+address than the rules do.
+
+An entry with neither a plausible email key nor an email in its metadata — the
+bare `"Ada Lovelace": {}` a newline upload produces — becomes a **name-only VIP**.
+That is legal and useful: display-name impersonation is the high-yield shape and
+needs no address to be detected.
+
+Metadata keys are matched case-insensitively; `name` (alias `display_name`),
+`email` and `title` are read and everything else is ignored, so a list maintained
+for another purpose can be pointed at without being reshaped.
+
+Both the plain and the pre-indexed (optimized) storage forms of a lookup record
+are read, because which one the Hive holds depends only on how the record was
+uploaded.
+
+### What is surfaced
+
+- A reference whose record is **absent, disabled, not shaped like a lookup, or
+  empty of usable entries** resolves to zero entries and is **reported to the
+  organization** — a configured VIP list that contributes nobody is a coverage
+  lie, and it is reported repeatedly until fixed rather than once per process.
+- A reference that could not be **read** keeps serving its last good entries and
+  is reported as stale rather than lost, so one datastore blip does not disarm
+  your VIP list.
+- Malformed entries and truncation are counted and reported **as counts, never
+  with the entry's contents** — a VIP list is a list of named people, and a
+  malformed row is exactly as personal as a well-formed one.
+- One reference contributes at most **1,000 entries**. The VIP list is scanned
+  once per message, so pointing this at a large threat feed would put a huge scan
+  in the ingest path of every message. Truncation is surfaced, never silent.
+
+Resolution never fails the policy: inline entries and every other reference stay
+in force.
+
+**Default:** none.
+
+---
+
+## `thresholds`
+
+The verdict cutoffs and per-rule overrides.
+
+```yaml
+policy_type: thresholds
+malicious_min: 80
+suspicious_min: 40
+rule_overrides:
+  ms-link-unranked-domain:
+    weight: 15
+  ms-graymail-precedence-bulk:
+    disabled: true
+```
+
+| Field | Default | |
+|---|---|---|
+| `malicious_min` | 85 | 1–100 |
+| `suspicious_min` | 45 | 1–100 |
+| `rule_overrides` | — | Keyed by rule id: `disabled` to switch a packaged rule off for your organization, `weight` (0–100) to replace its packaged weight |
+
+`malicious_min` must remain **above** `suspicious_min`. Two records that are each
+individually sane can compose into an inversion — one lowers malicious, another
+raises suspicious — so the invariant is enforced after composition, not only per
+record. An inverted pair would make every suspicious message malicious.
+
+Rule ids are stable and are never renamed, which is the only reason an override
+can be persisted at all.
+
+---
+
+## `banners`
+
+The warning banner's text and switch.
+
+```yaml
+policy_type: banners
+enabled: true
+text: "External sender. Verify before clicking links or opening attachments."
+```
+
+| Field | Default | |
+|---|---|---|
+| `enabled` | `false` | Bannering rewrites the customer's mail, and nothing in this product modifies mail by default |
+| `text` | A packaged warning | **Plain text only** — no `<` or `>` — and capped at 512 characters |
+
+The HTML template is fixed and sanitized in code; policy contributes only the
+text. Accepting markup here would turn a configuration field into stored HTML
+injection against your own users.
+
+Bannering also needs the provider capability: `Mail.ReadWrite` is enough on
+Microsoft 365 (edited in place), while Google Workspace additionally needs the
+optional `https://mail.google.com/` scope and **replaces** the message.
+
+---
+
+## `retention`
+
+How long flagged evidence is kept.
+
+```yaml
+policy_type: retention
+flagged_days: 180
+```
+
+| Field | Default | Range |
+|---|---|---|
+| `flagged_days` | 400 | 30–400 |
+
+400 is the schema's hard ceiling: policy can only choose *within* what the store
+keeps, because a policy asking for longer would be a promise the database
+silently breaks.
+
+Composition takes the **maximum** rather than the last writer. Two records
+disagreeing about retention is a disagreement about how much evidence to destroy,
+and the safe resolution is always "keep it longer" — a shorter setting is
+recoverable by editing policy, deleted rows are not.
+
+The 35-day searchable message index and the raw-message window are separate and
+are not configured here.
+
+---
+
+## `reporter_reply`
+
+The templated acknowledgement sent to someone who reported a message. See
+[User Reports](user-reports.md#reporter-replies).
+
+```yaml
+policy_type: reporter_reply
+enabled: true
+templates:
+  malicious: "Thanks — you were right. We removed that message from every mailbox it reached."
+  benign: "Thanks for checking. That message is legitimate; no action was needed."
+```
+
+| Field | Default | |
+|---|---|---|
+| `enabled` | `false` | It sends mail on your behalf to your own staff; opt-in |
+| `templates` | — | Keyed by verdict. A verdict with no template falls back to a generic acknowledgement, so enabling replies can never leave a reporter with silence |
+
+Template keys must be verdicts. Values are plain text (no `<` or `>`), capped at
+4096 characters.
+
+---
+
+## `hunt_defaults`
+
+Starting values for retro-hunt requests.
+
+```yaml
+policy_type: hunt_defaults
+window_days: 7
+max_results: 1000
+dry_run: true
+```
+
+| Field | Default | Range |
+|---|---|---|
+| `window_days` | 7 | 1–365 |
+| `max_results` | 1000 | 1–100000 |
+| `dry_run` | `true` | An operation that can bulk-remediate defaults to "show me what this would match" |
+
+---
+
+## Reading the resolved policy
+
+The resolved automation mode — the effective safety banner — is reported by
+coverage, and the console shows it on both **Overview** and **Settings**:
+
+```bash
+limacharlie mailsec coverage --oid $OID --output yaml --filter 'overview'
+```
+
+It reads `enforce` when any resolved rule can act, and fails closed to
+`alert_only` when the policy is absent, unreadable, or carries a mode this build
+does not recognize.

--- a/docs/email-security/provider-setup/google-workspace.md
+++ b/docs/email-security/provider-setup/google-workspace.md
@@ -1,0 +1,228 @@
+# Google Workspace
+
+--8<-- "includes/email-security-beta.md"
+
+A Google Workspace connection reads and remediates Gmail through the Gmail API,
+using a **service account with domain-wide delegation**. There is no mail
+routing change and no content compliance rule: the product is not in the
+delivery path.
+
+Workspace needs setup that Microsoft 365 does not, and the reason is worth
+stating once: **Gmail will only publish change notifications to a Pub/Sub topic
+in the service account's own Google Cloud project.** That topic and its
+subscription are therefore yours, in your project, and the same service account
+that reads mail is the one that reads the subscription — so a Workspace
+connection still needs exactly one credential.
+
+**Auth model:** a Google Cloud **service account** whose numeric OAuth2 client ID
+is authorized in your Workspace admin console for a specific list of scopes,
+impersonating a Workspace admin.
+
+## Prerequisites
+
+- A Google Cloud project you control (it can be a new, empty one).
+- **Super Admin** access to the Workspace admin console, to authorize
+  domain-wide delegation.
+- A Workspace administrator address for the service account to impersonate.
+
+## Scopes
+
+| Scope | Required | What it buys | Without it |
+|---|:--:|---|---|
+| `https://www.googleapis.com/auth/admin.directory.user.readonly` | ✅ | Read the list of users in your domain, so we know which mailboxes to protect | No mailbox can be discovered, so nothing is protected at all |
+| `https://www.googleapis.com/auth/gmail.modify` | ✅ | Read messages, change their labels, and move them to trash. It does **not** permit permanent deletion | No mail can be analyzed, quarantined or restored |
+| `https://mail.google.com/` | — | Insert and delete messages, which is the only way to place a warning banner on delivered mail — Gmail has no API to edit a message in place. Also enables reporter auto-replies | Everything works except banners and reporter replies. Quarantine, trash, restore and move-to-spam are unaffected. Grant it only if you want those; it is broader access than the rest |
+
+!!! info "Mail *configuration* is a different product"
+    Scopes such as `gmail.settings.basic` are not part of this connection.
+    Diffable mail configuration — forwarding rules, delegation, transport rules,
+    DKIM/SPF/DMARC posture — belongs to
+    [Cloud Security](../../cloud-security/provider-setup/google-workspace.md),
+    which collects it as posture findings. Email Security owns the *messages*.
+
+## Setup steps
+
+!!! tip "Let the console render these with your values"
+    The wizard serves the same steps with your project id and service-account
+    address already substituted, and every command in order as a single paste.
+    `limacharlie mailsec onboarding --provider gworkspace --oid $OID` returns
+    the same thing headless. The steps below are the narrative.
+
+### 1. Create a service account and download its JSON key
+
+In any Google Cloud project you control. It needs **no IAM roles on the
+project** — its mail access comes entirely from domain-wide delegation. Note its
+**numeric OAuth2 client ID**; the Workspace console needs the number, not the
+email address.
+
+### 2. Enable the APIs
+
+In the same project as the service account.
+
+```bash
+gcloud services enable gmail.googleapis.com admin.googleapis.com \
+  pubsub.googleapis.com --project=<YOUR_PROJECT_ID>
+```
+
+### 3. Authorize the service account in the Workspace admin console
+
+**Security → Access and data control → API controls → Domain-wide delegation →
+Add new.** Paste the numeric client ID and the scopes as one comma-separated
+line. Include `https://mail.google.com/` only if you want banners and reporter
+replies.
+
+*Verified by the `directory` check in the connection test.*
+
+### 4. Create the notification topic
+
+It **must** be in the same project as the service account — Gmail refuses a
+topic in any other project.
+
+```bash
+gcloud pubsub topics create mailsec-gmail-push --project=<YOUR_PROJECT_ID>
+```
+
+### 5. Let Gmail publish to the topic
+
+```bash
+gcloud pubsub topics add-iam-policy-binding mailsec-gmail-push \
+  --project=<YOUR_PROJECT_ID> \
+  --member="serviceAccount:gmail-api-push@system.gserviceaccount.com" \
+  --role="roles/pubsub.publisher"
+```
+
+`gmail-api-push@system.gserviceaccount.com` is a Google-owned account, so the
+console will warn that it is outside your organization. That is expected — it is
+how Gmail delivers notifications.
+
+*Verified by the `pubsub_watch` check.*
+
+### 6. Create the subscription we read from
+
+A **pull** subscription on that topic.
+
+```bash
+gcloud pubsub subscriptions create mailsec-gmail-push-sub \
+  --topic=mailsec-gmail-push --project=<YOUR_PROJECT_ID> --ack-deadline=60
+```
+
+### 7. Let us read the subscription
+
+Granted to the **same** service account you already created.
+
+```bash
+gcloud pubsub subscriptions add-iam-policy-binding mailsec-gmail-push-sub \
+  --project=<YOUR_PROJECT_ID> \
+  --member="serviceAccount:<SERVICE_ACCOUNT_EMAIL>" \
+  --role="roles/pubsub.subscriber"
+```
+
+*Verified by the `pubsub_pull` check.*
+
+## Store the credential
+
+The secret is the service-account JSON key **plus** the Workspace administrator
+address to impersonate:
+
+```json
+{
+  "admin_email": "admin@corp.example",
+  "type": "service_account",
+  "project_id": "<YOUR_PROJECT_ID>",
+  "private_key_id": "<key-id>",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "client_email": "<SERVICE_ACCOUNT_EMAIL>",
+  "client_id": "<numeric-oauth2-client-id>",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+```
+
+```bash
+limacharlie secret set --key gws-mail \
+  --value "$(cat gws-credential.json)" --enabled --oid $OID
+```
+
+## Create the connection
+
+```yaml
+# gws.yaml
+provider: gworkspace
+credentials: hive://secret/gws-mail
+ingest:
+  mode: push
+  backfill_days: 14
+features:
+  outbound_observation: true
+  reports_mailbox: phishing@corp.example
+  pubsub_topic: projects/<YOUR_PROJECT_ID>/topics/mailsec-gmail-push
+  pubsub_subscription: projects/<YOUR_PROJECT_ID>/subscriptions/mailsec-gmail-push-sub
+```
+
+```bash
+limacharlie hive set --hive-name mailsec_provider --key gws-prod \
+  --input-file gws.yaml --enabled --oid $OID
+```
+
+`ingest.mode: push` requires **both** `pubsub_topic` and `pubsub_subscription`;
+a record that asks for push and names nowhere to receive is refused at save. Use
+`auto` to let the collector decide.
+
+## Verify
+
+```bash
+limacharlie mailsec connection test gws-prod --oid $OID --output yaml
+limacharlie mailsec connection test gws-prod --include-watch --oid $OID --output yaml
+```
+
+| Check | Required | Meaning if it fails |
+|---|:--:|---|
+| `credential` | ✅ | The service-account key is malformed, or `admin_email` is missing |
+| `directory` | ✅ | `admin.directory.user.readonly` is not delegated |
+| `mail_modify` | ✅ | `gmail.modify` is not delegated — no analysis or remediation |
+| `mail_full` | — | `https://mail.google.com/` not delegated; banners and reporter replies are unavailable. Reported as `skipped`, and `ok` stays true |
+| `mailbox_read` | ✅ | Delegation is in place but the directory returned nothing, or the impersonated admin cannot list users |
+| `pubsub_pull` | ✅ (when push is configured) | The service account lacks `roles/pubsub.subscriber` on the subscription, or the subscription name is wrong |
+| `pubsub_watch` | ✅ (when push is configured) | Gmail cannot publish to the topic — usually the missing publisher binding, or a topic outside the service account's project |
+
+`--include-watch` establishes a real Gmail watch and requires a real Pub/Sub pull
+before lifecycle can pass. It is idempotent and the watch expires on its own.
+
+## How ingestion works
+
+- **Discovery** lists users per domain through the Admin SDK.
+- **Push mode**: a `users.watch` per mailbox publishes to your topic; the
+  collector pulls your subscription with the same service-account credential and
+  reads the change history from the last known point. Watches are renewed on a
+  daily schedule — Gmail expires them within seven days.
+- **Poll mode** walks each mailbox's change history on an interval. It is a
+  small-tenant and failure fallback, not a scale plan: it spends quota in your
+  project continuously whether or not any mail arrived.
+- Sent mail is ingested as `direction: outbound`, observation-only.
+
+!!! warning "Gmail cannot enumerate active watches"
+    There is no Gmail API that lists the watches currently established for a
+    domain, so reconciliation compares against **our** stored state rather than
+    the provider's own view. That is a genuinely lower assurance than the
+    Microsoft 365 side, and it is surfaced on every Workspace connection row
+    rather than hidden. `--include-watch` is how you positively prove delivery.
+
+## Remediation semantics
+
+| Action | What happens in Gmail |
+|---|---|
+| `quarantine_message` | `INBOX` removed, an `LC Quarantine` label added — restorable, and out of the user's inbox |
+| `trash_message` | `TRASH` added. The product's own quarantine label is removed afterwards, so the message's placement reads as trashed rather than still quarantined |
+| `move_to_spam` | `SPAM` added, resolved through Gmail's own identifiers |
+| `restore_message` | The labels are inverted |
+| `banner_message` / `unbanner_message` | Gmail cannot edit a stored message, so the message is **replaced**: the banner-carrying copy is inserted before the original is deleted (so an interruption leaves a repairable duplicate rather than data loss), preserving thread, internal date and labels. **The provider message id changes**, and the new one is persisted. Requires `https://mail.google.com/`; without it the action is refused by name |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `credential` fails | Key JSON malformed, or `admin_email` missing from the secret | Re-store the secret with `admin_email` included |
+| `directory` fails | Delegation authorized against the service-account **email** instead of its **numeric client ID**, or a scope typo | Re-add the delegation with the numeric client ID and the exact scope strings |
+| `mail_full` fails and banners are refused | `https://mail.google.com/` is not in the delegated scope list | Add it to the same delegation entry, or accept that banners and reporter replies are unavailable |
+| `pubsub_watch` fails | Missing publisher binding for `gmail-api-push@system.gserviceaccount.com`, or the topic is in a different project | Add the binding; move the topic into the service account's project |
+| `pubsub_pull` fails or times out | Missing `roles/pubsub.subscriber`, wrong subscription name, or the subscription is push rather than pull | Grant the role; recreate as a pull subscription |
+| Banner "worked" but a later action fails | Something cached the pre-banner provider message id | Re-read `provider_message_id`; a Workspace banner mints a new one |

--- a/docs/email-security/provider-setup/microsoft-365.md
+++ b/docs/email-security/provider-setup/microsoft-365.md
@@ -1,0 +1,182 @@
+# Microsoft 365
+
+--8<-- "includes/email-security-beta.md"
+
+A Microsoft 365 connection reads and remediates Exchange Online mail over
+Microsoft Graph, using an **application-only** credential. There is no mail
+routing change, no connector, and no transport rule: the product is not in the
+delivery path.
+
+**Auth model:** an **Entra ID app registration** (service principal) with a
+**client secret** and Microsoft Graph **application** permissions, admin-consented
+tenant-wide.
+
+## Prerequisites
+
+- Permission to create an app registration (**Application Developer** or higher).
+- Permission to **grant tenant-wide admin consent** (**Privileged Role
+  Administrator** or **Global Administrator**).
+- Your **tenant ID** (Entra ID → Overview).
+- Mailboxes on Exchange Online. A user without an Exchange Online mailbox is not
+  discovered, because there is no mail to protect.
+
+## Required permissions
+
+Both are **Application** permissions on Microsoft Graph, and both need admin
+consent.
+
+| Grant | Why | Connection-test check |
+|---|---|---|
+| **Mail.ReadWrite** | Read raw message bytes, and perform every remediation: quarantine, trash, move to spam, restore, apply and remove a banner | `mail_write` |
+| **User.Read.All** | Enumerate the tenant's users to discover which mailboxes to protect | `mailbox_read` |
+
+## Optional permissions
+
+| Grant | Unlocks | Without it |
+|---|---|---|
+| **Mail.Send** | Reporter auto-replies — the templated acknowledgement sent to a person who reported a message | Reporter replies are **refused by name**, reported as an explicitly unavailable capability rather than silently skipped. Everything else is unaffected. Check `mail_send` reports `skipped`. |
+
+!!! info "Why the consented set is readable at all"
+    Microsoft Graph authorizes at call time, so the only read-only view of what
+    was actually consented is the `roles` claim on the app's own access token.
+    That is what the connection test reads — which means `mail_send` can be
+    checked without sending a message to find out.
+
+!!! danger "Application permissions, not delegated"
+    Graph permissions must be added under **Application permissions**. Delegated
+    permissions require a signed-in user and leave the connection failing after
+    consent looks granted.
+
+## Create the app registration
+
+In the portal: **Microsoft Entra ID → App registrations → New registration**
+(single tenant) → **Certificates & secrets → New client secret** (copy the
+*Value*, not the *Secret ID*) → **API permissions → Add a permission →
+Microsoft Graph → Application permissions** → add `Mail.ReadWrite` and
+`User.Read.All` (and `Mail.Send` if you want reporter replies) → **Grant admin
+consent**.
+
+With the Azure CLI:
+
+```bash
+TENANT_ID=$(az account show --query tenantId -o tsv)
+
+APP_ID=$(az ad app create --display-name lc-email-security --query appId -o tsv)
+az ad sp create --id "$APP_ID"
+
+az ad app credential reset --id "$APP_ID" --years 2 --append \
+  --display-name lc-email-security --query password -o tsv   # capture this once
+
+GRAPH=00000003-0000-0000-c000-000000000000
+
+# Resolve each app-role id from Graph itself rather than pasting a GUID.
+for PERM in Mail.ReadWrite User.Read.All Mail.Send; do   # Mail.Send is optional
+  ROLE_ID=$(az ad sp show --id "$GRAPH" \
+    --query "appRoles[?value=='$PERM'].id | [0]" -o tsv)
+  az ad app permission add --id "$APP_ID" --api "$GRAPH" \
+    --api-permissions "$ROLE_ID=Role"
+done
+
+az ad app permission admin-consent --id "$APP_ID"
+```
+
+!!! danger "`credential reset` clears existing secrets"
+    Without `--append`, `az ad app credential reset` **removes every existing
+    password and certificate** on the app before adding the new one.
+
+!!! tip "Restricting which mailboxes the app can reach"
+    Exchange Online can limit an application's mailbox access at the tenant side
+    (application access policies / RBAC for Applications). That is complementary
+    to the connection record's own `scope`: the record decides which mailboxes
+    the product *asks for*, and the tenant policy decides which ones Exchange
+    *permits*. Mailboxes the tenant refuses are tolerated rather than fatal, so
+    set the record's `scope` to match the tenant policy — then the coverage
+    numbers reflect a decision you made rather than a refusal you have to
+    reverse-engineer.
+
+## Store the credential
+
+```json
+{"tenant_id": "<tenant-id>", "client_id": "<application-client-id>", "client_secret": "<the-secret-value>"}
+```
+
+```bash
+limacharlie secret set --key m365-mail \
+  --value "$(cat m365-credential.json)" --enabled --oid $OID
+```
+
+## Create the connection
+
+In the console: **Email Security → Settings → add a connection → Microsoft 365**.
+The wizard renders the setup guide with your own values, stores the credential
+as a secret if you paste one, and runs **Test Connection** before you finish.
+
+As code:
+
+```yaml
+# m365.yaml
+provider: m365
+credentials: hive://secret/m365-mail
+ingest:
+  mode: auto
+  backfill_days: 14
+features:
+  outbound_observation: true
+  reports_mailbox: phishing@corp.example
+```
+
+```bash
+limacharlie hive set --hive-name mailsec_provider --key m365-prod \
+  --input-file m365.yaml --enabled --oid $OID
+```
+
+The full field reference is in [Connecting Providers](../providers.md#the-connection-record).
+
+## Verify
+
+```bash
+limacharlie mailsec connection test m365-prod --oid $OID --output yaml
+```
+
+| Check | Required | Meaning if it fails |
+|---|:--:|---|
+| `credential` | ✅ | The tenant/client/secret triple was rejected, or the client secret expired |
+| `mailbox_read` | ✅ | `User.Read.All` not consented — no mailbox can be discovered. Also fails when the directory genuinely returns no mailboxes |
+| `mail_write` | ✅ | `Mail.ReadWrite` not consented — nothing can be read or remediated |
+| `mail_send` | — | `Mail.Send` not consented; reporter replies unavailable. Reported as `skipped`, and `ok` stays true |
+
+## How ingestion works
+
+- **Discovery** enumerates users with mailboxes and reconciles the mailbox
+  inventory, re-syncing periodically.
+- **Change notifications**: one Microsoft Graph subscription per mailbox on
+  `/users/{id}/messages`, delivered to a dedicated public receiver that validates
+  and enqueues **routing identifiers only** — no subject, sender or body ever
+  passes through it. Lifecycle notifications arrive on a separate endpoint and
+  drive reauthorization, recreation and gap backfill.
+- **Fetch**: on notification, the raw MIME is fetched, parsed, enriched, judged,
+  persisted and emitted. Only folders that mean "delivered" are analyzed as
+  inbound; Sent is processed as `direction: outbound`, observation-only.
+- Subscriptions are renewed well before expiry, and the renewal sweep reconciles
+  the provider's subscription set against ours.
+
+## Remediation semantics
+
+| Action | What happens in Exchange Online |
+|---|---|
+| `quarantine_message` | Moved to a **hidden** `LC Quarantine` folder we create in the mailbox — invisible to the user, fully restorable |
+| `trash_message` | Moved to **Recoverable Items**. Invisible to the user and recoverable by an admin; this is deliberately *not* Deleted Items |
+| `move_to_spam` | Moved to the Junk Email folder |
+| `restore_message` | Moved back to the folder it came from, which we recorded at quarantine time. If that is unknown it goes to the Inbox — a message the customer asked to have back belongs somewhere they will find it |
+| `banner_message` / `unbanner_message` | The body is edited **in place** with a fixed, sanitized banner block carrying an idempotency marker, so it is never applied twice and can be removed cleanly. The message keeps its provider id |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `credential` fails with `invalid_client` | Stored the secret **ID** instead of its **Value**, or the secret expired | Re-mint the secret and update the secret record |
+| `mail_write` fails after consent | Permissions added as *Delegated*, or admin consent not actually granted | Re-add under *Application permissions* and grant tenant-wide admin consent |
+| `mailbox_read` reports no mailboxes | Wrong tenant, or the users have no Exchange Online mailbox | Confirm the tenant, confirm licensing |
+| Some mailboxes never become `protected` | An Exchange application access policy denies the app for those mailboxes | Widen the policy, or exclude those mailboxes in the record's `scope` so coverage reflects a decision rather than a refusal |
+| Attachment analysis looks incomplete | Defender **Safe Attachments in Dynamic Delivery mode** detaches the attachment from the delivered message | Use Block mode if you want attachments analyzed post-delivery |
+| Everything fails at `credential` after months of working | Client secrets expire | Re-mint before expiry and update the secret record; nothing else changes |

--- a/docs/email-security/providers.md
+++ b/docs/email-security/providers.md
@@ -1,0 +1,160 @@
+# Connecting Providers
+
+--8<-- "includes/email-security-beta.md"
+
+A mail connection is one `mailsec_provider` Hive record plus one credential in
+the [secret](../7-administration/config-hive/secrets.md) Hive. Two providers are
+supported, and an organization may hold **one connection of each**:
+
+| Provider | `provider` | Auth model | Setup |
+|---|---|---|---|
+| Microsoft 365 / Exchange Online | `m365` | Entra ID app registration (client credentials) with Microsoft Graph **application** permissions | [Microsoft 365](provider-setup/microsoft-365.md) |
+| Google Workspace / Gmail | `gworkspace` | Google Cloud service account with **domain-wide delegation**, plus Pub/Sub in the same project | [Google Workspace](provider-setup/google-workspace.md) |
+
+!!! info "One enabled record per provider"
+    Creating a second enabled record for a provider that already has one is
+    refused at write time. Notifications carry a mailbox and a subscription, not
+    a credential, so two same-provider connections in one organization would
+    make it ambiguous which tenant's credential should fetch a given message.
+    An M365 connection **and** a Workspace connection in the same organization
+    is fully supported and runs concurrently; a campaign can span both.
+
+## The connection record
+
+```yaml
+provider: m365 | gworkspace
+credentials: hive://secret/<name>
+
+scope:
+  include_addresses: []
+  exclude_addresses: []
+  include_groups: []
+  domains: []
+
+ingest:
+  mode: auto | push | poll
+  backfill_days: 14
+
+features:
+  outbound_observation: true
+  reports_mailbox: ""
+  pubsub_topic: ""          # Google Workspace only
+  pubsub_subscription: ""   # Google Workspace only
+```
+
+The record is decoded strictly: an unknown key is **refused**, not ignored. A
+typo in a security control that silently does nothing is the worst available
+failure mode, so a rejected record is preferred to an ignored field.
+
+### `credentials`
+
+Always a `hive://secret/<name>` reference. The credential is resolved in the
+collector's memory only; a decoded connection record carries no secret material,
+which is what makes it safe to read through the API, mirror and log.
+
+### `scope`
+
+Which mailboxes the connection covers.
+
+| Field | Meaning |
+|---|---|
+| `include_addresses` | Exact mailbox addresses to cover. **Empty means every discovered mailbox** — the intended default. |
+| `exclude_addresses` | Mailboxes never to cover. Excludes always win over includes. |
+| `include_groups` | Directory groups to expand into addresses before discovery. |
+| `domains` | Restrict to mailboxes in these domains. |
+
+Addresses and domains are lowercased on save.
+
+!!! warning "Group expansion is fail-closed on the connection, not on the scope"
+    A group-scoped connection whose groups cannot be expanded is treated as a
+    **connection error** rather than proceeding — because an unexpanded group
+    scope would silently widen to every mailbox.
+
+### `ingest`
+
+| Field | Meaning |
+|---|---|
+| `mode` | `auto` (default) picks push where the provider supports it, `push` requires it, `poll` forces periodic polling. |
+| `backfill_days` | Historical **metadata-only** bootstrap window, 0–90, default **14**. It seeds sender profiles and campaign statistics; it computes no verdicts and performs no actions. `0` disables it, at the cost of first-contact signals being uninformative for the first weeks. |
+
+Push is the normal mode for both providers. Polling exists for small tenants and
+as a failure fallback; at scale it spends provider quota continuously whether or
+not any mail arrived.
+
+### `features`
+
+| Field | Meaning |
+|---|---|
+| `outbound_observation` | Ingest Sent mail as `direction: outbound`, observation-only — it is never remediated. **Defaults on**: outbound is where account takeover shows itself. |
+| `reports_mailbox` | The abuse mailbox to ingest as user reports. See [User Reports](user-reports.md). |
+| `pubsub_topic` | Google Workspace only. The topic Gmail publishes notifications to. It **must** live in the service account's own Google Cloud project — Gmail rejects any other. |
+| `pubsub_subscription` | Google Workspace only. The pull subscription the collector reads. Separate from the topic because a topic is write-only from Gmail's side. |
+
+A Pub/Sub field on an `m365` record is refused rather than ignored: it means a
+Workspace record was copied, and ignoring it would leave an operator believing
+push was configured through a topic nothing reads.
+
+## The connection test
+
+The single most useful thing after saving a record. It reports each requirement
+independently, so a UI (and a human) can say "step 4 is missing" instead of
+"connection failed".
+
+```bash
+limacharlie mailsec connection test <record-name> --oid $OID --output yaml
+```
+
+Every check carries `id`, `name`, `required`, `status` and — when it fails — a
+`detail` and a `remediation` naming the exact fix. `ok` is the AND of the
+**required** checks only.
+
+| Provider | Checks |
+|---|---|
+| Microsoft 365 | `credential` (authenticate to Graph), `mailbox_read` (list mailboxes), `mail_write` (`Mail.ReadWrite` — required), `mail_send` (`Mail.Send` — optional) |
+| Google Workspace | `credential` (key well formed), `directory` (`admin.directory.user.readonly`), `mail_modify` (`gmail.modify`), `mail_full` (`https://mail.google.com/` — optional), `mailbox_read` (list mailboxes in the domain), `pubsub_pull` (read the subscription), `pubsub_watch` (Gmail can publish to the topic) |
+
+Three properties are worth knowing:
+
+- **It takes a record name, not a credential.** The obvious shape — post the key,
+  get a verdict — would put a service-account private key in a request body,
+  where it transits the gateway and lands in logs. The credential stays in the
+  secret Hive; the test reads what is already there.
+- **A failed optional check is not an error.** A tenant that granted only the
+  narrow scopes has a working connection, and the missing capability is named
+  rather than silently absent.
+- **`--include-watch` has a side effect.** It establishes a real Gmail watch to
+  verify notification delivery end to end. The watch is idempotent and expires on
+  its own. Every other check is read-only.
+
+It requires `mailsec.act`, because it makes real calls against your provider.
+
+## Capability differences between providers
+
+Provider mechanics differ, and the differences are surfaced rather than papered
+over.
+
+| | Microsoft 365 | Google Workspace |
+|---|---|---|
+| **Quarantine** | Move to a hidden `LC Quarantine` folder — restorable, invisible to the user | Remove `INBOX`, add an `LC Quarantine` label |
+| **Trash** | Move to Recoverable Items — invisible to the user, recoverable by an admin. Distinct from Deleted Items | Add `TRASH` |
+| **Move to spam** | Move to the Junk Email folder | Add `SPAM` |
+| **Restore** | Move back to the folder we recorded, falling back to the Inbox | Invert the labels |
+| **Banner** | Edited **in place**; the message keeps its provider id | Gmail cannot edit a stored message, so the message is **replaced** and gets a **new provider id**. Requires the optional `https://mail.google.com/` scope; without it the action is refused by name, never reported as a silent success |
+| **Notification state** | Graph subscriptions can be listed, so reconciliation compares against the provider's own view | Gmail **cannot enumerate active watches**, so reconciliation uses stored state with correspondingly lower assurance. Every Workspace connection row says so |
+| **Reporter replies** | Need the optional `Mail.Send` application permission | Need the optional `https://mail.google.com/` scope |
+
+!!! note "Provider message ids are live handles"
+    A move mints a new provider id and invalidates the old one. The product
+    rewrites the stored handle after every action, which is why a restore days
+    after a quarantine still addresses the right message. If you script against
+    `provider_message_id`, re-read it rather than caching it.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Nothing is discovered or ingested | The Hive record was created disabled | `limacharlie hive enable --hive-name mailsec_provider --key <name>` |
+| `coverage` shows mailboxes as `discovered` but not `protected` | Discovery ran, subscription has not yet been established for those mailboxes | Give the subscription sweep a pass; if it persists, run the connection test |
+| Save refused with an unknown-field error | A key that is not in the record contract, or a Workspace-only field on an M365 record | Fix the key; the refusal names it |
+| Second connection for the same provider refused | Only one enabled record per provider is supported | Edit the existing record instead |
+| `connections.state` is `unconfigured` | No connection record exists, or none has completed a pass | Create/enable the record; an empty list is never reported as healthy |

--- a/docs/email-security/user-reports.md
+++ b/docs/email-security/user-reports.md
@@ -1,0 +1,174 @@
+# User Reports
+
+--8<-- "includes/email-security-beta.md"
+
+Your own people are the best detector you have for the mail that got through.
+Email Security turns an abuse mailbox into an SLA queue: reports are joined back
+to the original message across the whole tenant, robots that mail the abuse
+address are kept out of the numbers, and the reporter can be told what happened.
+
+## Setting it up
+
+Designate an abuse mailbox on the connection record:
+
+```yaml
+features:
+  reports_mailbox: phishing@corp.example
+```
+
+Anything delivered to that mailbox is read as a report. Point your existing
+report path at it — a "report phishing" button that forwards, a mail rule, or
+just an address people know.
+
+!!! warning "The abuse mailbox must not be a mailbox people report *from*"
+    A report is a message forwarded **to** the abuse address. One mailbox cannot
+    be both the sender and the destination of the same forward, so keep the
+    abuse address separate from the mailboxes your users send from.
+
+The reported message arrives as a forward carrying the original as a nested
+message. The parser handles the nesting, and the original is located across
+**every** protected mailbox by its internet message id — so a campaign that hit
+forty people is found from one person's report.
+
+## What happens to a report
+
+1. An `EMAIL_USER_REPORT` event is emitted and a report row is created.
+2. The original message is located across the tenant and joined to the report.
+3. The original's campaign, if it has one, is attached.
+4. The original is stamped `user_reported`. That flag outranks a benign verdict
+   in the triage queue — a human flagging something is the strongest free signal
+   the product gets.
+5. If reporter replies are enabled, the reporter is sent a templated
+   acknowledgement.
+
+Reports have three states: `open`, `triaging`, `resolved`.
+
+## The queue
+
+```bash
+limacharlie mailsec report list --status open --oldest-first --oid $OID
+limacharlie mailsec report get <report_id> --oid $OID
+```
+
+`--oldest-first` is what makes this an SLA surface rather than a feed. "The
+oldest thing nobody has looked at" is the question a queue exists to answer, and
+it is not answerable from a newest-first page.
+
+In the console, **Reports** carries the queue, per-row age and resolution, SLA
+tiles computed from exact sources, a drawer timeline (reported → joined →
+actioned → reporter replied) and pivots to the message and its campaign.
+
+### `original_found`
+
+Every report says whether its original was located. A report whose original was
+never indexed is a **real state**, not a blank field: the mail predates the
+connection, or it landed in a mailbox outside the connection's scope. It is shown
+as a gap so you can tell "we could not find it" from "we did not look".
+
+## Resolving
+
+```bash
+limacharlie mailsec report resolve <report_id> --disposition true_positive --oid $OID
+```
+
+| Disposition | Meaning |
+|---|---|
+| `true_positive` | It was malicious |
+| `false_positive` | We flagged it and it was fine |
+| `benign` | It was never a threat |
+
+Resolving requires `mailsec.set`, **not** `mailsec.act`: it changes triage state
+the product owns, and touches nobody's mailbox. That is the line `mailsec.act`
+draws.
+
+Resolving an already-resolved report succeeds and reports `already_resolved`, so
+two analysts clicking at once is not an error.
+
+!!! tip "`benign` also repairs the sender's history"
+    Resolving a report as `benign` subtracts that message's contribution from the
+    sender's flagged-history counter. Without it, one wrong flag would keep
+    weighing on every later message from a legitimate correspondent. The repair
+    runs once per report even if the resolution is retried.
+
+## Automated senders
+
+An abuse mailbox receives a great deal that is not a report: vendor service
+notices, ticketing and calendar robots, delivery-status notifications for mail
+the mailbox itself sent, and list traffic the address was subscribed to years
+ago. Left alone, each one becomes an open queue item with no reported message
+behind it, ageing in the SLA numbers next to real reports — and, with reporter
+replies on, gets mailed back to an address that cannot receive mail.
+
+So a message whose **sender says it is a machine** produces a report row that is
+born **resolved**, attributed to `system:automated-sender`.
+
+Five triggers, each independently sufficient, and every one of them is a
+statement the sending system made about itself:
+
+| Reason | What it is |
+|---|---|
+| `no_reply_local_part` | The address itself says replies go nowhere — `no-reply`, `no_reply`, `No.Reply`, `donotreply`, `do-not-reply`, and vendor variants like `<product>-noreply@…`. Matched on the local part only, tokenized on its separators, so `juno.reply` does not join them |
+| `auto_submitted` | RFC 3834: any `Auto-Submitted` keyword other than `no` means the message was generated automatically |
+| `precedence_bulk` | The pre-RFC convention: `Precedence: bulk`, `junk` or `auto_reply` |
+| `list_id` | RFC 2919: the message came from a mailing list — a distribution mechanism nobody clicks "report phishing" from. Carve-out: if the list-id names your own abuse mailbox (many organizations run the abuse address as a group), it does not count |
+| `null_return_path` | RFC 5321's null reverse path, required on every delivery-status notification. The sender is asserting this message must never be bounced |
+
+This is **not a filter**:
+
+- The message is still ingested, still indexed, still judged, and its raw copy is
+  still stored.
+- An `EMAIL_USER_REPORT` event is still emitted and a report row still exists.
+- The reasons are recorded on the report, so "auto-resolved because the sender set
+  `Precedence: bulk`" names the thing to argue with, rather than an unactionable
+  "auto-resolved".
+
+Two things it deliberately does *not* do:
+
+- **It does not stamp `user_reported` on the original.** No human flagged
+  anything. A delivery-status notification really does carry the message it
+  bounced, and manufacturing the product's strongest human signal out of a robot
+  — in the one place a reader cannot check — would be worse than the noise it
+  removes. The join is still recorded on the report; only the claim about who
+  made it is withheld.
+- **It never overrules a human.** The classifier gets exactly one attempt at a
+  report. A report an analyst has touched — reopened, put in `triaging`, or
+  resolved themselves — is left alone, which is what makes a reopen stick. That
+  is the whole basis on which auto-resolving is defensible.
+
+The `system:` prefix cannot be a real principal, so an analyst reading the
+resolved queue can tell at a glance that nobody looked.
+
+## Reporter replies
+
+Off by default: it sends mail on your behalf, to your own staff.
+
+```yaml
+policy_type: reporter_reply
+enabled: true
+templates:
+  malicious: "Thanks — you were right. We have removed that message from every mailbox it reached."
+  benign: "Thanks for checking. That message is legitimate; no action was needed."
+```
+
+- Templates are keyed by verdict, and a verdict with no template falls back to a
+  generic acknowledgement — enabling replies can never leave a reporter with
+  silence.
+- Templates are **plain text** (no `<` or `>`), capped in length. The rendering
+  is fixed in code.
+- Sending needs the optional provider capability: `Mail.Send` on Microsoft 365,
+  `https://mail.google.com/` on Google Workspace. Without it the reply is refused
+  **by name** rather than silently skipped.
+- Replies are **never** sent to an automated sender. A no-reply address either
+  blackholes it or bounces it straight back into the abuse mailbox, producing a
+  fresh report and another reply.
+- A reply is sent **once per report**, and the acknowledgement carries a marker so
+  it cannot be re-read as a new report. The loop guard requires both the marker
+  **and** that the sender is the abuse mailbox, because a header alone is
+  attacker-controlled — otherwise anyone who had ever received an
+  acknowledgement could forge one and keep a phish out of the abuse queue.
+
+## Automating on reports
+
+`EMAIL_USER_REPORT` is ordinary telemetry, so a D&R rule can act the moment
+someone reports something — page a channel, open a case, or drive remediation
+through the extension. See [Events & Automation](automation.md).

--- a/docs/includes/email-security-beta.md
+++ b/docs/includes/email-security-beta.md
@@ -1,0 +1,11 @@
+!!! warning "Private beta"
+    Email Security is in **private beta**. It is not generally available, and
+    access is enabled per organization — if the `ext-email-security` extension
+    is not in your catalog, this product is not turned on for you yet.
+
+    While it is in beta, expect the surface described here to move: commands,
+    fields and event shapes may change between releases, and they may change in
+    ways that are not backwards compatible. Pin a CLI version if you script
+    against it, and re-read this page after upgrading.
+
+    Talk to us before relying on it in production.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -585,7 +585,21 @@ nav:
           - Gap Analysis: 9-ai-sessions/compliance/gap-analysis.md
 
   - Email Security (Private Beta):
+      - Overview: email-security/index.md
+      - Getting Started: email-security/getting-started.md
+      - Connecting Providers: email-security/providers.md
+      - Provider Setup:
+          - Microsoft 365: email-security/provider-setup/microsoft-365.md
+          - Google Workspace: email-security/provider-setup/google-workspace.md
+      - Messages & Triage: email-security/messages.md
+      - Campaigns: email-security/campaigns.md
+      - User Reports: email-security/user-reports.md
+      - Detections & Verdicts: email-security/detections.md
+      - Custom Rules: email-security/custom-rules.md
+      - Policy Reference: email-security/policy.md
+      - Events & Automation: email-security/automation.md
       - Command Line Interface: email-security/cli.md
+      - API Reference: email-security/api-reference.md
       - AI Triage: email-security/ai-triage.md
 
   - Cloud Security:


### PR DESCRIPTION
Email Security had two pages in the docs (CLI and AI Triage) and no product section around them. This adds the rest: what the product is, how to connect each mail provider, how a verdict is produced, how to work the queue, and the configuration and API contracts.

## Structure

Mirrors the **Cloud Security** section, which is the closest existing product in shape — extension-gated, Hive-configured, provider connections, a findings-style worklist:

| Nav entry | Page |
|---|---|
| Overview | `email-security/index.md` |
| Getting Started | `email-security/getting-started.md` |
| Connecting Providers | `email-security/providers.md` |
| Provider Setup → Microsoft 365 | `email-security/provider-setup/microsoft-365.md` |
| Provider Setup → Google Workspace | `email-security/provider-setup/google-workspace.md` |
| Messages & Triage | `email-security/messages.md` |
| Campaigns | `email-security/campaigns.md` |
| User Reports | `email-security/user-reports.md` |
| Detections & Verdicts | `email-security/detections.md` |
| Custom Rules | `email-security/custom-rules.md` |
| Policy Reference | `email-security/policy.md` |
| Events & Automation | `email-security/automation.md` |
| Command Line Interface | `email-security/cli.md` *(existing)* |
| API Reference | `email-security/api-reference.md` |
| AI Triage | `email-security/ai-triage.md` *(existing)* |

The private-beta admonition the two existing pages each carried is now a snippet (`docs/includes/email-security-beta.md`) that every page in the section includes, so it is written once.

## Scope

Only shipped behaviour is documented. The setup pages carry the conceptual walkthrough and the prerequisites, and point at the in-product wizard for the organization-specific values, because those values are served by the product and go stale in any copy of them. No tenant identifiers, real addresses or secrets appear anywhere; every example uses reserved `.example` names.

## Two corrections to the existing CLI page

- **The hunt commands are removed.** The backing routes answer with a typed `not_implemented`, so documenting them sent readers at a wall.
- **`campaign action --confirm` took the campaign id**, which the server refuses. The confirmation token comes from the preview and is derived from the exact member set, so a campaign that grew while the operator was reading it fails the confirmation instead of sweeping a set nobody approved. The page now shows the preview → token → execute flow.

## Checks

`mkdocs build --strict`, `markdownlint-cli2` (0 errors over all 384 files), `check-list-numbering.py`, `check-release-note-headings.py`, `check-release-feeds.py` and `pytest tests/` (210 passed) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
