### PR TITLE
docs(reference): document dir_find, file_grep, container_list and multi-file artifact_get

### DIFF
--- a/docs/8-reference/edr-events.md
+++ b/docs/8-reference/edr-events.md
@@ -16,9 +16,11 @@ These are the events emitted by the endpoint agent for each supported operating 
 | [CLOUD\_NOTIFICATION](#cloud_notification) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | [CODE\_IDENTITY](#code_identity) | ☑️ | ☑️ | ☑️ |  |  |
 | [CONNECTED](#connected) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
+| [CONTAINER\_LIST\_REP](#container_list_rep) |  |  | ☑️ |  |  |
 | DATA\_DROPPED | ☑️ | ☑️ | ☑️ |  |  |
 | [DEBUG\_DATA\_REP](#debug_data_rep) |  | ☑️ |  |  |  |
 | DELETED\_SENSOR | ☑️ | ☑️ | ☑️ |  |  |
+| [DIR\_FIND\_REP](#dir_find_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [DIR\_FINDHASH\_REP](#dir_findhash_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [DIR\_LIST\_REP](#dir_list_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [DNS\_REQUEST](#dns_request) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
@@ -33,6 +35,7 @@ These are the events emitted by the endpoint agent for each supported operating 
 | [FILE\_DEL\_REP](#file_del_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [FILE\_DELETE](#file_delete) | ☑️ | ☑️ | ☑️ |  |  |
 | [FILE\_GET\_REP](#file_get_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [FILE\_GREP\_REP](#file_grep_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [FILE\_HASH\_REP](#file_hash_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [FILE\_INFO\_REP](#file_info_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [FILE\_MODIFIED](#file_modified) | ☑️ | ☑️ | ☑️ |  |  |
@@ -186,6 +189,43 @@ This event is generated when a Sensor connects to the cloud.
 }
 ```
 
+### CONTAINER\_LIST\_REP
+
+Response event for the `container_list` sensor command.
+
+**Platforms:** Linux
+
+Each entry in `CONTAINERS` describes one container or, when `--include-images`
+is used, one local image (`CONTAINER_IS_IMAGE`). Entries discovered from cgroups
+but not enriched by a container daemon are marked `CONTAINER_IS_PARTIAL`, and
+`CONTAINER_DAEMON_ERRORS` counts the daemon queries that failed.
+
+**Sample Event:**
+
+```json
+{
+  "event": {
+    "CONTAINERS": [
+      {
+        "CONTAINER_ID": "3f2b1c8d9e0a",
+        "CONTAINER_RUNTIME": "docker",
+        "NAME": "web-frontend",
+        "CONTAINER_IMAGE_REF": "nginx:1.27",
+        "CONTAINER_IMAGE_DIGEST": "sha256:9c2b0f...",
+        "CONTAINER_CREATED_AT": 1756684800000,
+        "STATE": "running",
+        "PROCESS_ID": 4812
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 217,
+    "CONTAINER_DAEMON_ERRORS": 0,
+    "CONTAINER_IS_PARTIAL": 0,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
+  }
+}
+```
+
 ### DEBUG\_DATA\_REP
 
 Response from a `get_debug_data` request. It reports the sensor's own internal state at the moment of the request, including `PACKAGE_VERSION_STRING` and `PACKAGE_VERSION_GIT` (the running build), `UPTIME`, `PROCESS_ID`, `PERCENT_CPU`, `MEMORY_USAGE`, `TIMEDELTA` (the sensor's clock offset), `KERNEL_ACQ_AVAILABLE`, and, starting with sensor version 5.3.6, `LOSS_ACCOUNTING`.
@@ -237,6 +277,49 @@ It answers a different question than [DATA_DROPPED](platform-events.md#data_drop
 - **Both bounds are enforced on every event that enters the queue**, so eviction can be triggered by either the event count or the byte budget. A host generating many small events reaches `LOSS_MAX_EVENTS` first; a host producing a few very large events reaches `LOSS_MAX_BYTES` first.
 - **A non-zero `LOSS_REFUSED_EVENTS` means individual events too large for the queue**, which is a different problem than an overloaded queue and is not solved by the host catching up on its backlog.
 - **These totals are accounted separately from the counter behind `DATA_DROPPED`.** Requesting `get_debug_data` does not consume or reset anything `DATA_DROPPED` reports, so the two signals can be used together.
+
+### DIR\_FIND\_REP
+
+Response event for the `dir_find` sensor command.
+
+**Platforms:** macOS | Windows | Linux
+
+`FILES` holds one entry per hit. `HASH_MD5`, `HASH_SHA1` and `HASH` (SHA-256)
+are present only when `--with-hashes` was requested. `FILE_IS_DIRECTORY` marks
+directory hits returned by `--include-dirs`.
+
+Every bounded search reports how much work it did, so a truncated result is
+never mistaken for an empty one:
+
+- `SCAN_ENTRIES_SCANNED`: filesystem entries examined
+- `SCAN_FILES_SCANNED`: files considered after the include/exclude expressions
+- `SCAN_BYTES_PROCESSED`: bytes read
+- `SCAN_IS_TRUNCATED`: `1` when a budget stopped the search early
+- `SCAN_STOPPED_REASON`: which budget stopped it
+
+**Sample Event:**
+
+```json
+{
+  "event": {
+    "FILES": [
+      {
+        "FILE_PATH": "C:\\Users\\jdoe\\Downloads\\setup.exe",
+        "FILE_SIZE": 481232,
+        "MODIFICATION_TIME": 1756771200000,
+        "HASH_MD5": "d41d8cd98f00b204e9800998ecf8427e",
+        "HASH_SHA1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "HASH": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 18422,
+    "SCAN_FILES_SCANNED": 15310,
+    "SCAN_BYTES_PROCESSED": 4812331,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
+  }
+}
+```
 
 ### DIR\_FINDHASH\_REP
 
@@ -443,6 +526,48 @@ Response event for the `file_get` sensor command.
   "FILE_CONTENT": "$BASE64_ENCODED_FILE_CONTENTS",
   "FILE_PATH": "C:\\windows\\system32\\svchost.exe",
   "FILE_SIZE": 78880
+}
+```
+
+### FILE\_GREP\_REP
+
+Response event for the `file_grep` sensor command.
+
+**Platforms:** macOS | Windows | Linux
+
+`FILE_MATCHES` is a flat list of matches across all files. `MATCH_PATTERN_INDEX`
+is the zero-based index of the `--pattern` that matched. `FILE_CONTENT` carries
+the matched bytes plus any requested `--context-bytes`, and is absent entirely
+when the search was run with `--no-content`.
+
+Every bounded search reports how much work it did, so a truncated result is
+never mistaken for an empty one:
+
+- `SCAN_ENTRIES_SCANNED`: filesystem entries examined
+- `SCAN_FILES_SCANNED`: files considered after the include/exclude expressions
+- `SCAN_BYTES_PROCESSED`: bytes read
+- `SCAN_IS_TRUNCATED`: `1` when a budget stopped the search early
+- `SCAN_STOPPED_REASON`: which budget stopped it
+
+**Sample Event:**
+
+```json
+{
+  "event": {
+    "FILE_MATCHES": [
+      {
+        "FILE_PATH": "/home/jdoe/app/.env",
+        "MATCH_PATTERN_INDEX": 0,
+        "MATCH_OFFSET": 412,
+        "MATCH_LENGTH": 21
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 9014,
+    "SCAN_FILES_SCANNED": 7781,
+    "SCAN_BYTES_PROCESSED": 33814402,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
+  }
 }
 ```
 
@@ -800,7 +925,13 @@ Provides HTTP Response headers.
 
 ### LOG\_GET\_REP
 
-Response from a `log_get` request.
+Response from a `log_get` or `artifact_get` request.
+
+For a multi-file `artifact_get --root-dir` request, the event carries a `FILES`
+list with one entry per selected file (`FILE_PATH`, `PAYLOAD_ID`, `ERROR`, and
+`ERROR_MESSAGE` on failure), plus the scan accounting fields
+`SCAN_ENTRIES_SCANNED`, `SCAN_FILES_SCANNED`, `SCAN_BYTES_PROCESSED`,
+`SCAN_IS_TRUNCATED` and `SCAN_STOPPED_REASON`.
 
 ### LOG\_LIST\_REP
 

--- a/docs/8-reference/endpoint-commands.md
+++ b/docs/8-reference/endpoint-commands.md
@@ -6,8 +6,10 @@ For commands which emit a report/reply event type from the agent, the correspond
 
 | Command | Report/Reply Event | macOS | Windows | Linux | Chrome | Edge |
 | --- | --- | --- | --- | --- | --- | --- |
-| [artifact\_get](#artifact_get) | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [artifact\_get](#artifact_get) | [LOG\_GET\_REP](edr-events.md#log_get_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [container\_list](#container_list) | [CONTAINER\_LIST\_REP](edr-events.md#container_list_rep) |  |  | ☑️ |  |  |
 | deny\_tree | N/A | ☑️ | ☑️ | ☑️ |  |  |
+| [dir\_find](#dir_find) | [DIR\_FIND\_REP](edr-events.md#dir_find_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [dir\_find\_hash](#dir_findhash) | [DIR\_FINDHASH\_REP](edr-events.md#dir_findhash_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [dir\_list](#dir_list) | [DIR\_LIST\_REP](edr-events.md#dir_list_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [dns\_resolve](#dns_resolve) | [DNS\_REQUEST](edr-events.md#dns_request) | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
@@ -18,6 +20,7 @@ For commands which emit a report/reply event type from the agent, the correspond
 | [exfil\_get](#exfil_get) | [GET\_EXFIL\_EVENT\_REP](edr-events.md#get_exfil_event_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [file\_del](#file_del) | [FILE\_DEL\_REP](edr-events.md#file_del_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [file\_get](#file_get) | [FILE\_GET\_REP](edr-events.md#file_get_rep) | ☑️ | ☑️ | ☑️ |  |  |
+| [file\_grep](#file_grep) | [FILE\_GREP\_REP](edr-events.md#file_grep_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [file\_hash](#file_hash) | [FILE\_HASH\_REP](edr-events.md#file_hash_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [file\_info](#file_info) | [FILE\_INFO\_REP](edr-events.md#file_info_rep) | ☑️ | ☑️ | ☑️ |  |  |
 | [file\_mov](#file_mov) | [FILE\_MOV\_REP](edr-events.md#file_mov_rep) | ☑️ | ☑️ | ☑️ |  |  |
@@ -68,24 +71,123 @@ For commands which emit a report/reply event type from the agent, the correspond
 
 ### artifact_get
 
-Collect an artifact from a sensor by specifying a file path.
+Collect one or more artifacts from a sensor and upload them to Artifact Collection.
+
+Exactly one of `--file`, `--source` or `--root-dir` must be given. `--root-dir`
+selects the bounded multi-file mode, which walks a directory tree and uploads
+every file matching the include expressions, subject to the budgets below.
 
 **Platforms:** macOS | Windows | Linux
 
 **Parameters:**
 
-- `file` (required): File path to collect from the sensor
-- `type` (optional): Artifact type (e.g., "pcap")
-- `payload_id` (optional): Idempotent payload ID for the request (auto-generated if not provided)
-- `days_retention` (optional): Number of days the artifact should be retained (default: 30)
-- `is_ignore_cert` (optional): If set, the sensor will ignore SSL certificate mismatches during artifact upload
+- `--file`: Single file path to collect from the sensor
+- `--source`: OS-specific artifact source to collect (for example a Windows Event Log channel)
+- `--root-dir`: Root directory for bounded multi-file retrieval
+- `-x, --file-exp` (optional): Glob to retrieve under `--root-dir`, repeatable; defaults to all files
+- `-X, --exclude-exp` (optional): Glob to exclude under `--root-dir`, repeatable
+- `-d, --depth` (optional): Maximum directory depth for multi-file retrieval (default: 6, max: 32)
+- `--max-files` (optional): Maximum files to upload (default: 25, max: 100)
+- `--max-file-size` (optional): Maximum size in bytes of each uploaded file (default: 8388608, max: 67108864)
+- `--max-total-bytes` (optional): Maximum bytes uploaded across all files (default: 67108864, max: 1073741824)
+- `--max-files-scanned` (optional): Maximum filesystem entries to examine (default: 250000)
+- `--max-seconds` (optional): Wall-clock discovery budget in seconds (default: 120, max: 900)
+- `--type` (optional): Artifact type (e.g., "pcap")
+- `--payload-id` (optional): Idempotent payload ID for the request (auto-generated if not
+  provided). Not valid with `--root-dir`; multi-file mode generates one payload ID per file.
+- `--days-retention` (optional): Number of days the artifact should be retained (default: 30)
+- `--is-ignore-cert` (optional): If set, the sensor will ignore SSL certificate mismatches during artifact upload
 
-**Response Event:** FILE_GET_REP
+**Response Event:** LOG_GET_REP
+
+**Usage Examples:**
+
+```bash
+limacharlie task send --sid <SID> --task 'artifact_get --file "C:\\Windows\\System32\\drivers\\etc\\hosts"'
+```
+
+Collect every `.conf` file under `/etc`, at most 10 files and 8 MB in total:
+
+```bash
+limacharlie task send --sid <SID> --task 'artifact_get --root-dir /etc -x "*.conf" --max-files 10 --max-total-bytes 8388608'
+```
+
+**Sample Response (multi-file):**
+
+```json
+{
+  "event": {
+    "FILES": [
+      {
+        "FILE_PATH": "/etc/ssh/sshd_config",
+        "PAYLOAD_ID": "4e6f2f1a-2c3d-4b5e-8a90-1f2e3d4c5b6a",
+        "ERROR": 200
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 812,
+    "SCAN_FILES_SCANNED": 137,
+    "SCAN_BYTES_PROCESSED": 48213,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
+  }
+}
+```
+
+Each entry reports the per-file upload status in `ERROR` (200 on success), with
+`ERROR_MESSAGE` present when an individual file fails. A partial run still
+returns the files it did upload.
+
+---
+
+### container_list
+
+Inventory the containers running on a Linux host, and optionally the local
+container images, across the Docker, containerd, Podman and CRI-O runtimes.
+
+Containers are discovered from cgroups, so they are reported even when no
+container daemon is reachable. When a Docker or Podman daemon is available the
+records are enriched with the image reference, digest, state and creation time;
+records that could not be enriched are marked `CONTAINER_IS_PARTIAL`.
+
+**Platforms:** Linux
+
+**Parameters:**
+
+- `--runtime` (optional): Runtime to query: `docker`, `containerd`, `podman`, `crio`, or `all` (default: `all`)
+- `--include-images` (optional): Also list local Docker/Podman images
+- `--include-stopped` (optional): Also list stopped Docker/Podman containers
+- `--limit` (optional): Maximum total records (default: 500, max: 5000)
+
+**Response Event:** CONTAINER_LIST_REP
 
 **Usage Example:**
 
 ```bash
-limacharlie sensor task <SID> artifact_get --file "C:\\Windows\\System32\\drivers\\etc\\hosts"
+limacharlie task send --sid <SID> --task 'container_list --runtime docker --include-images'
+```
+
+**Sample Response:**
+
+```json
+{
+  "event": {
+    "CONTAINERS": [
+      {
+        "CONTAINER_ID": "3f2b1c8d9e0a",
+        "CONTAINER_RUNTIME": "docker",
+        "NAME": "web-frontend",
+        "CONTAINER_IMAGE_REF": "nginx:1.27",
+        "CONTAINER_IMAGE_DIGEST": "sha256:9c2b0f...",
+        "STATE": "running",
+        "PROCESS_ID": 4812
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 217,
+    "CONTAINER_DAEMON_ERRORS": 0,
+    "CONTAINER_IS_PARTIAL": 0,
+    "SCAN_IS_TRUNCATED": 0
+  }
+}
 ```
 
 ---
@@ -122,6 +224,69 @@ limacharlie task send --sid <SID> --task 'dir_list "C:\\Windows\\System32" "*.ex
         "LAST_MODIFIED": 1579000000
       }
     ]
+  }
+}
+```
+
+---
+
+### dir_find
+
+Search a directory tree for files matching metadata criteria, and optionally
+return their hashes. This is the general form of
+[dir\_findhash](#dir_findhash): it can filter on size, modification time and
+hash at once, and it is bounded by explicit time, entry and byte budgets so a
+search cannot run away on a large filesystem.
+
+**Platforms:** macOS | Windows | Linux
+
+**Parameters:**
+
+- `rootDir` (positional, required): Root directory to search
+- `-x, --file-exp` (optional): Glob to include, repeatable; defaults to all files
+- `-X, --exclude-exp` (optional): Glob to exclude, repeatable; matching directories are pruned
+- `-d, --depth` (optional): Maximum directory depth (default: 1, max: 32)
+- `--min-size` (optional): Minimum file size in bytes
+- `--max-size` (optional): Maximum file size in bytes
+- `--newer-than` (optional): Only files modified after this Unix epoch second
+- `--older-than` (optional): Only files modified before this Unix epoch second
+- `--hash` (optional): MD5, SHA-1 or SHA-256 digest to match, repeatable
+- `--with-hashes` (optional): Return MD5, SHA-1 and SHA-256 for every hit
+- `--limit` (optional): Maximum results (default: 1000, max: 10000)
+- `--max-files-scanned` (optional): Maximum filesystem entries to examine (default: 250000, max: 5000000)
+- `--max-seconds` (optional): Wall-clock budget in seconds (default: 120, max: 900)
+- `--max-bytes` (optional): Maximum bytes read for hashing (default: 1073741824)
+- `--one-file-system` (optional): Do not cross filesystem boundaries
+- `--include-dirs` (optional): Also return matching directories
+
+**Response Event:** DIR_FIND_REP
+
+**Usage Example:**
+
+```bash
+limacharlie task send --sid <SID> --task 'dir_find "C:\\Users" -x "*.exe" -X "AppData" --depth 4 --newer-than 1756684800 --with-hashes'
+```
+
+**Sample Response:**
+
+```json
+{
+  "event": {
+    "FILES": [
+      {
+        "FILE_PATH": "C:\\Users\\jdoe\\Downloads\\setup.exe",
+        "FILE_SIZE": 481232,
+        "MODIFICATION_TIME": 1756771200000,
+        "HASH_MD5": "d41d8cd98f00b204e9800998ecf8427e",
+        "HASH_SHA1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "HASH": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 18422,
+    "SCAN_FILES_SCANNED": 15310,
+    "SCAN_BYTES_PROCESSED": 4812331,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
   }
 }
 ```
@@ -289,6 +454,73 @@ Retrieve a file from the endpoint and upload it to LimaCharlie cloud storage.
 ```bash
 limacharlie sensor task <SID> file_get --file_path "C:\\Windows\\System32\\calc.exe"
 ```
+
+---
+
+### file_grep
+
+Search the contents of files under a directory tree for one or more literal
+byte patterns. Patterns are literal, not regular expressions.
+
+Use `--no-content` to return only the path, pattern index, offset and length of
+each match and never any file bytes. This lets an operator confirm that a
+secret or indicator is present on a host without exfiltrating the surrounding
+data.
+
+**Platforms:** macOS | Windows | Linux
+
+**Parameters:**
+
+- `rootDir` (positional, required): Root directory to search
+- `-p, --pattern` (required): Literal byte pattern to find, repeatable
+- `-x, --file-exp` (optional): Glob to include, repeatable; defaults to all files
+- `-X, --exclude-exp` (optional): Glob to exclude, repeatable; matching directories are pruned
+- `-d, --depth` (optional): Maximum directory depth (default: 1, max: 32)
+- `-i, --ignore-case` (optional): Use ASCII case-insensitive matching
+- `--context-bytes` (optional): Surrounding bytes to return for each match (max: 4096)
+- `--no-content` (optional): Return only path and offsets, never file bytes
+- `--max-file-size` (optional): Maximum file size to read in bytes (default: 16777216, max: 67108864)
+- `--max-matches-per-file` (optional): Maximum matches returned per file (default: 10, max: 1000)
+- `--limit` (optional): Maximum total matches (default: 500, max: 10000)
+- `--max-files-scanned` (optional): Maximum filesystem entries to examine (default: 250000, max: 5000000)
+- `--max-seconds` (optional): Wall-clock budget in seconds (default: 120, max: 900)
+- `--max-bytes` (optional): Maximum bytes read (default: 1073741824)
+- `--binary` (optional): Also scan files that contain NUL bytes
+- `--one-file-system` (optional): Do not cross filesystem boundaries
+
+**Response Event:** FILE_GREP_REP
+
+**Usage Example:**
+
+```bash
+limacharlie task send --sid <SID> --task 'file_grep /home -x "*.env" -p "AWS_SECRET_ACCESS_KEY" --depth 5 --no-content'
+```
+
+**Sample Response:**
+
+```json
+{
+  "event": {
+    "FILE_MATCHES": [
+      {
+        "FILE_PATH": "/home/jdoe/app/.env",
+        "MATCH_PATTERN_INDEX": 0,
+        "MATCH_OFFSET": 412,
+        "MATCH_LENGTH": 21
+      }
+    ],
+    "SCAN_ENTRIES_SCANNED": 9014,
+    "SCAN_FILES_SCANNED": 7781,
+    "SCAN_BYTES_PROCESSED": 33814402,
+    "SCAN_IS_TRUNCATED": 0,
+    "SCAN_STOPPED_REASON": "completed"
+  }
+}
+```
+
+`MATCH_PATTERN_INDEX` is the zero-based index of the `--pattern` that matched.
+`FILE_CONTENT` carries the matched bytes plus any requested context, and is
+absent when `--no-content` is used.
 
 ---
 


### PR DESCRIPTION
## Summary

Four sensor taskings shipped in the endpoint agent without reference documentation. This adds them to the endpoint command reference and the EDR event reference, and corrects the existing `artifact_get` entry.

- **`dir_find`** — bounded metadata/hash file discovery; the general form of `dir_find_hash`, filtering on size, mtime and hash at once under explicit entry/time/byte budgets.
- **`file_grep`** — literal byte-pattern search inside files, including the `--no-content` mode that returns paths and offsets without any file bytes.
- **`container_list`** — Linux-only Docker/containerd/Podman/CRI-O inventory. This is the reference page's first single-OS Linux entry.
- **`artifact_get`** — the new `--root-dir` bounded multi-file mode, its budgets, and the fact that `--payload-id` is rejected there because multi-file mode mints one payload ID per file.

Each new tasking also gets its reply event documented in `edr-events.md` (`DIR_FIND_REP`, `FILE_GREP_REP`, `CONTAINER_LIST_REP`), with the shared scan-accounting fields explained so a truncated result is not mistaken for an empty one.

## Corrections to existing content

Both found while writing the above, and verified against the tasking parser and the sensor collector rather than inferred:

- `artifact_get`'s response event was documented as `FILE_GET_REP`. It is `LOG_GET_REP`. The OS-support table separately claimed `N/A` for the same field.
- `artifact_get --source` was undocumented.
- `LOG_GET_REP` was described as only a `log_get` response; it is also how every `artifact_get` result comes back.

## Accuracy

Every flag, default and cap is transcribed from the command parser's argument definitions and the endpoint-side validation constants; the reply-event fields come from the collectors that build them. Nothing here is from memory.

## Not included

No release-notes entry — agent 5.3.9 has not shipped, so there is no dated section to add these under. Worth a follow-up when it does.

Also out of scope, but worth flagging: `usb_list_devices` and `repo_list` are still undocumented on this page, and `usb_list_devices` is already announced in the 5.3.8 release notes.

## Validation

- `markdownlint-cli2` over all 384 docs — 0 issues
- `mkdocs build --strict` — clean; this is what catches a table row pointing at a missing anchor