### PR TITLE
docs(email-security): message pipeline and IOC feed recipe

### DIFF
--- a/docs/email-security/index.md
+++ b/docs/email-security/index.md
@@ -99,6 +99,7 @@ Managing connections and policy uses the ordinary Hive permissions for the
 
 | | |
 |---|---|
+| [How a Message Is Processed](pipeline.md) | The pipeline end to end: what is synchronous, what is stored, and how long it takes |
 | [Getting Started](getting-started.md) | Subscribe, connect a tenant, see the first judged message |
 | [Connecting Providers](providers.md) | The connection record, credentials, scope, ingest modes and the connection test |
 | [Microsoft 365](provider-setup/microsoft-365.md) · [Google Workspace](provider-setup/google-workspace.md) | Per-provider setup |
@@ -107,6 +108,7 @@ Managing connections and policy uses the ordinary Hive permissions for the
 | [User Reports](user-reports.md) | The abuse mailbox and the report SLA queue |
 | [Detections & Verdicts](detections.md) | How a verdict is produced, and what the rules can read |
 | [Custom Rules](custom-rules.md) | Writing, validating and backtesting your own mail rules |
+| [IOC & Reputation Feeds](ioc-feeds.md) | Mirroring a threat feed into a lookup and matching messages against it |
 | [Policy Reference](policy.md) | Every `mailsec_policy` record type |
 | [Events & Automation](automation.md) | The `EMAIL_*` events and wiring them to D&R |
 | [Command Line Interface](cli.md) · [API Reference](api-reference.md) | The programmable surface |

--- a/docs/email-security/ioc-feeds.md
+++ b/docs/email-security/ioc-feeds.md
@@ -1,0 +1,333 @@
+# IOC & Reputation Feeds
+
+--8<-- "includes/email-security-beta.md"
+
+The managed rule pack carries its own link and sender reputation signals. This
+page is about the other lane: mirroring a threat feed **you** have chosen, and
+are licensed to use, into a LimaCharlie `lookup`, then matching every message's
+links, attachments and sender domains against it.
+
+Nothing on this page is installed for you. Which feeds you trust, on what terms,
+and how hard you act on a hit are your decisions, and they differ enough between
+organizations that a default would be wrong more often than right.
+
+## How the pieces fit
+
+There is no email-specific feed integration. You are composing three things that
+already exist:
+
+| Piece | Role |
+|---|---|
+| [Lookup Manager](../5-integrations/extensions/limacharlie/lookup-manager.md) (`ext-lookup-manager`) | Fetches a feed on a schedule and writes it into a `lookup` Hive record |
+| The `lookup` Hive | Holds the indicator set, keyed by the name you chose |
+| `op: lookup` in a D&R rule | Tests one value out of a message against that record |
+
+The feed never touches Email Security's own configuration. It is an organization
+resource that a mail rule happens to read, which is why the same record can also
+back an EDR rule, a cloud rule, or a query.
+
+## Read the feed's licence first
+
+This is the part people skip, and it is the part that has consequences.
+
+A public threat feed is not public-domain data. Most carry terms covering
+redistribution, attribution and commercial use, and those terms bind **you**,
+not us. Two rules keep you out of trouble:
+
+- **Fetch from the source, with your own credential.** The Lookup Manager
+  configuration you write is your organization's, the key in it is your key, and
+  the request goes from LimaCharlie to the provider on your behalf. Do not
+  source a licensed feed from a third-party mirror, ours included, unless the
+  licence plainly allows it.
+- **Keep the attribution.** If the feed asks to be credited, credit it in the
+  lookup's `tags` and in the `name` of any rule that acts on it, so an analyst
+  reading a detection knows whose data decided it.
+
+!!! warning "abuse.ch feeds: free, but not unconditional"
+    The abuse.ch datasets (URLhaus, ThreatFox, MalwareBazaar) have required a
+    free **Auth-Key** since 2024, and they are offered under fair-use
+    principles rather than an open licence. Read
+    [abuse.ch Terms of Use](https://abuse.ch/terms-of-use/) and the
+    [Fair Use Principles](https://abuse.ch/terms-of-use/#principles) before you
+    configure anything.
+
+    Two consequences worth stating plainly:
+
+    - **Use your own Auth-Key**, obtained from your own abuse.ch account, in
+      your own organization's configuration.
+    - **Commercial or for-profit use may require a paid subscription.** If you
+      are an MSSP mirroring these feeds into customer tenants, that is exactly
+      the case abuse.ch's fair-use wording is about. Ask them, not us.
+
+## 1. Get a feed URL you are entitled to use
+
+Sign in to the provider and copy the export URL it gives *you*. For abuse.ch,
+the file exports embed your key as a path segment rather than a header:
+
+```text
+https://urlhaus-api.abuse.ch/v2/files/exports/YOUR-AUTH-KEY-HERE/<export-file>
+```
+
+The same shape holds for `threatfox-api.abuse.ch` and `mb-api.abuse.ch`. The
+exact filenames are listed on each feed's export page once you are signed in,
+so copy them from there rather than from this page.
+
+Pick an export that satisfies three constraints:
+
+| Constraint | Why |
+|---|---|
+| **Not a `.zip`** | The fetcher stores what it downloads. It does not unpack archives, so a zipped export lands as bytes nothing can read |
+| **JSON, or one indicator per line** | Those are the two shapes the `format` field understands. A CSV export is neither |
+| **Comfortably under 10 MB** | A `lookup` record is capped at 10 MB. Prefer the "recent" or "online" export over the full historical dump |
+
+!!! tip "Size is the constraint people hit"
+    The 10 MB ceiling is a hard limit on the Hive record, not a soft
+    recommendation, and the full dumps of the larger feeds are well past it.
+    Recent-window exports are also better detection content: an indicator from
+    three years ago mostly costs you review time.
+
+## 2. Subscribe the extension
+
+```bash
+limacharlie extension subscribe --name ext-lookup-manager --oid $OID
+```
+
+## 3. Configure the feed
+
+The extension configuration is a single record holding **every** lookup the
+extension manages, so read the current one before you write.
+
+```bash
+limacharlie extension config-get --name ext-lookup-manager --oid $OID --output yaml
+```
+
+```yaml
+# lookups.yaml. This REPLACES the whole configuration.
+data:
+  lookup_manager_rules:
+    - name: abusech-urlhaus-domains
+      arl: "[https,urlhaus-api.abuse.ch/v2/files/exports/YOUR-AUTH-KEY-HERE/<export-file>]"
+      format: newline
+      tags: [ioc, abusech, urlhaus]
+
+    - name: abusech-malwarebazaar-sha256
+      arl: "[https,mb-api.abuse.ch/v2/files/exports/YOUR-AUTH-KEY-HERE/<export-file>]"
+      format: newline
+      tags: [ioc, abusech, malwarebazaar]
+```
+
+```bash
+limacharlie extension config-set --name ext-lookup-manager \
+  --input-file lookups.yaml --oid $OID
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | The `lookup` record key this feed becomes, and therefore the name your rules will reference. Pick it once; renaming it orphans every rule pointing at the old name |
+| `arl` | An [Authenticated Resource Locator](../8-reference/authentication-resource-locator.md). `[https,<host-and-path>]` is the whole form you need when the key is already in the path |
+| `format` | `json`, `newline`, `yaml` or `optimized`. `newline` is the one for a plain indicator-per-line list |
+| `tags` | Copied onto the `lookup` record. Tag the source here so the record's provenance survives the person who added it |
+
+!!! warning "An ARL is comma-delimited"
+    The bracket form splits on commas, so a URL containing one will not parse.
+    Every abuse.ch export URL is comma-free, but check yours before assuming.
+
+    An ARL also cannot set an arbitrary HTTP header. It supports `basic`,
+    `bearer`, `token` and OTX authentication only, which is why the workable
+    pattern is a feed that carries its credential in the URL. If your feed
+    insists on a custom header, mirror it into a private GitHub repository or a
+    GCS bucket yourself and point the ARL at that instead.
+
+## 4. Sync it, and check what landed
+
+A new configuration is **not** fetched immediately. The extension installs a
+24-hour sync schedule when you subscribe, so without a manual kick your first
+lookup could be a day away:
+
+```bash
+limacharlie extension request --name ext-lookup-manager --action sync --oid $OID
+```
+
+Then confirm the record exists and holds what you expect:
+
+```bash
+limacharlie hive get --hive-name lookup --key abusech-urlhaus-domains \
+  --oid $OID --output yaml | head -40
+```
+
+A `newline` feed is stored as one key per line with no metadata attached. Blank
+lines are dropped; comment lines are not, so a feed with a `#`-prefixed header
+block contributes a handful of keys that no message will ever match. Harmless,
+but do not mistake them for indicators when you eyeball the record.
+
+!!! danger "Indicators must be lowercase"
+    A D&R rule lowercases the value it extracts before looking it up, unless the
+    rule sets `case sensitive: true`. A feed shipping uppercase hashes therefore
+    matches **nothing**, silently, and looks exactly like a feed with no hits in
+    it. Check a sample of the stored keys, not just the record's existence.
+
+## 5. Match messages against it
+
+`EMAIL_MESSAGE` carries the whole parsed message, so a rule reads the links,
+attachments and sender out of the event and tests them against the lookup. These
+run in the platform seat and produce a **LimaCharlie detection**. See
+[Events & Automation](automation.md) for the seat this sits in.
+
+### A link pointing at a known-bad domain
+
+```yaml
+# hive: dr-general, record name: email-link-in-ioc-feed
+detect:
+  op: and
+  rules:
+    - op: is
+      path: routing/event_type
+      value: EMAIL_MESSAGE
+    - op: lookup
+      path: event/links/?/href_url/domain/root
+      resource: hive://lookup/abusech-urlhaus-domains
+
+respond:
+  - action: report
+    name: email-link-matches-urlhaus
+    priority: 2
+```
+
+`?` walks every element of `links`, and `href_url/domain/root` is the
+registrable root domain of the destination, so `login.evil.example` matches an
+entry for `evil.example`. That is usually what you want from a domain feed. If
+your feed lists full URLs rather than domains, point the path at
+`event/links/?/href_url/raw` instead and accept that it will then only match a
+byte-identical URL.
+
+### An attachment whose hash is in a malware feed
+
+```yaml
+# hive: dr-general, record name: email-attachment-in-ioc-feed
+detect:
+  op: and
+  rules:
+    - op: is
+      path: routing/event_type
+      value: EMAIL_MESSAGE
+    - op: lookup
+      path: event/attachments/*/sha256
+      resource: hive://lookup/abusech-malwarebazaar-sha256
+
+respond:
+  - action: report
+    name: email-attachment-matches-malwarebazaar
+    priority: 1
+```
+
+`*` rather than `?` here on purpose: attachment explosion nests unpacked
+children under `attachments[].explode.children[]`, recursively, and each child
+carries its own hashes. The recursive wildcard reaches the hash of a payload
+inside an archive inside an archive, which is the one an attacker was counting
+on you not to compute.
+
+### A sender whose domain is in a feed
+
+```yaml
+# hive: dr-general, record name: email-sender-domain-in-ioc-feed
+detect:
+  op: and
+  rules:
+    - op: is
+      path: routing/event_type
+      value: EMAIL_MESSAGE
+    - op: lookup
+      path: event/headers/from/email/domain/root
+      resource: hive://lookup/my-sender-domain-blocklist
+
+respond:
+  - action: report
+    name: email-sender-domain-matches-feed
+    priority: 2
+```
+
+### Acting on it, not just alerting
+
+A detection is the safe default. When you trust a feed enough to move mail on
+its say-so, add the remediation action to the same rule. It goes through the
+product's single remediation path, so `alert_only` / `enforce` mode, idempotency
+and the audit row all apply unchanged:
+
+```yaml
+respond:
+  - action: report
+    name: email-link-matches-urlhaus
+  - action: extension request
+    extension name: ext-email-security
+    extension action: quarantine_message
+    extension request:
+      msg_uuid: '{{ .event.msg_uuid }}'
+```
+
+Do this feed by feed rather than for feeds in general. A high-confidence,
+narrowly-scoped list is worth quarantining on. A large aggregated reputation
+list, refreshed daily, is worth a detection and a human.
+
+## Changing the verdict instead of raising a detection
+
+Everything above runs *after* the verdict is decided, so a feed hit produces a
+detection alongside a message the engine may still have called benign. Feeding
+the match into the verdict itself is the other seat: a `dr-mail` signal rule,
+which compounds with the managed pack in the same scoring pass. Rules there
+address the message model at the **root**, with no `event/` prefix:
+
+```yaml
+# What this will look like. It is NOT accepted today; see the note below.
+name: Link matches my IOC feed
+phase: pre_verdict
+class: detection
+weight: 90
+confidence: 90
+tags: [ioc]
+fp_notes: >
+  Only as good as the feed. Review the feed's own false-positive rate before
+  giving this a weight this high.
+detect:
+  op: lookup
+  path: links/?/href_url/domain/root
+  resource: hive://lookup/abusech-urlhaus-domains
+```
+
+!!! warning "Lookups in `dr-mail` are not available yet"
+    The `dr-mail` Hive validates a rule against a closed list of operators, and
+    `lookup` is not on it. A record using it is **refused at write time**, not
+    accepted and quietly ignored.
+
+    The reason is deliberate: the operator is service-backed, and enabling it
+    before the mail engine supplies it a lookup provider would mean a rule that
+    parses and never matches. The two land together or not at all. Until then,
+    use the `dr-general` rules above, which work today and give you the same
+    match with a detection instead of a score.
+
+## Keeping it honest
+
+- **Freshness is 24 hours by default.** A feed syncs on the extension's
+  schedule, so a rule's worst case is a day-old indicator set. For a feed you
+  depend on, run a manual `sync` after any change and treat the lookup's
+  contents as evidence, not as a live oracle.
+- **A miss is not a verdict.** Absence from a feed says only that the feed had
+  not published the indicator when it was last fetched. Write rules that treat a
+  hit as evidence and never treat a non-hit as clearance.
+- **Backtest before you enforce.** `limacharlie mailsec message list
+  --link-domain <domain>` tells you who else received a given domain, which is
+  the fastest way to find out whether a feed you are about to trust would have
+  quarantined something it should not have. See
+  [Messages & Triage](messages.md#the-two-ioc-pivots).
+- **One feed, one lookup.** Merging several sources into one record saves a
+  little configuration and costs you the ability to say which source decided a
+  quarantine. Keep them separate and let the rule names carry the attribution.
+
+## Related pages
+
+| | |
+|---|---|
+| [Lookup Manager](../5-integrations/extensions/limacharlie/lookup-manager.md) | The extension itself, outside a mail context |
+| [Authenticated Resource Locator](../8-reference/authentication-resource-locator.md) | The ARL forms and auth types |
+| [Detections & Verdicts](detections.md) | How a verdict is produced and what the rules can read |
+| [Custom Rules](custom-rules.md) | Writing `dr-mail` rules |
+| [Events & Automation](automation.md) | The `EMAIL_*` events and the D&R seat |

--- a/docs/email-security/pipeline.md
+++ b/docs/email-security/pipeline.md
@@ -1,0 +1,283 @@
+# How a Message Is Processed
+
+--8<-- "includes/email-security-beta.md"
+
+This is the page to read first if you are evaluating the product. It follows one
+message from the moment your provider says it exists to the moment somebody
+decides what to do about it, and it is explicit about which parts happen in one
+pass and which parts can happen later.
+
+The short version: **everything that produces the first verdict happens
+synchronously, in one pass, per message.** There is no queue of half-judged mail
+and no second job that fills in the answer. Anything that changes a verdict
+afterwards is recorded as a *revision*, not as a late arrival.
+
+## The stages
+
+| # | Stage | What happens |
+|---|---|---|
+| 1 | **Notify** | The provider tells us a message exists |
+| 2 | **Fetch** | The raw MIME is pulled from the provider |
+| 3 | **Parse** | MIME becomes the Message Data Model |
+| 4 | **Enrich** | Sender history, lookalike, domain age, link features, attachment explosion |
+| 5 | **Score** | The managed pack and your `dr-mail` rules are matched and scored as one set |
+| 6 | **Verdict** | One class, one score, and the signals that produced them |
+| 7 | **Cluster** | The message is attributed to a campaign, or not |
+| 8 | **Persist** | Index row, sealed raw message, sealed judged model |
+| 9 | **Emit** | `EMAIL_MESSAGE`, once |
+| 10 | **Automate** | Policy automations, `dr-mail` `post_verdict` rules, and ordinary D&R rules |
+| 11 | **Triage** | A person or an agent revises the verdict, if it needs revising |
+| 12 | **Remediate** | The message is moved at the provider |
+
+Stages 2 through 9 are one function call. If any of them fails, the failure is
+emitted as `EMAIL_INGEST_ERROR` rather than swallowed.
+
+### 1. Notify
+
+Email Security connects to the provider's API. **There is no MX change, no mail
+routing change, and nothing in the delivery path.** It is post-delivery: the
+message has already landed in the mailbox by the time we hear about it.
+
+| Provider | Mechanism |
+|---|---|
+| Microsoft 365 | A Microsoft Graph change-notification subscription per protected mailbox. Subscriptions are renewed well before Graph's ceiling, and lifecycle notifications are handled on their own endpoint |
+| Google Workspace | A Gmail `users.watch` per mailbox publishing to **your own** Pub/Sub topic, which the collector consumes with a pull subscription. Renewed daily. A history-based poll is the fallback for small tenants and for outages |
+
+Both are push. Polling exists as a safety net, not as the normal path. See
+[Connecting Providers](providers.md).
+
+### 2-3. Fetch and parse
+
+The raw MIME is fetched and parsed into the **Message Data Model**: headers with
+decomposed addresses and domains, sender, recipients, subject, a
+thread-segmented body, links, attachments, parsed SPF/DKIM/DMARC/ARC results,
+and the `Received` chain. Every later stage reads the model, never the bytes.
+
+### 4. Enrich
+
+Enrichers run in a fixed order so a given message produces the same model every
+time: sender and sender-domain history, then static link features, then
+lookalike and VIP impersonation distances, then attachment explosion. Sender
+domain registration age is resolved from RDAP through a bounded cache.
+
+**Attachment explosion runs here, inline.** Archives are unpacked recursively,
+macros extracted, QR codes decoded, files identified by content rather than by
+the extension the sender claimed. It carries a per-message time budget; when the
+budget is exhausted the verdict is computed without it and the model says so
+(`_meta/explode_timeout`) instead of pretending the file was clean.
+
+Everything an enricher resolves is stamped **into** the message, which is why a
+rule reads an enrichment as an ordinary path and why re-reading the event later
+shows exactly what the engine saw. An enrichment that could not be resolved is
+*absent*, never a reassuring default. See
+[Detections & Verdicts](detections.md#enrichments).
+
+### 5-6. Score and decide
+
+The managed rule pack and your own `dr-mail` `pre_verdict` rules are matched
+separately and then **scored together as one set**. That matters more than it
+sounds: a custom rule is evidence in the same verdict rather than a second
+opinion sitting beside it, so two 50-weight signals from different sources
+compound instead of standing at 50 each.
+
+The score is a weighted compounding model, not a "first rule to fire wins"
+model. Each signal removes a fraction of the remaining headroom, so five weak
+signals cannot outvote one strong one. The arithmetic, the thresholds, the
+graymail lane and the exclusion mechanism are all in
+[Detections & Verdicts](detections.md#scoring).
+
+The result is one verdict (`malicious`, `suspicious`, `graymail`, `benign`,
+`unknown` or `error`), a score, and the signals that produced it.
+
+### 7-9. Cluster, persist, emit
+
+The message is clustered into a [campaign](campaigns.md) if it belongs to one,
+then written: an index row, the sealed raw message, and the sealed **judged
+model** (the enrichments as resolved and the verdict as stamped).
+
+Then `EMAIL_MESSAGE` is emitted, once. It is immutable, and it carries the whole
+model including the enrichments and the verdict, so a D&R rule never has to call
+back for context.
+
+### 10-12. Automate, triage, remediate
+
+From here the message is ordinary work: [policy automations](policy.md#automations)
+and `post_verdict` rules can dispatch an action, [D&R rules](automation.md) on
+the `EMAIL_*` events get the platform's full response set, an analyst or an
+[AI triage agent](ai-triage.md) can revise the verdict, and remediation moves
+the message at the provider.
+
+## What is synchronous, and what is not
+
+| | |
+|---|---|
+| **Synchronous, one pass per message** | Fetch, parse, every enrichment including attachment explosion, matching, scoring, the verdict, campaign clustering, persistence, and the `EMAIL_MESSAGE` emission |
+| **Later, and recorded as such** | Verdict revisions, remediation outcomes, campaign membership added when a later message joins the cluster |
+
+A revision does **not** rewrite `EMAIL_MESSAGE`. The original event stands as the
+record of what the engine decided at ingest, a revision row is appended with its
+sequence number, and an `EMAIL_VERDICT` event is emitted carrying the new
+conclusion. Two consumers reading the same stream therefore agree on both what
+was decided and what it was changed to, which a mutated event could never give
+you.
+
+!!! info "Why the first pass is not allowed to wait"
+    Anything the pipeline waits on is a mailbox that stays unjudged while it
+    waits. So every enricher is bounded, every one of them can fail toward "not
+    resolved", and the verdict is computed from whatever resolved in time with
+    the gaps named. A slow enrichment degrades one signal. A blocking one
+    degrades coverage, which is the thing you bought.
+
+## Managed detections are optional
+
+The managed rule pack is on by default, and you can turn it off. Some
+organizations want to own detection entirely through their own `dr-mail` rules,
+and forcing our opinions into their verdicts would make that impossible.
+
+```yaml
+# hive: mailsec_policy, record name: 00-managed-rules
+policy_type: managed_rules
+enabled: false
+```
+
+```bash
+limacharlie hive set --hive-name mailsec_policy --key 00-managed-rules \
+  --input-file managed-rules.yaml --enabled --oid $OID
+```
+
+The extension also exposes `get_managed_rules` and `set_managed_rules` for
+reading and flipping this without hand-writing the record.
+
+| | |
+|---|---|
+| **Default** | Enabled. An organization that has written no policy has the pack |
+| **When disabled** | The managed pack is not matched at all. Your own `dr-mail` rules still are, and they are still scored the same way |
+| **If nothing matches** | The verdict is `unknown`, never `benign`. "Nobody was looking" and "we looked and it was fine" are different facts and are reported differently |
+| **Time to take effect** | On the next policy resolve. A policy change invalidates the cache, and there is a five-minute backstop for a change we did not hear about |
+
+The record must state `enabled` explicitly. A `managed_rules` record that sets
+nothing is refused rather than read as "disable", because the failure mode of
+guessing wrong here is an organization with no detection that believes it has
+some.
+
+You do not need this switch to tune the pack. Disabling one packaged rule, or
+changing its weight, is a
+[`rule_overrides`](custom-rules.md#tuning-the-managed-pack) entry.
+
+## The state model
+
+A message carries several **independent** dimensions. They are not stages of one
+workflow, and reading them as if they were is the most common way to
+misinterpret the queue.
+
+| Dimension | Values | Changed by |
+|---|---|---|
+| **Verdict** | `malicious`, `suspicious`, `graymail`, `benign`, `unknown`, `error` | The scoring pass, then any revision |
+| **Decision mode** | `auto`, `analyst`, `ai` | Who last decided. `auto` is the rule pack |
+| **Revision history** | An append-only sequence | Each revision, with its rationale |
+| **Report status** | `open`, `triaging`, `resolved`, plus a disposition | The [abuse-mailbox queue](user-reports.md) |
+| **Remediation state** | `delivered`, `quarantined`, `trashed`, `restored`, `bannered`, `spam` | Actions performed at the provider |
+| **Campaign membership** | A campaign id, or none | The [clustering engine](campaigns.md) |
+
+Each has exactly one writer. A quarantined message can still be `benign`
+(somebody quarantined it anyway), a `malicious` message can still be `delivered`
+(nobody acted, or the organization is in `alert_only`), and a resolved report
+can sit on a message whose verdict was never revised. Collapsing these into a
+single "status" would lose every one of those distinctions.
+
+## Storage and privacy
+
+A mail security product holds the most sensitive data in the tenant, so it is
+worth being precise about what is kept, where, and who can read it.
+
+### The raw message
+
+The full original message is stored, compressed and then encrypted with
+**AES-256-GCM**. Keys are **per organization**, derived with HKDF from a root key
+that is itself KMS-wrapped, so the deployment's secret is ciphertext and only a
+workload with decrypt permission on the KMS key can turn it into key material. A
+service that cannot reach KMS fails to start rather than falling back to
+plaintext.
+
+The object's own storage path is bound into the encryption as additional
+authenticated data, which means a copied object cannot be opened somewhere else.
+
+### Two retention lanes
+
+| Lane | Kept | Holds |
+|---|---|---|
+| Transient | **35 days** | Every message |
+| Retained | up to **400 days** | Flagged messages and the evidence attached to them |
+
+The lane is chosen at ingest from the verdict. A message that becomes evidence
+later, because it was reported, re-judged or acted on, is promoted into the
+retained lane by re-sealing it there. The retained window is tunable within the
+ceiling through [`mailsec_policy/retention`](policy.md#retention); 400 days is
+the store's hard limit, and policy can only choose within what the store keeps.
+
+The searchable message index keeps 35 days as well. `EMAIL_*` events go to the
+platform's telemetry lake and follow your ordinary retention, which is why
+[LCQL](automation.md#querying-mail-with-lcql) reaches further back than the queue
+does.
+
+### What lands in telemetry
+
+`EMAIL_MESSAGE` carries parsed body content, so mail text is in your normal
+telemetry and is subject to your normal Outputs and access controls. Plan for
+that deliberately rather than discovering it.
+
+Body parts are capped at roughly **256 KB each**. When a cap is hit the model
+sets `body/truncated` and `_meta/truncations` names the exact paths that were
+clipped, so a rule author can tell a short message from a clipped one. The
+stored raw message always holds the full content regardless.
+
+### Reading a message back
+
+Opening the drawer serves the **sealed judged model** where it exists, labelled
+`mdm_source: stored`. That is what the engine actually decided with, enrichments
+included. The fallback re-parses the encrypted raw message with today's parser
+(`mdm_source: eml_reparse`) and carries no enrichments at all, and the response
+always says which one you are reading. Neither needs a justification: the model
+is the product's structured view of the message.
+
+The **original bytes** are gated separately. Downloading the EML requires the
+`mailsec.get.eml` permission on top of `mailsec.get`, plus a written
+justification that is stored verbatim against your authenticated identity. A
+failed attempt is recorded too, and the bytes are not served if the audit write
+fails. See [Messages & Triage](messages.md#downloading-the-original-message).
+
+## Latency
+
+End-to-end time for a message is three terms:
+
+| Term | Who owns it |
+|---|---|
+| **Provider notification delay** | Your mail provider. This is normally the dominant term and it is not ours to shorten |
+| **Queue** | Time between the notification arriving and a worker picking it up |
+| **Processing** | Fetch, parse, enrich, score, persist, emit |
+
+Within processing, fetching from the provider and exploding attachments are the
+expensive stages, and only the second of those is bounded by a budget we choose.
+Parsing, matching and scoring are not where the time goes.
+
+!!! note "We do not publish a latency figure yet"
+    The `coverage` call reports the processing-latency percentile as
+    **not recorded** rather than returning an estimate, because the immutable
+    timestamps that would make it a measurement are not yet recorded. A number
+    that looks like a measurement and is not one is worse than an honest gap, so
+    the gap is what you get until it can be computed properly.
+
+    Verdict revisions are a separate clock entirely. A revision arrives when a
+    person or an agent gets to the message, which is a queue-depth question
+    rather than a pipeline question.
+
+## Where to go next
+
+| | |
+|---|---|
+| [Getting Started](getting-started.md) | Connect a tenant and see the first judged message |
+| [Detections & Verdicts](detections.md) | The scoring model, the managed pack, and what the rules can read |
+| [Custom Rules](custom-rules.md) | Writing `dr-mail` rules that compound with the pack |
+| [Events & Automation](automation.md) | The `EMAIL_*` events and the D&R seat |
+| [Messages & Triage](messages.md) | The queue, the drawer, actions and the audit trail |
+| [Policy Reference](policy.md) | Every `mailsec_policy` record type |

--- a/docs/email-security/pipeline.md
+++ b/docs/email-security/pipeline.md
@@ -135,7 +135,7 @@ organizations want to own detection entirely through their own `dr-mail` rules,
 and forcing our opinions into their verdicts would make that impossible.
 
 ```yaml
-# hive: mailsec_policy, record name: 00-managed-rules
+# managed-rules.yaml, saved as mailsec_policy record 00-managed-rules
 policy_type: managed_rules
 enabled: false
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -586,6 +586,7 @@ nav:
 
   - Email Security (Private Beta):
       - Overview: email-security/index.md
+      - How a Message Is Processed: email-security/pipeline.md
       - Getting Started: email-security/getting-started.md
       - Connecting Providers: email-security/providers.md
       - Provider Setup:
@@ -596,6 +597,7 @@ nav:
       - User Reports: email-security/user-reports.md
       - Detections & Verdicts: email-security/detections.md
       - Custom Rules: email-security/custom-rules.md
+      - IOC & Reputation Feeds: email-security/ioc-feeds.md
       - Policy Reference: email-security/policy.md
       - Events & Automation: email-security/automation.md
       - Command Line Interface: email-security/cli.md


### PR DESCRIPTION
Two new Email Security pages, both nav-placed and lint-clean.

## `email-security/pipeline.md` — "How a Message Is Processed"

Placed directly after **Overview**, because it is the page an evaluator wants before anything else.

Covers the twelve stages from provider notification to remediation, and is explicit about the thing product pages usually blur:

- **What is synchronous.** Fetch, parse, every enrichment *including attachment explosion*, matching, scoring, the verdict, clustering, persistence and the `EMAIL_MESSAGE` emission are one pass per message. Anything that changes a verdict afterwards is an appended revision that emits `EMAIL_VERDICT`; `EMAIL_MESSAGE` is never rewritten.
- **Managed detections are optional.** The `mailsec_policy` / `managed_rules` opt-out, the fact that the record must state `enabled` explicitly, and that with nothing matching the verdict is `unknown` rather than `benign`.
- **The state model** as six independent dimensions with one writer each, rather than one collapsed "status".
- **Storage and privacy.** AES-256-GCM, per-org keys derived from a KMS-wrapped root, storage path bound in as additional authenticated data, the 35-day transient / 400-day retained lanes, the ~256 KB per-part body cap with `body/truncated` and `_meta/truncations`, and the separately-gated EML download.
- **Latency** as three terms (provider notification delay, queue, processing) with **no invented numbers**. The page says plainly that we do not publish a latency figure yet, which matches the backend reporting that percentile as not recorded rather than estimating one.

## `email-security/ioc-feeds.md` — "IOC & Reputation Feeds"

Placed after **Custom Rules**. The recipe for mirroring a threat feed into a `lookup` with `ext-lookup-manager` and matching message links, attachments and sender domains against it.

Licensing is stated up front and not softened: fetch from the source with your own credential, keep the attribution, and read abuse.ch's fair-use terms before mirroring their data. No LimaCharlie-hosted copy of a licensed feed is referenced or recommended anywhere on the page.

### Two corrections to the original brief, worth a look

1. **The `Auth-Key` header does not work, and the page does not claim it does.** An ARL supports `basic`, `bearer`, `token` and OTX auth only; it cannot set an arbitrary HTTP header. What *does* work is that abuse.ch's v2 file exports carry the key as a **URL path segment**, so a plain `[https,host/path]` ARL is sufficient. The page documents that, plus the escape hatch (mirror to your own GitHub/GCS) for feeds that insist on a header.
2. **`op: lookup` is not usable in `dr-mail` today.** The hive validator's operator allowlist does not include it, so such a record is refused at write time, not silently ignored. The page shows the intended rule shape but marks it unambiguously as unavailable, and makes the `dr-general` rules on `EMAIL_MESSAGE` the recipe that actually works.

Other constraints surfaced because they are the ones people will actually hit: the 10 MB `lookup` record ceiling (full feed dumps exceed it), no archive unpacking, `format` accepting only `json` / `newline` / `yaml` / `optimized`, the 24h sync schedule meaning a new config is not fetched until you run a manual `sync`, and the fact that D&R lowercases the extracted value so an uppercase-hash feed matches nothing silently.

## Verification

- Every event name, path, hive name, policy type, `format` value, permission and retention number was checked against the code rather than recalled.
- Every CLI verb and flag was checked with read-only `--help` / `--ai-help`. No mutating command was run.
- `markdownlint-cli2` clean; all internal links and heading anchors resolve.
- Production was not touched.

## For the reviewer

Two claims are ahead of `master` in their own repos and should be confirmed before this merges: the `set_managed_rules` / `get_managed_rules` extension actions, and the collector-side gate on the managed pack. The `managed_rules` policy type itself is already accepted. Everything else on both pages is on `master` today or is already documented in the existing beta pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)