### PR TITLE
docs(email-security): EMAIL_VERDICT is the whole verdict stream, not just the overrides

### DIFF
--- a/docs/email-security/ai-triage.md
+++ b/docs/email-security/ai-triage.md
@@ -34,7 +34,7 @@ clear is the whole idea, so here it is explicitly.
 
 | Email Security provides (the substrate) | You assemble (the recipe) |
 |---|---|
-| The events an agent triggers on, on the `edr` D&R target: `EMAIL_MESSAGE`, `EMAIL_USER_REPORT`, `EMAIL_ACTION` (and `EMAIL_VERDICT` for the write-back) | The `ai_agent` record — the agent's playbook, model, and session limits |
+| The events an agent triggers on, on the `edr` D&R target: `EMAIL_MESSAGE`, `EMAIL_VERDICT`, `EMAIL_USER_REPORT`, `EMAIL_ACTION`. Note `EMAIL_VERDICT` fires for **every** verdict decision, including the engine's own at ingest (`revision/seq: 0`) — a trigger meant for overrides only should say `revision/seq` is greater than `0` | The `ai_agent` record — the agent's playbook, model, and session limits |
 | The read/act API and its `limacharlie mailsec ...` CLI the agent drives as tools: message and report reads, sender profiles, `similar`/`campaign` pivots, report resolution, the typed actions, and the verdict write-back | The trigger rules that decide **when** the agent runs |
 | The permission model that decides what any agent may **do**, per credential, server-side, audited | The credentials: an AI provider key and a LimaCharlie API key at whatever permission ceiling you choose |
 | The `submit_to_triage` automation action — the one place mailsec says "this message warrants a look" | Whether the agent may act at all, and what it costs |
@@ -367,8 +367,9 @@ Prove the recipe before trusting it.
 3. **Read the transcript, and see the write-back.** Confirm the agent read the message,
    pivoted sensibly, and reached a conclusion it can defend with evidence. When an active
    agent revises a verdict it lands as a `mode: ai` [verdict revision](detections.md): the
-   message row updates and an `EMAIL_VERDICT` event is emitted, so the queue shows what the
-   agent decided and why, exactly as it does for the scorer. An active agent's quarantine
+   message row updates and an `EMAIL_VERDICT` event is emitted at the next `revision/seq`, so
+   the queue shows what the agent decided and why, exactly as it does for the scorer — whose
+   own verdict shipped as `seq 0` on the same event type at ingest. An active agent's quarantine
    or report-resolution shows up in the message and report timelines and in the
    `EMAIL_ACTION` audit trail.
 

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -97,6 +97,38 @@ success/failure:
 A campaign sweep returns `attempted`, `succeeded`, `alert_only` and a per-member
 `failed` map. It does not abort on the first error.
 
+## Telemetry event contract
+
+The routes above are the read/write surface. The **event** surface is ordinary
+LimaCharlie telemetry on the `email` platform, delivered to the default D&R
+target and to every configured Output, and it is a contract in its own right:
+these types and JSON paths are frozen and additive-only, because a year of stored
+telemetry and every customer rule is keyed on them.
+
+| Event | Cardinality |
+|---|---|
+| `EMAIL_MESSAGE` | Exactly once per message, at ingest, immutable. Carries the full Message Data Model |
+| `EMAIL_VERDICT` | Once per verdict **decision**. `revision/seq: 0` with `revision/mode: auto` is the rule pack's own verdict, emitted at ingest immediately after that message's `EMAIL_MESSAGE`; `seq: 1…` is one per override (`analyst`, `ai`, `detonation`) |
+| `EMAIL_ACTION` | Once per remediation outcome, including failures and skips |
+| `EMAIL_USER_REPORT` | Once per message that reaches the abuse mailbox |
+| `EMAIL_INGEST_ERROR` | Once per message that could not be fetched or processed |
+
+Two consequences worth stating plainly:
+
+- **The verdict appears twice at ingest** — inside `EMAIL_MESSAGE` under
+  `event/verdict/…` and again as the `seq 0` `EMAIL_VERDICT` under
+  `event/revision/…`. That is deliberate. It is what lets a rule about verdicts
+  be written once instead of once for the engine and once for every later
+  override, and it is why `EMAIL_VERDICT` can be treated as the complete verdict
+  stream for a message.
+- **The `seq 0` event is not a revision record.** `GET /messages/{msg_uuid}`
+  reports `revision_count: 0` and an empty revision history for a message nobody
+  has overridden. The rule pack's verdict is on the message itself, not in its
+  history of disagreements.
+
+The `EMAIL_VERDICT` body is documented field by field in
+[Events & Automation](automation.md#email_verdict).
+
 ## Attribution
 
 `actor` and `source` on every audit row are stamped by the server from the

--- a/docs/email-security/automation.md
+++ b/docs/email-security/automation.md
@@ -19,11 +19,41 @@ is one sensor, not ten thousand.
 | Event | Emitted when |
 |---|---|
 | `EMAIL_MESSAGE` | Once per message, at ingest. Carries the whole parsed model — headers, sender, recipients, body, links, attachments, authentication, hops — plus the enrichments and the verdict. It is the record that this mail arrived |
+| `EMAIL_VERDICT` | On **every** verdict decision: the rule pack's own, at ingest right after the `EMAIL_MESSAGE` (`revision/seq: 0`, `revision/mode: auto`), and then once per override afterwards (`seq: 1…`, mode `analyst`, `ai` or `detonation`) |
 | `EMAIL_ACTION` | On every remediation outcome, including failures and skips. Who asked, what was attempted, what happened |
 | `EMAIL_USER_REPORT` | When a message reaches the abuse mailbox and becomes a report |
 | `EMAIL_INGEST_ERROR` | When a message could not be fetched or processed. Coverage honesty: failures are visible, never silent |
 
-`EMAIL_MESSAGE` is emitted once and is immutable.
+`EMAIL_MESSAGE` is emitted once and is immutable. When a verdict changes, the
+original event is never rewritten — a new `EMAIL_VERDICT` is emitted instead, so
+the verdict history is the sequence of those events and a replay can reconstruct
+what was known at any point in time.
+
+### `EMAIL_VERDICT`
+
+The body carries the message's identity plus one `revision` block, and it is the
+same shape whichever decision it reports — which is the point: one rule reads all
+of them.
+
+| Path | |
+|---|---|
+| `event/msg_uuid` | The durable handle every typed action takes. A provider message id is folder-scoped and stops resolving the moment the message is quarantined; this does not |
+| `event/mailbox/address`, `event/provider` | Whose mail, from where |
+| `event/internet_message_id` | The cross-mailbox join key: one message sent to forty people is forty `msg_uuid`s and one of these |
+| `event/sender_email`, `event/sender_root_domain`, `event/subject` | Enough to match on without a lookup |
+| `event/ts` | The message's delivery time. The **event's own** timestamp is when the decision was made, so a hunt can window on either |
+| `event/campaign_id` | The campaign, if the message clustered into one |
+| `event/revision/seq` | `0` for the rule pack's verdict, `1…` for each override |
+| `event/revision/mode` | `auto`, `analyst`, `ai` or `detonation` |
+| `event/revision/verdict`, `event/revision/score` | The decision |
+| `event/revision/rationale` | The reasons, strongest first. For an override these are what the analyst or agent wrote; for `seq 0` they are the names of the signals that fired |
+| `event/revision/top_signals`, `event/revision/engine_version` | `seq 0` only — the rule ids that fired and the pack version that decided. An override has neither: nothing *matched*, somebody decided |
+| `event/revision/actor` | Who decided. Empty on `seq 0`: the rule pack is not a person, and `engine_version` is what identifies it |
+| `event/revision/prior` | What the override displaced — verdict, score, mode and engine version. Empty on `seq 0`, which displaced nothing |
+
+The MDM is deliberately *not* repeated here: it is already in the immutable
+`EMAIL_MESSAGE`, and copying it into every verdict change would multiply a year
+of telemetry by how often people change their minds.
 
 !!! info "Everything the rule needs is in the event"
     The verdict, the top signals and the enrichments the pipeline resolved are

--- a/docs/email-security/automation.md
+++ b/docs/email-security/automation.md
@@ -46,14 +46,22 @@ of them.
 | `event/revision/seq` | `0` for the rule pack's verdict, `1…` for each override |
 | `event/revision/mode` | `auto`, `analyst`, `ai` or `detonation` |
 | `event/revision/verdict`, `event/revision/score` | The decision |
-| `event/revision/rationale` | The reasons, strongest first. For an override these are what the analyst or agent wrote; for `seq 0` they are the names of the signals that fired |
+| `event/revision/rationale` | The reasons, strongest first. For an override these are what the analyst or agent wrote; for `seq 0` they are the names of the signals that fired — so it is **absent** on a benign message that matched nothing, which is the common case |
 | `event/revision/top_signals`, `event/revision/engine_version` | `seq 0` only — the rule ids that fired and the pack version that decided. An override has neither: nothing *matched*, somebody decided |
 | `event/revision/actor` | Who decided. Empty on `seq 0`: the rule pack is not a person, and `engine_version` is what identifies it |
-| `event/revision/prior` | What the override displaced — verdict, score, mode and engine version. Empty on `seq 0`, which displaced nothing |
+| `event/revision/prior` | What the override displaced — verdict, score, mode and engine version. On `seq 0` it is present but empty (`verdict: ""`, `score: 0`), because the engine's first call displaced nothing — so match on `revision/seq` or `revision/mode` to tell the two apart, not on `prior` |
 
 The MDM is deliberately *not* repeated here: it is already in the immutable
 `EMAIL_MESSAGE`, and copying it into every verdict change would multiply a year
 of telemetry by how often people change their minds.
+
+!!! warning "It roughly doubles your mail event volume"
+    `EMAIL_VERDICT` at `seq 0` is emitted for **every** ingested message, not only
+    for flagged ones, so a protected mailbox now produces about two events per
+    message instead of one. These are ordinary telemetry: they are evaluated by
+    your D&R rules and they land in your retention like any other event. The
+    bodies are small — identity plus a verdict, never the parsed message — so the
+    byte volume moves far less than the count.
 
 !!! info "Everything the rule needs is in the event"
     The verdict, the top signals and the enrichments the pipeline resolved are

--- a/docs/email-security/custom-rules.md
+++ b/docs/email-security/custom-rules.md
@@ -184,3 +184,50 @@ A `dr-mail` rule is one of two seats. The other is an ordinary D&R rule in
 `dr-general` matching the `EMAIL_*` events, which gets the platform's full
 response arsenal and can correlate mail with the rest of your telemetry. See
 [Events & Automation](automation.md).
+
+### Acting on a verdict
+
+`EMAIL_VERDICT` carries every verdict decision — the rule pack's own at
+`seq: 0`, and each later override — so a rule that should fire whenever a message
+is judged malicious is written once, against one path:
+
+```yaml
+# Detect
+op: and
+rules:
+  - op: is
+    path: routing/event_type
+    value: EMAIL_VERDICT
+  - op: is
+    path: event/revision/verdict
+    value: malicious
+```
+
+```yaml
+# Respond
+- action: report
+  name: email-verdict-malicious
+- action: extension request
+  extension name: ext-email-security
+  extension action: quarantine_message
+  extension request:
+    msg_uuid: '{{ .event.msg_uuid }}'
+```
+
+That fires when the pack decides a message is malicious **and** when an analyst,
+the AI triage agent or a link detonation later decides so. Narrow it with the
+fields that distinguish them:
+
+| To match | Add |
+|---|---|
+| Only the rule pack's own decision | `path: event/revision/seq`, `value: 0` |
+| Only overrides | `op: is greater than`, `path: event/revision/seq`, `value: 0` |
+| Only what a human decided | `path: event/revision/mode`, `value: analyst` |
+| Only a *change* to malicious | `path: event/revision/prior/verdict`, `op: is not`, `value: malicious` |
+| A specific rule that fired | `op: is`, `path: event/revision/top_signals/?/rule_id`, `value: ms-link-credentials-in-url` — the `?` matches any element of the list (`seq 0` only; an override carries no signals) |
+
+!!! warning "Overrides go both ways"
+    An override can also clear a verdict. A rule that quarantines on
+    `verdict: malicious` will see the escalation, and a later `benign` revision
+    does **not** undo the action it took — write the compensating rule if you
+    want one.

--- a/docs/email-security/detections.md
+++ b/docs/email-security/detections.md
@@ -38,6 +38,35 @@ The verdict object on a message carries:
     list). A score with no explanation would not be actionable and is not
     offered.
 
+### The verdict is also an event
+
+Every verdict this product reaches is emitted as an `EMAIL_VERDICT` event, so a
+rule that acts on verdicts is written **once**:
+
+| `revision/seq` | `revision/mode` | What it is |
+|---|---|---|
+| `0` | `auto` | What the rule pack decided, emitted at ingest immediately after the message's `EMAIL_MESSAGE` |
+| `1`, `2`, … | `analyst` | A human overrode it |
+| | `ai` | The AI triage agent overrode it |
+| | `detonation` | Link detonation found something at the other end and overrode it |
+
+The `seq 0` event repeats a verdict that is already inside `EMAIL_MESSAGE`, and
+that duplication is deliberate: without it, "tell me when a message is judged
+malicious" would be two rules against two paths on two event types — one for the
+engine's opinion and one for everything that happened after it — that you would
+have to keep in agreement forever.
+
+`EMAIL_MESSAGE` is still emitted once per message and is still immutable. The
+verdict *history* is the sequence of `EMAIL_VERDICT` events, which is what lets a
+hunt reconstruct what was known at any point in time.
+
+The `seq 0` event is an event and nothing else. It is not an entry in the
+message's revision history, and a message nobody has overridden reports zero
+revisions in the API and the console.
+
+See [Events & Automation](automation.md) for the payload and
+[Custom Rules](custom-rules.md#acting-on-a-verdict) for a rule that uses it.
+
 ## Scoring
 
 Each matching rule carries a **weight** (0–100, how much this evidence is worth)

--- a/docs/email-security/index.md
+++ b/docs/email-security/index.md
@@ -25,7 +25,7 @@ it at the provider.
 | **Remediation** | Typed, idempotent, audited actions performed at the provider: quarantine, trash, move to spam, restore, apply and remove a warning banner. Available by policy automation, from the console, from a D&R rule, from the API and from the CLI. |
 | **Campaigns** | Messages the engine attributed to one attack are clustered, so a campaign that hit forty mailboxes is triaged once and swept once. |
 | **User reports** | An abuse mailbox becomes an SLA queue: reports are joined back to the original message across the whole tenant, robots that mail the abuse address are auto-resolved out of the queue, and reporters can be sent a templated acknowledgement. |
-| **Telemetry** | `EMAIL_MESSAGE`, `EMAIL_VERDICT`, `EMAIL_ACTION`, `EMAIL_USER_REPORT` and `EMAIL_INGEST_ERROR` land in the same lake as your EDR, cloud and identity telemetry — so "phish delivered, then that user's endpoint ran a new binary" is one D&R rule. |
+| **Telemetry** | `EMAIL_MESSAGE`, `EMAIL_VERDICT` (every verdict decision — the engine's own at ingest, then each override), `EMAIL_ACTION`, `EMAIL_USER_REPORT` and `EMAIL_INGEST_ERROR` land in the same lake as your EDR, cloud and identity telemetry — so "phish delivered, then that user's endpoint ran a new binary" is one D&R rule. |
 | **Configuration as data** | Connections, policy and custom rules are Hive records, so everything is API-first and git-syncable from day one. |
 
 ## What it does not do

--- a/docs/email-security/pipeline.md
+++ b/docs/email-security/pipeline.md
@@ -111,7 +111,7 @@ the message at the provider.
 
 | | |
 |---|---|
-| **Synchronous, one pass per message** | Fetch, parse, every enrichment including attachment explosion, matching, scoring, the verdict, campaign clustering, persistence, and the `EMAIL_MESSAGE` emission |
+| **Synchronous, one pass per message** | Fetch, parse, every enrichment including attachment explosion, matching, scoring, the verdict, campaign clustering, persistence, and the emission of `EMAIL_MESSAGE` followed by the engine's own `EMAIL_VERDICT` (`revision/seq: 0`) |
 | **Later, and recorded as such** | Verdict revisions, remediation outcomes, campaign membership added when a later message joins the cluster |
 
 A revision does **not** rewrite `EMAIL_MESSAGE`. The original event stands as the
@@ -120,6 +120,13 @@ sequence number, and an `EMAIL_VERDICT` event is emitted carrying the new
 conclusion. Two consumers reading the same stream therefore agree on both what
 was decided and what it was changed to, which a mutated event could never give
 you.
+
+The engine's own verdict gets an `EMAIL_VERDICT` too, at `revision/seq: 0` and
+`revision/mode: auto`, emitted at ingest right after that message's
+`EMAIL_MESSAGE`. It repeats a verdict that is already inside `EMAIL_MESSAGE`, so
+that one rule against `EMAIL_VERDICT` covers the engine's call *and* every later
+override instead of needing one rule per event type. The `seq 0` event is not a
+revision: a message nobody has overridden still reports zero revisions.
 
 !!! info "Why the first pass is not allowed to wait"
     Anything the pipeline waits on is a mailbox that stays unjudged while it


### PR DESCRIPTION
**Do not merge yet** — this documents behaviour that is landing on the collector in a separate private PR and is being verified on the experimental cluster first. Public repo, so it waits for Maxime either way.

## Why

`EMAIL_VERDICT` was documented as the event for what happens *after* the engine decides, and the events table in `automation.md` did not list it at all. A reader who wanted to act on verdicts therefore had to find two different paths on two different event types — `event/verdict/verdict` on `EMAIL_MESSAGE` for the engine's opinion, `event/revision/verdict` on `EMAIL_VERDICT` for every override — and keep the pair in agreement forever. Most people found the second one only after an override surprised them.

The engine's own verdict is now emitted as an `EMAIL_VERDICT` of its own, at `revision/seq: 0` / `revision/mode: auto`, immediately after that message's `EMAIL_MESSAGE`. `EMAIL_VERDICT` becomes the complete verdict stream for a message and one rule reads all of it.

## What changed

- **`automation.md`** — the event joins the table, plus a field-by-field body reference: which fields only the `seq 0` event carries (`top_signals`, `engine_version`), why an override has neither (nothing *matched*; somebody decided), why `actor` is empty on `seq 0`, and why the MDM is deliberately not repeated.
- **`detections.md`** — "the verdict is also an event": the seq/mode table, why the duplication with `EMAIL_MESSAGE` is deliberate rather than an accident, and that the `seq 0` event is **not** a revision record (`revision_count` stays 0 for a message nobody overrode).
- **`custom-rules.md`** — a worked D&R rule on `EMAIL_VERDICT`, the narrowing clauses that separate the engine's decision from a human's, and a warning that an override can also *clear* a verdict without undoing an action that already fired.
- **`api-reference.md`** — a telemetry event contract section beside the route tables: cardinality per event type, and the two consequences a reader would otherwise be surprised by.

No route, parameter or permission changed.