### PR TITLE
email-security: document body-similarity campaign clustering

### DIFF
--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -77,6 +77,16 @@ across all 71,631 pairs. The policy ceiling is 35, below that closest pair on
 purpose: a setting above it is one you cannot have measured, and what it buys is
 a campaign-wide quarantine reaching mail that was never part of the attack.
 
+!!! warning "It is closer to all-or-nothing than a tolerance"
+    At the length of ordinary email, TLSH is very sensitive: two bodies whose
+    normalized text is byte-identical score **0**, and a single per-recipient word
+    the normalization could not identify — a name in a footer, an amount, a company
+    — has been measured at **100**, well past the ceiling. So the threshold is not a
+    slider that trades recall for precision in small steps. What it buys is the mass
+    case: one pitch, randomized subjects and links. A kit that rewrites a word of
+    prose per victim will not group, and that failure is entirely on the recall
+    side — it can never merge unrelated mail.
+
 ### It still takes two keys
 
 Body similarity does **not** join a campaign on its own. It is the strongest of

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -15,6 +15,7 @@ Every message contributes cluster keys at ingest time:
 | **Normalized subject** | Lowercased, reply/forward prefixes stripped (`Re:`, `Fwd:`, `AW:`, `SV:` …), then the parts an attacker varies per recipient collapsed — runs of two or more digits, UUIDs and long hex tokens all fold to a placeholder. "Invoice 88213" and "Invoice 88214" are one campaign, and a key that distinguished them would defeat the feature |
 | **Link root domains** | The sorted, deduplicated set of *registrable* root domains the message links to, fingerprinted. Root domains rather than URLs, because a phishing kit gives every recipient a unique path or tracking parameter while the domain is what the attacker had to register. Sorting means link order, which varies with templating, cannot split one campaign in two |
 | **Attachment hashes** | The set of attachment SHA-256s |
+| **Body similarity** | A fuzzy hash (TLSH) of the message body, normalized first — see [Body similarity](#body-similarity) |
 
 A message **joins an open campaign when at least two keys agree** with a
 candidate. One key is too easy to hit by accident — two unrelated messages with
@@ -25,14 +26,113 @@ An **empty key never matches**. Two messages with no subject, or with no links,
 are not evidence of anything, and treating empty as agreement would cluster the
 whole tenant into one campaign.
 
-!!! note "Body similarity is not currently a clustering key"
-    Near-identical bodies do not group on their own. Two messages that differ
-    only in wording, with different links and no attachments, will not cluster.
-    That is the conservative failure and the deliberate one — the alternative
-    collapses every body-less message into one cluster.
-
 Candidates are considered newest first, bounded, and the first one reaching the
 threshold wins. Joining an existing campaign always beats seeding a new one.
+
+## Body similarity
+
+The first three keys are all things an attacker can randomize. A kit that gives
+every recipient a unique subject line and a unique tracking path on every link
+defeats all three and sends one attack that looks like forty unrelated messages.
+
+What such a kit cannot randomize is the pitch. The body has to read the same to
+every victim, because the body **is** the attack. So the fourth key is a fuzzy
+hash of the body — one that gets *closer* the more two texts have in common,
+rather than changing completely when one character does.
+
+### The body is normalized first
+
+Hashing the raw body would key on exactly the bytes a kit varies. Before hashing,
+the body is reduced to what it actually says:
+
+- the **visible** text is used — text hidden from the reader (zero-height divs,
+  white-on-white) is dropped, because planting per-recipient noise there is the
+  oldest way to defeat a similarity hash;
+- **links** collapse to their scheme and host: the path, query and fragment are
+  where the victim's identifier lives, while the host is what the attacker had to
+  register;
+- **email addresses** collapse to a placeholder — the greeting and the "this was
+  sent to …" footer are otherwise a per-recipient signature;
+- the **salutation** and the **recipient's own name** collapse, so "Dear Riley,"
+  and "Dear Morgan," are the same sentence;
+- long **digit, hex and opaque tokens** collapse — invoice numbers, ticket ids,
+  unsubscribe and tracking tokens;
+- whitespace collapses last.
+
+How much this matters, measured rather than claimed: two copies of one 630-byte
+phishing body differing only in the recipient's name and the tracking parameters
+on its link are **86 apart before normalization and 0 apart after it**. The
+default join distance is 30, so without the normalization this key would not work
+at the length of an ordinary email.
+
+### The threshold
+
+Two bodies count as the same body at a **distance of 30 or less**, which is a
+policy knob (`clustering` — see the [Policy Reference](policy.md#clustering)).
+
+30 is measured. Across a 404-message corpus of ordinary business mail —
+newsletters, invoices, calendar invites, internal notices — the **closest pair of
+unrelated messages is 39 apart**, and at 30 the body key produces zero agreements
+across all 71,631 pairs. The policy ceiling is 35, below that closest pair on
+purpose: a setting above it is one you cannot have measured, and what it buys is
+a campaign-wide quarantine reaching mail that was never part of the attack.
+
+### It still takes two keys
+
+Body similarity does **not** join a campaign on its own. It is the strongest of
+the four keys and it is still one key, and a 39-point margin is a margin rather
+than a wall — two form letters from different vendors can read alike. What the
+key changes is not the threshold but how often it is *reachable*: a message whose
+subject and links were randomized now has a second key to agree on.
+
+### Why a message did or did not group
+
+Every message records the keys that agreed when it joined, and the drawer and the
+API return them:
+
+```bash
+limacharlie mailsec message get <msg_uuid> --oid $OID --output yaml
+```
+
+```yaml
+campaign_id: <campaign_id>
+cluster_reason:
+  - subject
+  - body_tlsh
+body_tlsh: T1A1B2...
+```
+
+`cluster_reason` is the answer to the question a campaign-wide quarantine
+provokes: *why was my mail in that group?*
+
+`body_tlsh` is the digest itself. It is shareable — it is the standard TLSH form,
+so it pastes into other tools — and the "similar messages" view ranges on it:
+
+```bash
+limacharlie mailsec message similar <msg_uuid> --oid $OID --output yaml
+```
+
+Every candidate carries `matched_keys` and, when both messages have a digest, a
+`body_distance` next to the threshold your policy set. That view returns
+*candidates*, not campaign members: the "two keys agree" decision belongs to the
+clustering engine, and a list presented as "similar" without saying how similar
+would be an unexplainable claim.
+
+### The window is wider for bodies
+
+The other three keys look back 72 hours, the open-campaign window. Body
+similarity looks back **seven days**, because the attack this key exists to catch
+is also the one that trickles: a kit sending a hundred distinct-looking messages
+over five days is one campaign, and a 72-hour horizon would split it into two
+nobody would ever connect. A body-similar message arriving days later **reopens**
+the campaign, because a campaign still receiving mail is still live.
+
+### Messages with no usable body
+
+A body under 50 bytes of normalized text — "ok, thanks" — or one with too little
+variety to characterize produces **no digest**, and `body_tlsh` is absent. That is
+a fact about the message, not a missing value: an empty key never matches, which
+is what stops every short message clustering with every other one.
 
 Campaigns close after **72 hours of silence**. Only open campaigns absorb new
 members, so an attacker re-using a subject three months later starts a new

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -9,7 +9,7 @@ fleet-wide policy are a script, not a UI workflow.
 | Hive | Records | Purpose |
 |---|---|---|
 | `mailsec_provider` | one per mail connection | which tenant to protect, with which credential — see [Connecting Providers](providers.md) |
-| `mailsec_policy` | many, discriminated by `policy_type` | automations, exclusions, VIPs, thresholds, banners, retention, reporter replies, hunt defaults |
+| `mailsec_policy` | many, discriminated by `policy_type` | automations, exclusions, VIPs, thresholds, banners, retention, reporter replies, hunt defaults, clustering |
 | `dr-mail` | one per custom rule | your own mail detection rules — see [Custom Rules](custom-rules.md) |
 
 ## How `mailsec_policy` records work
@@ -33,7 +33,7 @@ How each type composes:
 | `exclusions` | Concatenated — a set of independent suppressions |
 | `vips` | Union, deduplicated and sorted |
 | `thresholds` | Last writer wins per field, with the ordering invariant re-checked afterwards |
-| `banners`, `reporter_reply`, `hunt_defaults` | Last writer wins per field |
+| `banners`, `reporter_reply`, `hunt_defaults`, `clustering` | Last writer wins per field |
 | `retention` | **Maximum** wins — see [Retention](#retention) |
 
 ### Unknown fields are refused
@@ -380,6 +380,48 @@ dry_run: true
 | `window_days` | 7 | 1–365 |
 | `max_results` | 1000 | 1–100000 |
 | `dry_run` | `true` | An operation that can bulk-remediate defaults to "show me what this would match" |
+
+---
+
+## `clustering`
+
+How aggressively messages are grouped into a campaign — which is what sets the
+blast radius of a campaign-wide action. It is a separate record from
+`thresholds` on purpose: `thresholds` is how harshly mail is *judged*, and
+folding the reach of a bulk quarantine into a record named for scoring would hide
+it.
+
+```yaml
+policy_type: clustering
+body_similarity: true
+body_similarity_distance: 30
+```
+
+| Field | Default | Range |
+|---|---|---|
+| `body_similarity` | `true` | Whether the body fuzzy hash may count as an agreeing cluster key |
+| `body_similarity_distance` | 30 | 0–35. Lower is stricter; 0 means byte-identical normalized bodies only |
+
+The default is **on**, because the organization that most needs body similarity —
+one being hit by a kit that randomizes subjects and links — is the one least
+likely to go looking for a switch to turn on.
+
+The distance default is measured, not chosen: across a 404-message corpus of
+ordinary business mail the closest pair of *unrelated* messages is 39 apart,
+while two copies of one message differing only in the recipient's name and the
+link's tracking parameters are 0 apart. The ceiling of 35 sits below that closest
+pair deliberately — a setting above it is one you cannot have measured.
+
+See [Body similarity](campaigns.md#body-similarity) for what the key is and how a
+body is normalized before it is hashed.
+
+!!! note "Turning it off does not stop the digest being computed"
+    `body_similarity: false` stops the digest counting as *agreement*. It is
+    still computed, still stored, still returned on the message and still
+    searchable. So turning the switch back on gives you working clustering
+    immediately, rather than only for mail that arrives afterwards — and the
+    digest an analyst is looking at is never a value the product quietly stopped
+    maintaining.
 
 ---
 


### PR DESCRIPTION
## Why

Campaign clustering keys on the normalized subject, the link root-domain set, and the attachment digests. A phishing kit that gives every recipient a unique subject line and a unique tracking path on every link defeats all three by construction, and sends one attack that the product reports as forty unrelated messages. Body-similarity clustering — a fuzzy hash (TLSH) of the normalized body — is the fourth key, shipping now.

These docs also carried a note saying body similarity **is not** a clustering key. That note is now wrong, and a customer reading it would conclude the product cannot do something it does.

## What changed

**`campaigns.md`** — a new **Body similarity** section:

- the fourth key added to the cluster-key table;
- what is normalized away before the body is hashed, and why each step is there (visible text only; links to scheme+host; addresses, salutation and the recipient's own name; long digit/hex/opaque tokens);
- the measured numbers rather than assertions — two copies of one 630-byte phish differing only in the recipient's name and the link's tracking parameters are **86 apart before normalization and 0 after**; across a 404-message corpus of ordinary business mail the **closest pair of unrelated messages is 39 apart**, the default join distance is **30**, and at 30 the key produces zero agreements across all 71,631 pairs;
- why it still takes **two** agreeing keys, and that the key changes how often the threshold is *reachable* rather than what it is;
- `cluster_reason`, `body_tlsh` and `body_distance` — the answer to the question a campaign-wide quarantine provokes, *why was my mail in that group?*;
- the wider **seven-day** body window and the fact that a body-similar message reopens a campaign;
- what happens to a message with no usable body (no digest, and an empty key never matches).

**`policy.md`** — the new `clustering` record: `body_similarity` (default on) and `body_similarity_distance` (default 30, range 0–35), the composition rule, why it is a separate record from `thresholds`, and the note that turning it off stops the digest counting as *agreement* without stopping it being computed or stored.

## Assumption stated

The ceiling of 35 is documented as sitting *below* the corpus's closest unrelated pair on purpose. That is the product's own justification for the bound and it is worth a customer reading it, because the obvious operator instinct on a clustering knob is to raise it.

## Public repo

Per the mailsec working agreement this is opened for review and **not merged** — it needs Maxime's sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
