### PR TITLE
docs(email-security): document the tenant purge

### DIFF
--- a/docs/10-release-notes/index.md
+++ b/docs/10-release-notes/index.md
@@ -18,6 +18,20 @@ Release notes for LimaCharlie platform components, organized by date.
 
     For discussion and email notification of the same releases, set the [Platform Updates category](https://community.limacharlie.com/c/platform-updates/5) in the community forum to Watching. For service availability rather than releases, subscribe on the [status page](https://status.limacharlie.io/).
 
+## 2026-09-04
+
+### Extensions: Email Security tenant purge
+
+#### New Features
+
+- **Tenant purge for Email Security**: everything Email Security holds for an organization can now be deleted on request — the message index and the up-to-400-day evidence lane, campaigns, sender profiles, the product's action audit trail, user (abuse-mailbox) reports, stored raw messages and their parsed copies, link-detonation results, and the organization's provider connection and policy configuration. The purge also stops the mail connections at Microsoft 365 and Google Workspace, so the provider stops sending notifications instead of repopulating the index. It is irreversible, requires Owner-level authority (`mailsec.act`, `billing.ctrl` and `user.ctrl` together), and is recorded in the organization's audit log with the caller's identity and an optional reason.
+- The purge is two steps, and previews by default: `limacharlie mailsec tenant purge` prints the warning and mints a single-use confirmation token that expires in five minutes, and destroys nothing until that token is passed back with `--confirm`. A purge that reports `complete: false` did not finish and can simply be re-run with a fresh token. The Python SDK exposes the same pair as `Mailsec.prepare_tenant_purge()` and `Mailsec.purge_tenant()`.
+- Email Security data is now also deleted **automatically**: 30 days after an organization unsubscribes from the extension — resubscribing at any point inside that window cancels the scheduled deletion — and immediately when the organization itself is deleted.
+
+See [Data retention and deletion](../email-security/policy.md#data-retention-and-deletion), the [CLI notes](../email-security/cli.md#the-tenant-purge-is-irreversible) and [`DELETE /tenant`](../email-security/api-reference.md#delete-tenant).
+
+---
+
 ## 2026-08-31
 
 ### Endpoint Agent 5.3.8

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -18,6 +18,10 @@ standard `Authorization: Bearer <JWT>` header.
     connection test — requires `mailsec.act`. Downloading raw message bytes
     requires `mailsec.get` **and** `mailsec.get.eml`.
 
+    The tenant purge routes are the exception to all of that. Both
+    `GET /tenant` and `DELETE /tenant` require Owner-level authority —
+    `mailsec.act` **and** `billing.ctrl` **and** `user.ctrl` together.
+
     Connections, policy and custom rules are **not** `/mailsec` routes: their CRUD
     goes through Hive (`mailsec_provider`, `mailsec_policy`, `dr-mail`).
 
@@ -51,6 +55,7 @@ Shared behaviours:
 | `GET /senders/{key}` | The accumulated profile for one correspondent. `key` is qualified (`email:someone@corp.example` or `domain:corp.example`) or a bare address or domain. A key with no profile says so explicitly rather than returning a zeroed profile |
 | `GET /actions/{action_id}` | `{action}` — one audit entry expanded, **including the JSON request payload the message timeline omits**. For a raw-message download that payload carries the access justification. Gated on `mailsec.get`: reading who did what to a message is part of reading the product |
 | `GET /onboarding` | `{scopes, steps, script}` — the setup steps, OAuth scopes and `gcloud` commands for connecting a tenant, for rendering in a setup flow. Each step carries a `console` and, where verifiable, a `verified_by` naming the connection-test check that proves it. Params: `provider` (`gworkspace` default, or `m365`), `project_id`, `sa_email`, `topic`, `subscription` — supply them and the commands come back ready to run rather than templated |
+| `GET /tenant` | `{confirmation, expires_in_seconds, warning}` — the tenant-purge preview. Returns the warning describing exactly what a purge removes, and mints the single-use `confirmation` token that [`DELETE /tenant`](#delete-tenant) requires. **It changes nothing.** The token expires after `expires_in_seconds` (300). Requires Owner-level authority, not `mailsec.get` |
 
 ### `GET /messages/{msg_uuid}/eml`
 
@@ -63,6 +68,60 @@ the `justification` query parameter is **required**.
 
 Raw copies expire 35 days after delivery (longer for flagged messages), after
 which this returns a typed expiry error while the index row stays readable.
+
+### `DELETE /tenant`
+
+The tenant purge. It permanently deletes everything Email Security holds for the
+organization — the message index and the long-term evidence lane, campaigns,
+sender profiles, the action audit trail, user reports, stored raw messages and
+their parsed copies, link-detonation results, and the organization's provider
+connection and policy configuration — and it stops the mail connections at the
+provider so no further notifications arrive. It cannot be undone, and there is no
+smaller scope than the whole organization.
+
+Both this route and `GET /tenant` require **Owner-level authority**:
+`mailsec.act`, `billing.ctrl` and `user.ctrl` together — the same three
+permissions deleting the organization requires. There is no separate "owner"
+permission.
+
+The `confirmation` token comes from `GET /tenant`, which returns the warning text
+and changes nothing. The token is **single-use** and expires **5 minutes** after
+it is minted, so the destructive call cannot be replayed, and cannot be reached
+without the warning having been served first.
+
+| Param | |
+|---|---|
+| `confirmation` | **Required.** The token minted by `GET /tenant`. A token that has expired, has already been spent, or was minted for another organization is refused |
+| `reason` | Optional free text, **1024 characters maximum**. Recorded in the organization's audit log next to your authenticated identity. An over-long reason is refused rather than truncated |
+
+The response reports what was removed rather than flattening it into success:
+
+| Field | |
+|---|---|
+| `complete` | `true` when nothing was left behind. `false` means part of the purge did not finish and the call should be repeated |
+| `objects_deleted` | Stored raw messages removed |
+| `mdms_deleted` | Parsed message copies (Message Data Models) removed |
+| `detonation_results_deleted` | Link-detonation results removed |
+| `detonation_results_skipped` | Link-detonation results left in place — reported rather than quietly counted as deleted |
+| `objects_failed` | Stored items that could not be removed. Any non-zero value is a reason `complete` is `false` |
+| `tables_purged` | The list of the product's data sets that were cleared, named so a partial purge shows which ones were reached |
+| `subscriptions_stopped` | Provider notification subscriptions stopped, after which the provider sends nothing further |
+| `subscriptions_failed` | Subscriptions the provider would not stop |
+| `mailboxes_walked` | Mailboxes visited while stopping notifications |
+| `provider_records_deleted` | Email Security provider connection records removed |
+| `policy_records_deleted` | Email Security policy records removed |
+| `connections_unreachable` | Connections that could not be reached at all — a revoked credential or a tenant that is already gone. Their data is still purged; only the provider-side stop could not be confirmed |
+| `rows_remained` | Rows still present when the pass ended. Non-zero means re-run |
+
+**The call is re-runnable.** A purge that returns `complete: false` has deleted
+whatever it could, and repeating it deletes what remained — nothing is
+double-counted and nothing is skipped for having been attempted. Mint a **fresh**
+confirmation token for each attempt: the previous one was spent.
+
+Deletion also happens without this route being called — 30 days after an
+organization unsubscribes from Email Security, and immediately when the
+organization is deleted. See
+[Data retention and deletion](policy.md#data-retention-and-deletion).
 
 ## Writes
 

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -6,7 +6,7 @@ The `limacharlie mailsec` command group covers the Email Security API surface:
 the coverage screen, the message index and drawer, the audited raw-EML download,
 campaigns and campaign-wide sweeps, sender profiles, the action audit trail, the
 abuse-mailbox report queue, custom-rule validation and backtest, the connection
-preflight, and the served onboarding guide.
+preflight, the served onboarding guide, and the tenant purge.
 
 Commands take the global options (`--oid`,
 `--output json|yaml|toon|csv|table|jsonl`, `--filter <jmespath>`,
@@ -32,7 +32,7 @@ standard `limacharlie hive` commands (`mailsec_provider`, `mailsec_policy`,
 ## Permissions
 
 Four, rather than the usual get/set pair, because Email Security asks to be
-trusted with four separable things:
+trusted with four separable things — plus one command that is not any of them:
 
 | Permission | Covers |
 |---|---|
@@ -40,6 +40,7 @@ trusted with four separable things:
 | `mailsec.set` | Change triage state — resolving a user report |
 | `mailsec.act` | Remediate live mail at the provider |
 | `mailsec.get.eml` | Download the original bytes of a message; requires a logged justification |
+| `mailsec.act` **and** `billing.ctrl` **and** `user.ctrl` | `tenant purge`, in both its preview and its destructive form. Owner-level authority, the same trio deleting the organization requires — there is no separate "owner" permission |
 
 `mailsec.get.eml` is separate on purpose: opening the drawer shows you the
 product's structured view of a message, while downloading the EML takes a
@@ -90,6 +91,9 @@ limacharlie mailsec rule backtest --file rule.json --since 2026-08-01
 limacharlie mailsec analyze --file suspect.eml --org-domain corp.example
 limacharlie mailsec connection test gws-exp
 limacharlie mailsec onboarding --provider gworkspace
+
+# Delete everything Email Security holds for this org — previews without --confirm
+limacharlie mailsec tenant purge
 ```
 
 ## Things worth knowing before you script this
@@ -174,6 +178,42 @@ and would have you discard a good rule.
 ```bash
 limacharlie mailsec rule backtest --file rule.json --output yaml
 ```
+
+### The tenant purge is irreversible
+
+`tenant purge` permanently deletes everything Email Security holds for the
+organization — the message index and the long-term evidence lane, campaigns,
+sender profiles, the action audit trail, user reports, stored raw messages and
+their parsed copies, and link-detonation results — and removes the provider
+connection and policy records, which stops the provider sending any further
+notifications. There is no undo and no smaller scope than the whole tenant.
+
+So it is two calls. With **no** `--confirm` the command previews: it prints the
+warning and mints a confirmation token, and destroys nothing.
+
+```bash
+# 1. Preview. Prints the warning and a single-use token; changes nothing.
+PREVIEW=$(limacharlie mailsec tenant purge --oid "$OID" --output json)
+echo "$PREVIEW" | jq -r .warning
+
+# 2. Purge, within 5 minutes, quoting that token.
+TOKEN=$(echo "$PREVIEW" | jq -r .confirmation)
+limacharlie mailsec tenant purge --oid "$OID" \
+  --confirm "$TOKEN" \
+  --reason "Tenant offboarded"
+```
+
+The token is **single-use and expires 5 minutes after it is minted**, so a purge
+cannot be replayed and cannot be scripted without someone having been shown the
+warning. A purge that comes back with `complete: false` did not finish and is
+safe to repeat — but repeating it means starting again at step 1, because step 2
+spent the token.
+
+`--reason` is optional, capped at 1024 characters, and written to the
+organization's audit log with your identity. Requires Owner-level authority. See
+[Data retention and deletion](policy.md#data-retention-and-deletion) for exactly
+what a purge removes, and for the deletion that happens on its own 30 days after
+an organization unsubscribes.
 
 ## Filtering and pagination
 

--- a/docs/email-security/pipeline.md
+++ b/docs/email-security/pipeline.md
@@ -220,6 +220,11 @@ platform's telemetry lake and follow your ordinary retention, which is why
 [LCQL](automation.md#querying-mail-with-lcql) reaches further back than the queue
 does.
 
+Both lanes can also be emptied outright rather than waited out: a tenant purge
+removes everything this product holds for an organization at once, and the same
+deletion runs on its own 30 days after an organization unsubscribes. See
+[Data retention and deletion](policy.md#data-retention-and-deletion).
+
 ### What lands in telemetry
 
 `EMAIL_MESSAGE` carries parsed body content, so mail text is in your normal

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -337,7 +337,99 @@ and the safe resolution is always "keep it longer" — a shorter setting is
 recoverable by editing policy, deleted rows are not.
 
 The 35-day searchable message index and the raw-message window are separate and
-are not configured here.
+are not configured here — see [Data retention and deletion](#data-retention-and-deletion)
+for all three clocks, and for removing an organization's Email Security data
+outright rather than waiting for a window to end.
+
+---
+
+## Data retention and deletion
+
+Retention and deletion answer different questions. Retention decides *when* data
+ages out on a clock and runs on its own. A **tenant purge** decides that the data
+is gone *now*: everything Email Security holds for one organization, removed
+everywhere, in one operation, on request.
+
+### The three clocks
+
+| Lane | Kept | Holds |
+|---|---|---|
+| Message index | **35 days** | The searchable row for every message, and what the queue and the drawer read from |
+| Evidence | up to **400 days** | Flagged messages and the evidence attached to them. Tunable with [`retention`](#retention) within the 400-day ceiling |
+| Raw messages | 35 days after delivery, longer once a message is flagged | The original bytes and the parsed copy behind them |
+
+Nothing on those clocks needs a request. Data leaves each lane when its window
+ends, and only that lane's window moves it. See
+[Two retention lanes](pipeline.md#two-retention-lanes) for how a message is
+placed in a lane and promoted between them.
+
+### What a purge removes
+
+A tenant purge permanently deletes, for one organization:
+
+- the message index and the long-term evidence lane
+- campaigns
+- sender profiles
+- the remediation and action audit trail this product keeps
+- user (abuse-mailbox) reports
+- stored raw messages and their parsed copies
+- link-detonation results
+- the organization's Email Security provider connection and policy configuration
+
+It also **stops the mail connections at Microsoft 365 and Google Workspace**, so
+the provider stops sending notifications. That matters as much as the deletion
+itself: a purge that left the connections running would begin repopulating the
+index with the next message to arrive.
+
+!!! danger "A purge cannot be undone"
+    There is no restore, no grace period and no partial scope — the unit is the
+    whole organization. A purged organization looks to Email Security exactly
+    like one that was never connected.
+
+### Authority and audit
+
+Both the preview and the purge itself require **Owner-level authority**:
+`mailsec.act`, `billing.ctrl` and `user.ctrl` together. That is the same trio
+deleting the organization requires; there is no separate "owner" permission to
+grant, and no combination short of all three is accepted.
+
+The purge is written to the organization's audit log with your authenticated
+identity and, if you supplied one, a free-text `reason` of up to 1024
+characters. As everywhere else in this product, the identity is stamped by the
+server from your verified claims rather than taken from the request.
+
+### It also happens without a request
+
+| Event | When the data is deleted |
+|---|---|
+| The organization unsubscribes from Email Security | **30 days** later. Resubscribing at any point inside those 30 days cancels the scheduled deletion |
+| The organization itself is deleted | Immediately |
+
+Neither needs anyone to ask. The 30-day delay exists so that unsubscribing by
+mistake, or moving billing around, is recoverable — and resubscribing is all the
+recovery takes.
+
+### Requesting a purge
+
+Two steps, because the confirmation token is minted by a call that shows you the
+warning and changes nothing:
+
+```bash
+# 1. Preview. Prints the warning and mints a single-use token; deletes nothing.
+PREVIEW=$(limacharlie mailsec tenant purge --oid "$OID" --output json)
+echo "$PREVIEW" | jq -r .warning
+
+# 2. Purge, within 5 minutes, quoting that token.
+limacharlie mailsec tenant purge --oid "$OID" \
+  --confirm "$(echo "$PREVIEW" | jq -r .confirmation)" \
+  --reason "Tenant offboarded"
+```
+
+The token is single-use and expires 5 minutes after it is minted, so a purge
+cannot be replayed and a re-run always starts from a fresh preview. See
+[the CLI notes](cli.md#the-tenant-purge-is-irreversible) and
+[`DELETE /tenant`](api-reference.md#delete-tenant) for the response fields and
+for what to do when a purge reports that it did not finish.
 
 ---
 


### PR DESCRIPTION
Documents the new Email Security tenant purge: the on-request deletion of everything the product holds for one organization, and the automatic deletion that follows unsubscribing or deleting the organization.

## Sections added

**`docs/email-security/policy.md`** — new `## Data retention and deletion`, placed immediately after the `retention` policy type:

- `### The three clocks` — the 35-day message index, the up-to-400-day evidence lane, the raw-message lanes, and how a purge differs (retention expires data on a clock; a purge removes it now, everywhere, at once).
- `### What a purge removes` — the full customer-facing list, and that it also stops the mail connections at the provider so notifications stop arriving.
- `### Authority and audit` — irreversible, Owner-level authority (`mailsec.act` + `billing.ctrl` + `user.ctrl`), audited with the caller's identity and the optional reason.
- `### It also happens without a request` — 30 days after unsubscribing (resubscribing inside the window cancels it), immediately on organization deletion.
- `### Requesting a purge` — the two-step CLI, cross-linked to `cli.md` and `api-reference.md`.

The existing `retention` section's closing sentence now cross-links to the new section.

**`docs/email-security/api-reference.md`**

- `GET /tenant` added to the `## Reads` table (preview + token mint; changes nothing).
- New `### \`DELETE /tenant\`` section modelled on the `GET /messages/{msg_uuid}/eml` section: prose, then a parameter table, then the response-field table. Covers the permissions trio, the single-use token that expires in 5 minutes, the optional 1024-character audited `reason`, every response field with a one-line meaning, and that the call is re-runnable when `complete` is `false`.
- The permissions admonition now notes that the tenant routes are the Owner-level exception to the `mailsec.get` rule.

**`docs/email-security/cli.md`**

- One line in `## At a glance`.
- New `### The tenant purge is irreversible` under `## Things worth knowing before you script this`, with a runnable two-step bash snippet (preview to mint the token, then `--confirm`), the 5-minute expiry, and that a re-run needs a fresh token.
- A row in the `## Permissions` table for `tenant purge` (lead-in reworded so the "four permissions" count still reads correctly).
- `tenant purge` added to the surface summary in the intro.

**`docs/email-security/pipeline.md`** — `### Two retention lanes` now cross-links to the new policy section.

**`docs/10-release-notes/index.md`** — a new `## 2026-09-04` group with `### Extensions: Email Security tenant purge`.

## A note on the release-note version

Email Security is in private beta and has never published a version string in these docs — there is no prior Email Security release-note entry to follow, and `Email Security` is not a canonical component name in `hooks/release_feed.py`. Rather than invent a version, the entry uses the canonical **versionless announcement form** (`### <Component>: <announcement>`), which is collision-free by heading text and passes the heading lint. Happy to switch it to `### Extensions <version>` if there is a version this should carry.

## Verification

All run from the repo root, all clean:

| Check | Result |
|---|---|
| `mkdocs build --strict` | pass, no warnings |
| `npx --yes markdownlint-cli2` | `0 issues in 0 files` (386 files) |
| `python scripts/check-release-note-headings.py --baseline scripts/release-note-headings-baseline.json` | `0 new heading issue(s); 22 baselined` |
| `python scripts/check-release-feeds.py site` | `9 feed(s) OK`, 81 entries |
| `pytest tests/` | `210 passed` |

Every anchor introduced or linked was checked against the built HTML: `#data-retention-and-deletion`, `#the-tenant-purge-is-irreversible`, `#delete-tenant`, `#two-retention-lanes`, `#retention`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)