### PR TITLE
docs(email-security): retention is a setting that deletes, and it has two lanes

### DIFF
--- a/docs/email-security/messages.md
+++ b/docs/email-security/messages.md
@@ -66,9 +66,11 @@ that means something else. Restart the walk instead.
 
 ### Retention
 
-The searchable message index keeps **35 days**. Flagged messages — and their
-stored evidence — are retained longer, up to **400 days**, tunable through
-[`mailsec_policy/retention`](policy.md#retention). A miss on an older id is a
+The searchable message index keeps **35 days** by default; flagged messages and
+their stored evidence are kept up to **400 days**. Both are *maxima* you can
+lower — `message_days` and `flagged_days` in
+[`mailsec_policy/retention`](policy.md#retention) — and data past whichever
+horizon you set is deleted rather than merely hidden. A miss on an older id is a
 normal outcome and returns a null message rather than an error.
 
 ## The drawer

--- a/docs/email-security/pipeline.md
+++ b/docs/email-security/pipeline.md
@@ -211,16 +211,17 @@ authenticated data, which means a copied object cannot be opened somewhere else.
 
 ### Two retention lanes
 
-| Lane | Kept | Holds |
-|---|---|---|
-| Transient | **35 days** | Every message |
-| Retained | up to **400 days** | Flagged messages and the evidence attached to them |
+| Lane | Kept | Holds | Shortened by |
+|---|---|---|---|
+| Transient | **35 days** | Every message | `message_days` |
+| Retained | up to **400 days** | Flagged messages and the evidence attached to them | `flagged_days` |
 
 The lane is chosen at ingest from the verdict. A message that becomes evidence
 later, because it was reported, re-judged or acted on, is promoted into the
-retained lane by re-sealing it there. The retained window is tunable within the
-ceiling through [`mailsec_policy/retention`](policy.md#retention); 400 days is
-the store's hard limit, and policy can only choose within what the store keeps.
+retained lane by re-sealing it there. Both windows are tunable *downwards*
+through [`mailsec_policy/retention`](policy.md#retention): 35 and 400 days are
+the store's hard limits, policy can only choose within what the store keeps, and
+what falls past the horizon you set is deleted.
 
 The searchable message index keeps 35 days as well. `EMAIL_*` events go to the
 platform's telemetry lake and follow your ordinary retention, which is why

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -332,30 +332,79 @@ optional `https://mail.google.com/` scope and **replaces** the message.
 
 ## `retention`
 
-How long flagged evidence is kept.
+How long Email Security keeps your mail data. Lower it and the data is deleted;
+this is the setting that makes "we hold nothing older than N days" true.
 
 ```yaml
 policy_type: retention
+message_days: 14
 flagged_days: 180
 ```
 
-| Field | Default | Range |
-|---|---|---|
-| `flagged_days` | 400 | 30–400 |
+| Field | Default | Range | Governs |
+|---|---|---|---|
+| `message_days` | 35 | 1–35 | The searchable message index and the stored copy of the raw message |
+| `flagged_days` | 400 | 1–400 | Flagged evidence, its stored copy, verdict revisions, and the action, report, campaign and sender-profile history |
 
-400 is the schema's hard ceiling: policy can only choose *within* what the store
-keeps, because a policy asking for longer would be a promise the database
-silently breaks.
+Set either, or both. A record that sets neither is rejected — a retention policy
+that does nothing is worse than no policy, because you would believe it was in
+force.
 
-Composition takes the **maximum** rather than the last writer. Two records
-disagreeing about retention is a disagreement about how much evidence to destroy,
-and the safe resolution is always "keep it longer" — a shorter setting is
-recoverable by editing policy, deleted rows are not.
+### Two numbers, because there are two lanes
 
-The 35-day searchable message index and the raw-message window are separate and
-are not configured here — see [Data retention and deletion](#data-retention-and-deletion)
-for all three clocks, and for removing an organization's Email Security data
-outright rather than waiting for a window to end.
+The **message index** is the recent operational surface: every message, with the
+metadata the queue and the hunt read, plus the raw message itself. It is what
+`message_days` shortens.
+
+The **evidence lane** is what an investigation reaches for months later: the
+flagged messages, their stored copies, every verdict revision, and the record of
+what was done to the mail and who did it. It is what `flagged_days` shortens.
+There is no separate "evidence" setting — this is it.
+
+"Keep my queue for a week" and "keep my phishing evidence for a week" are
+different asks, so they are different fields.
+
+### The defaults are ceilings, not targets
+
+400 and 35 are the store's own hard limits. Policy can only choose a **shorter**
+horizon, never a longer one: a setting past the ceiling is rejected rather than
+quietly ignored, because it would be a promise the database silently breaks.
+
+The floor is **one day**. Below that a message would not survive long enough for
+the queue, the verdict and the analyst who opens it to exist, so a shorter value
+is rejected rather than clamped — Email Security tells you it will not do it
+instead of doing something else.
+
+### What deletion actually removes
+
+Data past your horizon is removed on a recurring sweep — the rows, the stored
+copies of the messages in cloud storage, the parsed projections beside them, and
+the link-detonation results derived from that mail. Deletion is permanent and
+there is no undo, which is why the horizon is a policy you edit rather than a
+button you press.
+
+Two consequences worth knowing:
+
+- Lowering a value takes effect on the next sweep, and a large backlog drains
+  over several sweeps rather than all at once.
+- The horizons are independent. A flagged message's evidence can outlive its
+  index entry (the usual case: 400 against 35), and if you set `flagged_days`
+  *below* `message_days` the reverse happens — the index entry remains without a
+  downloadable copy of the message, because you asked for the message itself to
+  be deleted.
+
+`GET /coverage` reports the horizon actually in force, so a window reaching past
+it is labelled rather than shown as though the missing days were empty.
+
+### Composition
+
+Composition takes the **minimum**, not the last writer. If one record says 30
+days and another says 200, the answer is 30: a retention record is an instruction
+to delete — usually one you have committed to somebody else — so the strictest
+one wins, in the direction of holding less of your mail.
+
+Removing an organization's Email Security data outright, rather than waiting for a
+window to end, is covered under [Data retention and deletion](#data-retention-and-deletion) below.
 
 ---
 

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -419,9 +419,9 @@ everywhere, in one operation, on request.
 
 | Lane | Kept | Holds |
 |---|---|---|
-| Message index | **35 days** | The searchable row for every message, and what the queue and the drawer read from |
-| Evidence | up to **400 days** | Flagged messages and the evidence attached to them. Tunable with [`retention`](#retention) within the 400-day ceiling |
-| Raw messages | 35 days after delivery, longer once a message is flagged | The original bytes and the parsed copy behind them |
+| Message index | up to **35 days** | The searchable row for every message, and what the queue and the drawer read from. Tunable with [`retention`](#retention) `message_days` within the 35-day ceiling |
+| Evidence | up to **400 days** | Flagged messages and the evidence attached to them. Tunable with [`retention`](#retention) `flagged_days` within the 400-day ceiling |
+| Raw messages | follows the message-index lane, and the evidence lane once a message is flagged | The original bytes and the parsed copy behind them |
 
 Nothing on those clocks needs a request. Data leaves each lane when its window
 ends, and only that lane's window moves it. See


### PR DESCRIPTION
## Why

The `retention` section documented a setting that did nothing. Two of its statements were false in the customer's disfavour:

- *"Composition takes the maximum … the safe resolution is always 'keep it longer'."* With the default already at the ceiling, a maximum can only raise — so `flagged_days: 30` and `flagged_days: 200` both resolved to 400 and no record could ever shorten anything.
- *"The 35-day searchable message index and the raw-message window … are not configured here."* They are now.

Backing change: go-mailsec#93 and legion_mailsec (the retention janitor's second duty) make the knob actually delete, below the store's own ceilings. This PR makes the docs describe what the product does.

## What changes

- **`policy.md` → `retention`**: both fields with what each lane governs; the ceilings and the one-day floor, both *refused* rather than clamped; what deletion actually removes and that it is permanent; and composition taking the **minimum** — the strictest record wins, toward holding less of the customer's mail.
- Two consequences a customer would otherwise discover by surprise are stated: a large backlog drains over several sweeps rather than at once, and setting `flagged_days` *below* `message_days` leaves index entries whose stored copy is already deleted (which is what they asked for, but is worth saying).
- **`messages.md` / `pipeline.md`**: the two lanes are now labelled with the field that shortens each, and "tunable" is corrected to "tunable *downwards*, and what falls past the horizon is deleted".

## Notes

- **Overlaps #378** (the tenant-purge docs, also open and awaiting you): both edit the tail of the `retention` section in `policy.md` and the retention block in `pipeline.md`. Whichever lands second needs a small rebase — say the word and I will do it. The two are complementary: #378 is deletion *on request*, this is deletion *on a clock the customer sets*.
- **No release note.** The feature is exp-only while the prod rollout is on hold; the composition change is a real behaviour change and belongs in the GA notes, not in today's.

Public repo — opening for review only, not merging.
