### PR TITLE
Email Security: document the raw-download budget and the access event

### DIFF
--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -82,6 +82,7 @@ that fires on volume. A refused attempt carries `result: refused` and a
 |---|---|
 | `permission_denied` | The caller holds `mailsec.get` but not `mailsec.get.eml` |
 | `quota_exceeded` | The organization's download budget for the window is spent |
+| `quota_unavailable` | The budget could not be evaluated (a `503`, not a `429` — nothing was exceeded) |
 | `justification_missing` / `justification_too_short` / `justification_too_long` | No usable reason was supplied |
 | `message_not_found` | The `msg_uuid` matched no indexed message |
 | `eml_never_stored` | The message exists but no raw copy was written at ingest |
@@ -105,6 +106,12 @@ no live mail connection to ship the event on. Expand the `action_id` through
     Exceeding either returns `429` with a body naming the budget. The
     organization-wide refusal is recorded in the action audit and emitted as an
     `EMAIL_ACTION` with `refused_reason: quota_exceeded`.
+
+    These budgets **fail closed**: if they cannot be evaluated, the download is
+    refused with a `503` and `refused_reason: quota_unavailable` rather than
+    served. A budget that cannot be counted is not a budget, and this is the one
+    route that hands original message bytes out of the platform. No other Email
+    Security route is rate-limited, so none is affected.
 
     Every other Email Security route returns the product's *view* of a message —
     the index row, the verdict, the parsed model — and reading those in bulk is

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -66,8 +66,51 @@ the `justification` query parameter is **required**.
 |---|---|
 | `justification` | Why these bytes are being accessed. Recorded against your authenticated identity in the organization's action audit and retained for 400 days — a failed attempt is recorded too. Stored verbatim; the backend enforces a minimum and a maximum length and refuses an over-long reason rather than truncating |
 
-Raw copies expire 35 days after delivery (longer for flagged messages), after
+Raw copies expire with their retention lane — `message_days` (up to 35) for the message index, `flagged_days` (up to 400) once a message is flagged, see [`retention`](policy.md#retention) — after
 which this returns a typed expiry error while the index row stays readable.
+
+**Every attempt is telemetry.** Served or refused, each call emits an
+`EMAIL_ACTION` event with `action: get_eml` on the connection's sensor, carrying
+the actor, the message, the mailbox, the stated justification, and — on a served
+download — the `bytes` handed over. That is what makes the download *alertable*
+rather than merely recorded: see
+[Detections & Verdicts](detections.md#watching-the-download-itself) for a rule
+that fires on volume. A refused attempt carries `result: refused` and a
+`refused_reason`:
+
+| `refused_reason` | Meaning |
+|---|---|
+| `permission_denied` | The caller holds `mailsec.get` but not `mailsec.get.eml` |
+| `quota_exceeded` | The organization's download budget for the window is spent |
+| `justification_missing` / `justification_too_short` / `justification_too_long` | No usable reason was supplied |
+| `message_not_found` | The `msg_uuid` matched no indexed message |
+| `eml_never_stored` | The message exists but no raw copy was written at ingest |
+| `eml_expired` | The raw copy aged out of its retention lane |
+| `read_failed` | The object is there and could not be read |
+| `eml_store_not_configured` | This deployment has no raw-message store |
+
+The response's `audited` block echoes the `action_id`, the recorded actor and
+justification, and `event_emitted` — which is `false` when the organization has
+no live mail connection to ship the event on. Expand the `action_id` through
+`GET /actions/{action_id}` to read the justification back.
+
+!!! warning "This route is rate-limited, and deliberately the only one that is"
+    Two budgets apply, both per rolling hour:
+
+    | Budget | Limit |
+    |---|---|
+    | Per API key (or user) per organization | **120** downloads |
+    | Per organization, across every key | **600** downloads |
+
+    Exceeding either returns `429` with a body naming the budget. The
+    organization-wide refusal is recorded in the action audit and emitted as an
+    `EMAIL_ACTION` with `refused_reason: quota_exceeded`.
+
+    Every other Email Security route returns the product's *view* of a message —
+    the index row, the verdict, the parsed model — and reading those in bulk is
+    what a dashboard does. This one returns the message, so a legitimate key
+    doing it in bulk is exfiltration. There is no bulk EML export route, and the
+    limits are sized for an analyst working a queue rather than for a scrape.
 
 ### `DELETE /tenant`
 

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -89,6 +89,7 @@ that fires on volume. A refused attempt carries `result: refused` and a
 | `eml_expired` | The raw copy aged out of its retention lane |
 | `read_failed` | The object is there and could not be read |
 | `eml_store_not_configured` | This deployment has no raw-message store |
+| `internal_error` | The service could not complete the read (an index-store failure, not an object failure) |
 
 The response's `audited` block echoes the `action_id`, the recorded actor and
 justification, and `event_emitted` — which is `false` when the organization has

--- a/docs/email-security/automation.md
+++ b/docs/email-security/automation.md
@@ -20,7 +20,7 @@ is one sensor, not ten thousand.
 |---|---|
 | `EMAIL_MESSAGE` | Once per message, at ingest. Carries the whole parsed model — headers, sender, recipients, body, links, attachments, authentication, hops — plus the enrichments and the verdict. It is the record that this mail arrived |
 | `EMAIL_VERDICT` | On **every** verdict decision: the rule pack's own, at ingest right after the `EMAIL_MESSAGE` (`revision/seq: 0`, `revision/mode: auto`), and then once per override afterwards (`seq: 1…`, mode `analyst`, `ai` or `detonation`) |
-| `EMAIL_ACTION` | On every remediation outcome, including failures and skips. Who asked, what was attempted, what happened |
+| `EMAIL_ACTION` | On every remediation outcome, including failures and skips, **and on every raw-message download** (`action: get_eml`), served or refused. Who asked, what was attempted, what happened |
 | `EMAIL_USER_REPORT` | When a message reaches the abuse mailbox and becomes a report |
 | `EMAIL_INGEST_ERROR` | When a message could not be fetched or processed. Coverage honesty: failures are visible, never silent |
 

--- a/docs/email-security/detections.md
+++ b/docs/email-security/detections.md
@@ -215,6 +215,87 @@ without forking anything, through
     your sender history, your VIP list — is named explicitly in the response
     rather than silently missing.
 
+## Watching the download itself
+
+Detection does not stop at the mail. The most privileged thing anyone can do in
+this product is take a person's original message out of it, and that act is
+telemetry too: every call to
+[`GET /messages/{msg_uuid}/eml`](api-reference.md#get-messagesmsg_uuideml) —
+served or refused — emits an `EMAIL_ACTION` with `action: get_eml`, carrying the
+actor, the mailbox, the stated justification, and the `bytes` handed over.
+
+One download is an analyst doing their job. A hundred in an hour is not, and it
+is the *volume* that says so — which is why the byte count is on the event.
+
+```yaml
+# Detect: one identity pulling raw mail in bulk
+op: and
+rules:
+  - op: is
+    path: routing/event_type
+    value: EMAIL_ACTION
+  - op: is
+    path: event/action
+    value: get_eml
+  - op: is
+    path: event/result
+    value: ok
+```
+
+```yaml
+# Respond
+- action: report
+  name: mailsec-raw-download
+  detect_data:
+    actor: '{{ .detect.event.actor }}'
+    mailbox: '{{ .detect.event.mailbox.address }}'
+    bytes: '{{ .detect.event.bytes }}'
+  suppression:
+    is_global: true
+    keys:
+      - 'mailsec-raw-download'
+      - '{{ .detect.event.actor }}'
+    max_count: 25
+    period: 1h
+```
+
+The suppression block is doing the real work: it lets twenty-five downloads an
+hour by one identity pass without a detection and reports the twenty-sixth, so
+the rule is quiet for normal use and loud for a scrape. Set `max_count` to what
+your team actually does in an hour, not to a number that feels safe.
+`is_global: true` keys the budget on the identity across the whole organization
+rather than per sensor — an analyst working two mail connections is still one
+analyst.
+
+Templates in `detect_data` and `metadata` resolve against the **detection**, not
+the raw event, which is why the paths above are `.detect.event.…`.
+
+!!! tip "Alert on the refusals too — they are the earlier signal"
+    A stolen or over-broad key usually fails before it succeeds. Match
+    `event/result` = `refused` and read `event/refused_reason`:
+    `permission_denied` means somebody without the `mailsec.get.eml` grant
+    reached for raw mail, and `quota_exceeded` means the organization's download
+    budget was hit. Both are worth a detection on the first occurrence, with no
+    suppression at all.
+
+```yaml
+# Detect: somebody reached for raw mail without the grant
+op: and
+rules:
+  - op: is
+    path: routing/event_type
+    value: EMAIL_ACTION
+  - op: is
+    path: event/action
+    value: get_eml
+  - op: is
+    path: event/refused_reason
+    value: permission_denied
+```
+
+Both rules are ordinary platform D&R rules on the `edr` target, so the same
+response arsenal applies — page a channel, open a ticket, disable the key.
+
 ## Two seats for rules
 
 Signal rules run in the collector, before the verdict is emitted. Platform D&R


### PR DESCRIPTION
Documents the two controls added to the raw-message download in the paired backend PRs.

**`api-reference.md`** — the `GET /messages/{msg_uuid}/eml` section now states that every attempt, served or refused, emits an `EMAIL_ACTION` with `action: get_eml` on the connection's sensor, carrying the actor, the message, the mailbox, the stated justification and the byte count. Adds the table of `refused_reason` codes a client can branch on, the `audited` block (including `event_emitted`, which is `false` when the organization has no live mail connection to ship on), and the two rate limits with the reason this is the only route on the surface that carries one.

**`detections.md`** — a new "Watching the download itself" section with two working D&R rules: one alerting on download *volume* (the byte count is on the event precisely so the rule can be about volume rather than about the fact that one download happened, and the suppression block is what makes it quiet for normal use and loud for a scrape), and one alerting on the first `permission_denied` refusal, which is the earlier signal a stolen key produces. Template paths are `.detect.event.…` per the response-actions reference — the transform context is the detection, not the raw event.

**`automation.md`** — one-line correction: the `EMAIL_ACTION` row said "on every remediation outcome", which is no longer the whole truth.

Paired with legion_mailsec#79 (the record) and lc_api-go#935 (the budgets). Public repo — **not merging**; opened for review and for Maxime to merge when the backend is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)