### PR TITLE
Email Security: a campaign takes two messages, and member_count never goes down

### DIFF
--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -48,7 +48,7 @@ Shared behaviours:
 | `GET /messages` | `{messages, next_cursor}` — the message index. Filters: `mailbox`, `sender_email`, `sender_root_domain`, `campaign_id`, `link_domain`, `attachment_sha256`, `verdict[]`, `state[]`, `direction[]`, `user_reported`, `min_score`, `q`, `since`, `until`, `cursor`, `limit` |
 | `GET /messages/{msg_uuid}` | `{message, mdm, mdm_source}` — the index row, the full signal rationale, the action timeline, and the Message Data Model. `mdm_source` is `stored` (the model the collector judged with, enrichments included) or `eml_reparse` (a fresh parse of the original bytes, no enrichments). `mdm_unavailable_reason` replaces the model when neither is available |
 | `GET /messages/{msg_uuid}/similar` | `{messages, since}` — recent messages sharing at least one clustering key, each with the `matched_keys` that matched, plus the lookback window that was searched. Candidates, not a cluster |
-| `GET /campaigns` | `{campaigns, next_cursor}`. Filters: `state[]`, `verdict[]`, `min_members`, `since`, `until`, `cursor`, `limit` |
+| `GET /campaigns` | `{campaigns, next_cursor}`. Filters: `state[]`, `verdict[]`, `min_members`, `since`, `until`, `cursor`, `limit`. Every campaign has at least two members, so `min_members` only narrows past that; values below `2` have no effect |
 | `GET /campaigns/{campaign_id}` | `{campaign}` — span, membership, verdict, and the keys that bound the messages together |
 | `GET /reports` | The user-report queue. Params: `status[]` (`open`, `triaging`, `resolved`), `oldest_first`, `cursor`, `limit` |
 | `GET /reports/{report_id}` | One report: who reported it, the message they reported, the original once located across the tenant's mailboxes, and its triage state |

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -29,6 +29,26 @@ whole tenant into one campaign.
 Candidates are considered newest first, bounded, and the first one reaching the
 threshold wins. Joining an existing campaign always beats seeding a new one.
 
+## A campaign takes two messages
+
+A campaign is created on the **second** message, never the first. When a message
+agrees with an earlier one that is not yet in any campaign, the campaign is
+created around **both** of them in one step — the earlier message is the seed, so
+the campaign's identity and its sample subject come from the first message of the
+attack, which is what you expect to see when you open it.
+
+A single message is not a campaign. `member_count` is the spread the campaign
+list leads with and the number a campaign-wide quarantine is justified by, so a
+cluster of one is deliberately not shown anywhere: not in the campaign list, not
+in the Overview's active-campaign count, and not in the campaign detail. Setting
+`min_members` to `1` does not reveal them — the filter can only narrow past the
+two-member minimum, never below it.
+
+`member_count` **never goes down**. A campaign row lives for 400 days while the
+message index it draws on lives for 35, so the count is the historical spread of
+the attack rather than a count of messages still in the index. A campaign whose
+members have aged out still tells you how big the attack was.
+
 ## Body similarity
 
 The first three keys are all things an attacker can randomize. A kit that gives
@@ -159,6 +179,8 @@ limacharlie mailsec campaign get <campaign_id> --oid $OID
 
 Filters: `state` (`open`, `closed`), `verdict`, `min_members`, `since`/`until`,
 all repeatable where it makes sense and keyset-paginated like every other list.
+`min_members` narrows past the two-member minimum every campaign already meets;
+values below `2` have no effect.
 
 The detail view gives the campaign's span, its membership, its verdict and the
 keys that bound its messages together. From a message, `campaign_id` is on the


### PR DESCRIPTION
Documents two campaign semantics the product enforces and the docs did not state.

**A campaign is created on the second message.** The engine has always intended this ("a campaign of one is not a campaign"), but 70% of the campaigns on the acceptance org had exactly one member because of two backend defects. Those are fixed, and the read side now enforces a two-member floor: a sub-threshold cluster is absent from the campaign list, from the Overview's active-campaign count and from the campaign detail, and `min_members` can only narrow past two rather than below it. That is a visible behaviour change for an API client that was passing `min_members=1`, so it is stated in both the guide and the route table.

**`member_count` never decreases.** The sweep-preview section already leaned on the number without defining it. A campaign row lives 400 days while the message index lives 35, so the count is the historical spread of the attack rather than a count of messages still in the index — a campaign whose members have aged out still says how big the attack was.

Public repo: PR only, not merged.