### PR TITLE
Email Security: the free trial, the 25-mailbox cap, and the notice before a deletion

### DIFF
--- a/docs/email-security/getting-started.md
+++ b/docs/email-security/getting-started.md
@@ -27,6 +27,20 @@ limacharlie extension list --oid $OID
 Subscribing also seeds the recommended policy records — all in `alert_only`
 mode, so nothing moves mail until you say so. See [Policy Reference](policy.md).
 
+!!! info "Free trial: 14 days, 25 mailboxes"
+    An organization on the LimaCharlie free tier gets Email Security in full for
+    **14 days** and protects up to **25 mailboxes** while it does. Every feature
+    is the same as on a paid plan; only the duration and the mailbox count
+    differ. The clock starts the day you subscribe and **does not restart if you
+    unsubscribe and resubscribe**, so point the 25 at the mailboxes that matter
+    — start with the executives, finance and the abuse mailbox.
+
+    When the trial ends, ingestion pauses and nothing is deleted; the data is
+    removed 30 days later unless the organization moves off the free tier, and
+    you are told before that happens. The full rules, and the exact fields to
+    read the countdown from, are in
+    [Plans, the free trial, and the mailbox cap](policy.md#plans-the-free-trial-and-the-mailbox-cap).
+
 ## 2. Grant the permissions
 
 Email Security ships four permissions. A user or API key that will triage mail
@@ -180,6 +194,28 @@ the **worst** connection, and an organization with no connection at all reads
 The same call reports message volume and the verdict funnel over a window, the
 parse-degradation rate, backfill progress, the emission backlog, open reports,
 active campaigns, and the effective automation mode.
+
+It also carries an `entitlement` block: which plan the organization is on, when
+a trial ends, how many mailboxes it may protect against how many it is
+protecting, and — if one is scheduled — the date its Email Security data will be
+deleted and what cancels it. On a trial organization this is where you check
+that the 25 mailboxes are the 25 you meant:
+
+```yaml
+entitlement:
+  plan: trial
+  trial_ends_at: "2026-09-20T14:02:11Z"
+  trial_days_remaining: 12
+  mailbox_cap: 25
+  mailboxes_active: 25
+  mailboxes_over_cap: 118        # discovered, not protected
+  mailbox_cap_reached: true
+```
+
+`mailboxes_over_cap` is the number that matters: those mailboxes were found and
+are not being watched. Narrow the connection's `scope`, or move off the free
+tier. See
+[Plans, the free trial, and the mailbox cap](policy.md#plans-the-free-trial-and-the-mailbox-cap).
 
 !!! note "Backfill is metadata-only"
     On connection, the collector walks up to `ingest.backfill_days` (14 by

--- a/docs/email-security/policy.md
+++ b/docs/email-security/policy.md
@@ -465,14 +465,103 @@ server from your verified claims rather than taken from the request.
 
 ### It also happens without a request
 
-| Event | When the data is deleted |
-|---|---|
-| The organization unsubscribes from Email Security | **30 days** later. Resubscribing at any point inside those 30 days cancels the scheduled deletion |
-| The organization itself is deleted | Immediately |
+| Event | When the data is deleted | What cancels it |
+|---|---|---|
+| The organization unsubscribes from Email Security | **30 days** later | Resubscribing at any point inside those 30 days |
+| The organization's free trial ends and it stays on the free tier | **30 days** later | Moving the organization off the free tier at any point inside those 30 days |
+| The organization itself is deleted | Immediately | Nothing — the organization no longer exists |
 
-Neither needs anyone to ask. The 30-day delay exists so that unsubscribing by
-mistake, or moving billing around, is recoverable — and resubscribing is all the
-recovery takes.
+None of them needs anyone to ask. The 30-day delay exists so that unsubscribing
+by mistake, letting a trial lapse over a holiday, or moving billing around is
+recoverable — and undoing the thing that started the clock is all the recovery
+takes. The two cancellations are **not interchangeable**: resubscribing does not
+cancel a deletion scheduled because a trial ended, and upgrading does not cancel
+one scheduled because the organization unsubscribed. Each undoes only what it
+contradicts.
+
+### You are told before it happens
+
+A scheduled deletion is never silent. You learn about it three ways:
+
+- **When it is scheduled**, as an error-stream notice naming the exact date, why
+  the deletion was scheduled, and what cancels it.
+- **Seven days before it fires**, as a second notice marked `FINAL NOTICE`.
+- **At any time**, from the `entitlement` block of
+  [`GET /coverage`](api-reference.md#get-coverage) — `purge_scheduled_at`,
+  `purge_reason`, `purge_days_remaining` and `purge_cancellable`. The block is
+  absent from the response only when nothing is scheduled.
+
+Both notices go to the organization's error stream, which is the same place
+Email Security reports that ingestion has paused — so there is one place to
+watch, and a D&R rule or an output can act on either. Each notice is delivered
+exactly once per scheduled deletion; if the deadline moves, the notices are
+re-sent for the new date.
+
+## Plans, the free trial, and the mailbox cap
+
+Email Security is available to every organization. What differs between a
+**trial** organization and a **paid** one is how long it runs and how many
+mailboxes it protects.
+
+An organization is on the trial when it is on the LimaCharlie free tier — the
+same line the rest of the platform draws, so an organization evaluating Email
+Security and Cloud Security at once gets one answer about what it is paying for.
+
+| | Trial | Paid |
+|---|---|---|
+| Duration | **14 days** from the day Email Security was enabled | No limit |
+| Protected mailboxes | **25** | No limit |
+| Everything else — detections, remediation, retention, API, telemetry | Identical | Identical |
+
+### The 14-day clock
+
+The clock starts the day the organization first subscribes to
+`ext-email-security` and is recorded durably. **Unsubscribing and resubscribing
+does not restart it**: the clock survives an unsubscribe, so a trial is 14 days
+once rather than 14 days per subscription. Moving the organization off the free
+tier clears the limits immediately.
+
+Read the remaining time from the `entitlement` block of
+[`GET /coverage`](api-reference.md#get-coverage): `trial_ends_at` and
+`trial_days_remaining`.
+
+### What happens when the trial ends
+
+The same thing that happens when an organization unsubscribes, and for the same
+reason — the product stops, nothing is deleted yet:
+
+- **Ingestion pauses.** No new mail is analyzed, and the mail connections are
+  not renewed, so the provider's own watches expire on their own schedule.
+- **Nothing is deleted, and nothing is changed.** The connections, the policy
+  records and every message already analyzed are intact and follow their normal
+  [retention](#data-retention-and-deletion).
+- **Reading and acting still work.** An analyst can still search the queue, read
+  a message and remediate mail that was already ingested.
+- **The 30-day deletion clock starts**, with the notices described above.
+
+Moving the organization off the free tier resumes ingestion within about five
+minutes, and cancels the scheduled deletion. Mail delivered while ingestion was
+paused is not analyzed retroactively.
+
+### The 25-mailbox cap
+
+A trial organization protects up to 25 mailboxes. The cap applies to the whole
+organization, across every connected mail tenant, and it works on **activation**
+only:
+
+- Discovery still finds every mailbox in the tenant — the ones past the cap are
+  reported as `discovered` rather than `protected`, so you can see exactly how
+  much of the estate is not covered.
+- A mailbox that is already protected is **never** dropped to fit a cap. If the
+  cap is reached, further mailboxes stop being protected; the ones already being
+  watched keep being watched.
+- Use [`exclusions`](#exclusions) and the connection's `scope` to choose *which*
+  25 mailboxes matter — the executives and finance addresses attacks aim at are
+  the ones worth spending a trial on.
+
+`GET /coverage`'s `entitlement` block reports `mailbox_cap`, `mailboxes_active`,
+`mailboxes_over_cap` and `mailbox_cap_reached`, so the shortfall is a number
+rather than a discovery.
 
 ### Requesting a purge
 


### PR DESCRIPTION
Board: [Pre-GA] W7 org lifecycle. Public repo — **open for review, not to be merged without Maxime's go-ahead.**

## Why

Two gaps a customer would hit in their first week:

- Nothing anywhere said what an Email Security **free trial** is. Not how long it runs, not how many mailboxes it covers, not what happens when it ends. The product now has a 14-day clock and a 25-mailbox cap; documenting them after they ship is the wrong order.
- `policy.md` already explained what a tenant purge deletes and that an unsubscribe schedules one 30 days out — but not that the customer is **told** before it happens, and not that a lapsed trial schedules one too. The whole point of a 30-day grace is that it is recoverable, and a grace nobody is told about is not one.

## What changed

**`policy.md`**

- New section **Plans, the free trial, and the mailbox cap**: 14 days, 25 mailboxes, the fact that the clock does not restart on a resubscribe, what happens at expiry (ingestion pauses, nothing is deleted, reading and remediation still work), and that the cap applies to activation only — a mailbox already protected is never dropped to fit it.
- The "it also happens without a request" table gains the trial row and a **what cancels it** column, with the point that the two cancellations are not interchangeable: resubscribing does not cancel a deletion scheduled because a trial ended, and upgrading does not cancel one scheduled because the organization unsubscribed.
- New subsection **You are told before it happens**: the notice when a deletion is scheduled, the `FINAL NOTICE` seven days before it fires, and the `entitlement` fields on `GET /coverage` to read the countdown from at any time.

**`getting-started.md`**

- A trial callout at the subscribe step — where a new organization actually is when the decision "which mailboxes do I point this at" is still open.
- The coverage step now shows the `entitlement` block, with `mailboxes_over_cap` called out as the number that matters: those mailboxes were found and are not being watched.

## Notes

No feature is documented ahead of itself: the backend is in review at the same time, and this PR should land with it. Nothing here names a price — pricing is deferred, and the trial is described in terms of the free tier the platform already has.
