### PR TITLE
docs(email-security): the campaign sweep's justification, its own audit row, and a deliberate retry

### DIFF
--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -183,7 +183,7 @@ organization is deleted. See
 | Route | Does |
 |---|---|
 | `POST /messages/{msg_uuid}/actions` | Perform a typed action on one message. Body: `action` (`quarantine_message`, `trash_message`, `move_to_spam`, `restore_message`, `banner_message`, `unbanner_message`), optional `reason`, optional `attempt` (idempotency token — omit to collapse onto the existing attempt). `banner_message` uses the organization's own banner, rendered from its `mailsec_policy` record of type `banners`; the body's `banner` field is **deprecated and ignored** and will be removed. Requires `mailsec.act` |
-| `POST /campaigns/{campaign_id}/actions` | Sweep a campaign. Same body plus `confirm`. **Without `confirm` this previews** and changes nothing, returning the member ids, the distinct mailboxes, the counts and a `confirm` token derived from that exact member set. With `confirm` it executes exactly that set; a campaign that grew since the preview is refused. Capped at 500 members. `reason` is recorded on **every member's** audit row and on the sweep's own row (`action_id` in the response); `attempt` mints a new row per member, so a deliberate retry is recorded beside what it retried instead of over it. Neither is part of the `confirm` token. Requires `mailsec.act` |
+| `POST /campaigns/{campaign_id}/actions` | Sweep a campaign. Same body plus `confirm`. **Without `confirm` this previews** and changes nothing, returning the member ids, the distinct mailboxes, the counts and a `confirm` token derived from that exact member set. With `confirm` it executes exactly that set; a campaign that grew since the preview is refused. Capped at 500 members. `reason` is recorded on **every member's** audit row and on the sweep's own row (`action_id` in the response); `attempt` (bounded at 128 characters, refused not truncated) mints a new row per member, so a deliberate retry is recorded beside what it retried instead of over it. Neither is part of the `confirm` token. Requires `mailsec.act` |
 | `POST /actions/bulk/execute` | Execute a previewed bulk remediation. Returns a `bulk_id` immediately and the provider work proceeds in the background. Requires `mailsec.act`. See [Bulk Remediation](remediation.md) |
 | `POST /reports/{report_id}/resolve` | Record a triage outcome. Body: `disposition` — one of `true_positive`, `false_positive`, `benign`. Resolving an already-resolved report succeeds and reports `already_resolved`, so two analysts clicking at once is not an error. Requires `mailsec.set` |
 | `POST /reports/{report_id}/reopen` | Put a resolved report back in the queue — see [`POST /reports/{report_id}/reopen`](#post-reportsreport_idreopen). Requires `mailsec.set` |
@@ -314,10 +314,11 @@ success/failure:
 | `failed` | The provider refused or errored; `error` carries the reason |
 | `pending` | In flight |
 
-A campaign sweep returns `attempted`, `succeeded`, `alert_only`, a per-member
-`failed` map, and `action_id` — the sweep's own audit row, readable through
-`GET /actions/{action_id}`, carrying the operator's justification and the counts.
-It does not abort on the first error.
+A campaign sweep returns `attempted`, `succeeded`, `skipped` (a subset of
+`succeeded`: members already in the target state, which cost no provider write),
+`alert_only`, a per-member `failed` map, and `action_id` — the sweep's own audit
+row, readable through `GET /actions/{action_id}`, carrying the operator's
+justification and the counts. It does not abort on the first error.
 
 ## Telemetry event contract
 

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -183,7 +183,7 @@ organization is deleted. See
 | Route | Does |
 |---|---|
 | `POST /messages/{msg_uuid}/actions` | Perform a typed action on one message. Body: `action` (`quarantine_message`, `trash_message`, `move_to_spam`, `restore_message`, `banner_message`, `unbanner_message`), optional `reason`, optional `attempt` (idempotency token — omit to collapse onto the existing attempt). `banner_message` uses the organization's own banner, rendered from its `mailsec_policy` record of type `banners`; the body's `banner` field is **deprecated and ignored** and will be removed. Requires `mailsec.act` |
-| `POST /campaigns/{campaign_id}/actions` | Sweep a campaign. Same body plus `confirm`. **Without `confirm` this previews** and changes nothing, returning the member ids, the distinct mailboxes, the counts and a `confirm` token derived from that exact member set. With `confirm` it executes exactly that set; a campaign that grew since the preview is refused. Capped at 500 members. Requires `mailsec.act` |
+| `POST /campaigns/{campaign_id}/actions` | Sweep a campaign. Same body plus `confirm`. **Without `confirm` this previews** and changes nothing, returning the member ids, the distinct mailboxes, the counts and a `confirm` token derived from that exact member set. With `confirm` it executes exactly that set; a campaign that grew since the preview is refused. Capped at 500 members. `reason` is recorded on **every member's** audit row and on the sweep's own row (`action_id` in the response); `attempt` mints a new row per member, so a deliberate retry is recorded beside what it retried instead of over it. Neither is part of the `confirm` token. Requires `mailsec.act` |
 | `POST /actions/bulk/execute` | Execute a previewed bulk remediation. Returns a `bulk_id` immediately and the provider work proceeds in the background. Requires `mailsec.act`. See [Bulk Remediation](remediation.md) |
 | `POST /reports/{report_id}/resolve` | Record a triage outcome. Body: `disposition` — one of `true_positive`, `false_positive`, `benign`. Resolving an already-resolved report succeeds and reports `already_resolved`, so two analysts clicking at once is not an error. Requires `mailsec.set` |
 | `POST /reports/{report_id}/reopen` | Put a resolved report back in the queue — see [`POST /reports/{report_id}/reopen`](#post-reportsreport_idreopen). Requires `mailsec.set` |
@@ -314,8 +314,10 @@ success/failure:
 | `failed` | The provider refused or errored; `error` carries the reason |
 | `pending` | In flight |
 
-A campaign sweep returns `attempted`, `succeeded`, `alert_only` and a per-member
-`failed` map. It does not abort on the first error.
+A campaign sweep returns `attempted`, `succeeded`, `alert_only`, a per-member
+`failed` map, and `action_id` — the sweep's own audit row, readable through
+`GET /actions/{action_id}`, carrying the operator's justification and the counts.
+It does not abort on the first error.
 
 ## Telemetry event contract
 

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -253,10 +253,17 @@ campaign_id: <campaign_id>
 action: quarantine_message
 attempted: 38
 succeeded: 36
+skipped: 4
 alert_only: 0
 failed:
   <msg_uuid>: "<provider error>"
+action_id: <action_id>
 ```
+
+`skipped` counts members that were **already** where the action wanted them. It is
+a *subset* of `succeeded` — the campaign is where you asked, and those members
+cost no provider write — so a re-run of a sweep reads `succeeded: 38, skipped: 38`
+rather than looking identical to the run that really moved 38 messages.
 
 A sweep does **not** abort on the first error. Stopping halfway leaves a campaign
 half-remediated, which is the worst of both states: the attacker still has reach
@@ -323,6 +330,10 @@ the retry lands **beside** the attempt it retried rather than over it. Repeating
 the *same* attempt collapses onto the same rows, which is what makes a lost
 response safe to re-send. `attempt` is not part of the confirmation token either,
 so a token minted by a preview stays valid when you decide to record one.
+
+It is an opaque handle, not prose: it is bounded at 128 characters and refused
+rather than truncated, because it is recorded on every member's audit row and a
+clipped idempotency token is a *different* token.
 
 ## Permissions
 

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -263,8 +263,66 @@ half-remediated, which is the worst of both states: the attacker still has reach
 and the operator believes it is handled. Every member is attempted and every
 failure is named.
 
-Re-running a sweep is idempotent per message and action, so clicking twice does
-not produce two audit rows claiming two quarantines.
+`action_id` is the sweep's own audit row — see below.
+
+### Say why
+
+`reason` is your justification for the campaign-wide action, recorded against
+your authenticated identity. It is stored **on every member's audit row** and on
+the sweep's own record, so an analyst asking "why was *my* message
+quarantined" gets the answer inline from the message, without having to find the
+sweep it came from.
+
+```bash
+limacharlie mailsec campaign action <campaign_id> \
+  --action quarantine_message --confirm "<token>" \
+  --reason "INC-4471: reporter-confirmed credential harvest" --oid $OID
+```
+
+It is optional — an automation has no sentence to type — and bounded at 1024
+characters. An over-long reason is **refused, not truncated**: a clipped
+justification is a corrupted audit record. The bound applies to the preview too,
+so you learn about it before the dialog asks you to confirm.
+
+The reason is deliberately **not** part of the confirmation token. Rewording your
+justification after reading the preview does not invalidate it.
+
+### The sweep's own record
+
+A sweep writes one audit row for itself, beside the one row per member. Its id
+comes back as `action_id`, and it reads like any other action:
+
+```bash
+limacharlie mailsec action get <action_id> --oid $OID
+```
+
+It carries who asked, when, why, and the counts — "quarantined 412 of 418, 6
+failed" — which is also what the campaign's own action history shows.
+
+### Repeating a sweep, and asking for a second one on purpose
+
+Re-running a sweep is idempotent per message and action: clicking twice does not
+produce two audit rows claiming two quarantines, and the provider re-checks each
+message's placement, so a member that is already where the action wanted it comes
+back `skipped`. This is the supported repair for a sweep that partly failed —
+re-run the same action and the members that failed are attempted again.
+
+When you want the retry **recorded separately** — a re-run after a provider
+outage, where the record of what failed matters as much as the record of the
+retry — pass an `attempt` token:
+
+```bash
+curl -X POST "https://api.limacharlie.io/v1/mailsec/$OID/campaigns/$CAMPAIGN/actions" \
+  -H "Authorization: bearer $JWT" -H "Content-Type: application/json" \
+  -d '{"action":"quarantine_message","confirm":"<token>",
+       "reason":"re-running after the provider outage","attempt":"after-the-outage"}'
+```
+
+Any new value mints a new audit row per member and a new record for the sweep, so
+the retry lands **beside** the attempt it retried rather than over it. Repeating
+the *same* attempt collapses onto the same rows, which is what makes a lost
+response safe to re-send. `attempt` is not part of the confirmation token either,
+so a token minted by a preview stays valid when you decide to record one.
 
 ## Permissions
 

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -297,14 +297,24 @@ justification after reading the preview does not invalidate it.
 ### The sweep's own record
 
 A sweep writes one audit row for itself, beside the one row per member. Its id
-comes back as `action_id`, and it reads like any other action:
+comes back as `action_id`, and it reads like any other action — though its
+`action` is the campaign-level name (`quarantine_campaign`), with the
+per-message action inside the request:
 
 ```bash
 limacharlie mailsec action get <action_id> --oid $OID
 ```
 
 It carries who asked, when, why, and the counts — "quarantined 412 of 418, 6
-failed" — which is also what the campaign's own action history shows.
+failed". The campaign's own action history lists the sweep as one row — who
+asked and how it ended — and this is the read you expand it with: the counts and
+the justification live on the row's request, which the history strip does not
+select.
+
+A second sweep of the same campaign upserts each member's row, so an already-swept
+member's inline `reason` and `actor` become the *second* operator's. The first
+operator's justification survives on their own sweep record, which is the other
+reason each sweep writes one.
 
 ### Repeating a sweep, and asking for a second one on purpose
 

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -136,6 +136,12 @@ limacharlie mailsec campaign action "$CAMPAIGN" \
 Sweeps are capped at 500 members: above that the answer is a person deciding,
 not a bigger dialog. See [Campaigns](campaigns.md#sweeping-a-campaign).
 
+`--reason` is recorded on every member's audit row **and** on the sweep's own
+row, which comes back as `action_id` and reads through
+`limacharlie mailsec action get`. It is bounded at 1024 characters and refused
+rather than truncated, and it is not part of the confirmation token — rewording
+it after the preview does not invalidate the token.
+
 ### `alert_only` is a success, not a failure
 
 An action's `result` can come back as `alert_only`, meaning the action was


### PR DESCRIPTION
Documents behaviour that legion_mailsec is landing now (backend PR is private): `POST /campaigns/{campaign_id}/actions` accepted `reason` and `attempt` — the gateway forwards both (the reason since the route shipped, the attempt since a later gateway release) and the API reference says the route takes "the same body plus `confirm`" — but the collector read neither, so a justification typed for a **campaign-wide** quarantine was discarded for every member of the campaign.

The backend now records both. This documents what an operator can rely on:

- **`reason`** is stored on **every member's** audit row and on the sweep's own row, so an analyst asking why *their* message was quarantined gets the answer from the message. Bounded at 1024 characters, **refused rather than truncated**, and validated on the preview leg too. Deliberately **not** part of the `confirm` token: rewording your justification after reading the preview does not invalidate it.
- **The sweep's own audit row**, returned as `action_id` and readable through `GET /actions/{action_id}` / `limacharlie mailsec action get` — who asked, when, why, and the counts.
- **Repeating a sweep** is the supported repair for one that partly failed (idempotent per message and action; an already-placed member comes back `skipped`). An **`attempt`** token is how you ask for the retry to be recorded *beside* what it retried rather than over it. Not part of the confirmation token either. It is bounded at 128 characters and refused rather than truncated, since it is recorded on every member's row.

Three files: `campaigns.md` (the operator's narrative), `api-reference.md` (the route row and the sweep's result), `cli.md` (`--reason` on `campaign action`, which the CLI already offers and whose help text has said "recorded on every resulting audit row" all along).

`npx markdownlint-cli2` is clean.

Public repo: **not merging this myself** — flagging for review.