### PR TITLE
docs(email-security): --attempt on the CLI campaign sweep, and retire the bulk --reason bug note

### DIFF
--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -335,6 +335,8 @@ limacharlie mailsec campaign action "$CAMPAIGN" --oid $OID \
   --attempt after-the-outage
 ```
 
+Or straight against the API:
+
 ```bash
 curl -X POST "https://api.limacharlie.io/v1/mailsec/$OID/campaigns/$CAMPAIGN/actions" \
   -H "Authorization: bearer $JWT" -H "Content-Type: application/json" \

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -329,6 +329,13 @@ outage, where the record of what failed matters as much as the record of the
 retry — pass an `attempt` token:
 
 ```bash
+limacharlie mailsec campaign action "$CAMPAIGN" --oid $OID \
+  --action quarantine_message --confirm "<token>" \
+  --reason "re-running after the provider outage" \
+  --attempt after-the-outage
+```
+
+```bash
 curl -X POST "https://api.limacharlie.io/v1/mailsec/$OID/campaigns/$CAMPAIGN/actions" \
   -H "Authorization: bearer $JWT" -H "Content-Type: application/json" \
   -d '{"action":"quarantine_message","confirm":"<token>",

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -142,6 +142,24 @@ row, which comes back as `action_id` and reads through
 rather than truncated, and it is not part of the confirmation token — rewording
 it after the preview does not invalidate the token.
 
+`--attempt` asks for a **deliberate second run**. Re-running a sweep is
+idempotent per member — the per-member audit key is the campaign itself, so a
+double click, or a retry of a request whose response you never saw, collapses
+onto the row each member already has instead of claiming a move that happened
+once as two. A new `--attempt` composes with the campaign, minting a new action
+id per member and a new sweep record, so a re-run after a provider outage is
+recorded *beside* the run that failed rather than over it; the same value twice
+collapses again. It is an opaque handle you mint, not prose: at most 128
+characters, refused rather than truncated, because a clipped idempotency token
+is a *different* token. Like `--reason`, it is not part of the confirmation.
+
+```bash
+limacharlie mailsec campaign action "$CAMPAIGN" \
+  --action quarantine_message --confirm "$TOKEN" \
+  --reason "re-running after the provider outage" \
+  --attempt after-the-outage
+```
+
 ### `alert_only` is a success, not a failure
 
 An action's `result` can come back as `alert_only`, meaning the action was

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -160,6 +160,11 @@ job's own identity, so the attempt is part of what it names, while a sweep's
 token authorizes a member set and nothing else. Repeat a bulk `--attempt` on the
 execute; add or change a sweep's freely.
 
+`--attempt` on a campaign sweep needs a recent `limacharlie` release; an older
+one refuses the flag as unknown, and the field can be sent directly to the API
+in the meantime (see
+[Campaigns](campaigns.md#repeating-a-sweep-and-asking-for-a-second-one-on-purpose)).
+
 ```bash
 limacharlie mailsec campaign action "$CAMPAIGN" \
   --action quarantine_message --confirm "$TOKEN" \

--- a/docs/email-security/cli.md
+++ b/docs/email-security/cli.md
@@ -151,7 +151,14 @@ id per member and a new sweep record, so a re-run after a provider outage is
 recorded *beside* the run that failed rather than over it; the same value twice
 collapses again. It is an opaque handle you mint, not prose: at most 128
 characters, refused rather than truncated, because a clipped idempotency token
-is a *different* token. Like `--reason`, it is not part of the confirmation.
+is a *different* token, and it is checked on the preview leg too.
+
+Like `--reason`, it is **not** part of a campaign sweep's confirmation — unlike a
+*bulk* action's `--attempt` [below](#bulk-remediation-previews-by-default-too),
+which is. The two tokens answer different questions: a bulk token derives the
+job's own identity, so the attempt is part of what it names, while a sweep's
+token authorizes a member set and nothing else. Repeat a bulk `--attempt` on the
+execute; add or change a sweep's freely.
 
 ```bash
 limacharlie mailsec campaign action "$CAMPAIGN" \

--- a/docs/email-security/remediation.md
+++ b/docs/email-security/remediation.md
@@ -214,24 +214,24 @@ and second column of a pasted CSV are the usual way this happens — is refused
 identical to a legitimately expired one, and the counts you would be consenting
 over would be wrong.
 
-`--reason` **is** supported on the execute and reaches the audit trail.
+`--reason` **is** supported on the execute and reaches the audit trail: it is
+recorded on the job's own row and on every message's, so an analyst reading one
+message's timeline sees why it was acted on without having to discover that the
+row belongs to a bulk job. It is not part of the confirmation token, so
+rewording it between previewing and executing neither invalidates a token you
+hold nor starts a second job over the same messages.
 
-!!! bug "The CLI's `--ai-help` text contradicts itself about `--reason`"
-    `limacharlie mailsec message bulk-action --ai-help` ends with a paragraph
-    claiming "there is no `--reason`". That paragraph is **stale**: the flag is
-    registered, the gateway forwards it, and an earlier paragraph in the same
-    help text describes it correctly. Trust this page and `--help`; the help text
-    is being corrected.
+Passing `--reason` to a *preview* does nothing, and the CLI says so rather than
+accepting it quietly: the preview mints the confirmation and takes no `reason`
+by design, precisely so that rewording a justification can never invalidate a
+selection somebody already approved.
 
-    The Python SDK's `bulk_action_execute()` docstring carries a related but
-    different caveat — that `reason` needs a gateway new enough to forward it.
-    That was true of older deployments and is not a contradiction; it is simply
-    no longer the situation on a current one.
-
-    Passing `--reason` to a *preview* does nothing, and the CLI says so rather
-    than accepting it quietly: the preview mints the confirmation and takes no
-    `reason` by design, so that rewording a justification can never invalidate a
-    selection somebody already approved.
+!!! note "Older CLI builds say the flag does not exist"
+    `limacharlie mailsec message bulk-action --ai-help` used to end with a stale
+    paragraph claiming "there is no `--reason`", contradicting an earlier
+    paragraph in the same text that described the flag correctly. That paragraph
+    has been removed. If your installed CLI still prints it, trust this page and
+    `--help`: the flag has been registered and forwarded the whole time.
 
 ### The exit code carries the outcome
 

--- a/docs/email-security/remediation.md
+++ b/docs/email-security/remediation.md
@@ -226,12 +226,18 @@ accepting it quietly: the preview mints the confirmation and takes no `reason`
 by design, precisely so that rewording a justification can never invalidate a
 selection somebody already approved.
 
-!!! note "Older CLI builds say the flag does not exist"
+!!! note "Older builds on either side of the wire"
     `limacharlie mailsec message bulk-action --ai-help` used to end with a stale
     paragraph claiming "there is no `--reason`", contradicting an earlier
     paragraph in the same text that described the flag correctly. That paragraph
-    has been removed. If your installed CLI still prints it, trust this page and
-    `--help`: the flag has been registered and forwarded the whole time.
+    has been removed; if your installed CLI still prints it, trust this page and
+    `--help`.
+
+    The flag itself has always been registered, but it did not always reach the
+    audit trail: the API used to drop `reason` from this one route before it got
+    to the backend, which is why the Python SDK's `bulk_action_execute()`
+    docstring still carries a note about it. Current deployments forward and
+    record it, so the caveat is history rather than a contradiction.
 
 ### The exit code carries the outcome
 


### PR DESCRIPTION
## Why

Two small drifts between the docs and the CLI.

**The campaign sweep's `attempt` was documented only as a raw HTTP field.** "Repeating a sweep, and asking for a second one on purpose" explained the semantics correctly but could only show a `curl`, because the CLI had no flag for it. It does now, so the section leads with the command an operator would actually run and keeps the `curl` beside it for anyone driving the API directly. `cli.md` gains the same flag beside the `--reason` paragraph it already carried.

**The bulk `--reason` bug notice describes a bug that is fixed.** `remediation.md` carried a standing `!!! bug` admonition because `message bulk-action --ai-help` ended with a paragraph denying a flag the command accepts. That paragraph has been removed upstream, so the notice becomes a short compatibility note for anyone still running an older build, and the accurate description of what the reason does — recorded on the job's row *and* on every message's, deliberately outside the confirmation token — moves into the body where it belongs rather than living inside a warning box.

## Verified

- No headings were added, removed or renamed, so no existing anchor moved.
- Every relative anchor referenced from the three edited pages was checked by hand against the target files' headings (`#body-similarity`, `#clustering`, `#sweeping-a-campaign`, `#revising-a-verdict`, `#data-retention-and-deletion`, `#from-the-cli`, `#writes`, `#actions`, `#automations`, `#banners`) — all resolve.
- The commands shown match the flags the CLI actually registers.

Pairs with the CLI/SDK change in the Python SDK repo; the flag reaches users on that repo's next release.