### PR TITLE
docs(email-security): the message search is literal, and blank text is not a filter

### DIFF
--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -31,6 +31,11 @@ Shared behaviours:
   `?verdict=malicious&verdict=suspicious`. OR within a key, AND across keys.
 - **Boolean selectors are tri-state.** An absent parameter means "not filtered",
   which is *not* the same as passing `false`.
+- **Free-text search (`q`) is literal.** It is a case-insensitive substring match
+  over the message's subject and sender address. `%` and `_` are ordinary
+  characters rather than wildcards — searching for `50% off` returns mail whose
+  subject contains `50% off`, and nothing else. Surrounding whitespace is
+  ignored, and a search that is only whitespace is not a filter at all.
 - **Keyset pagination.** Pages carry `next_cursor`; pass it back as `?cursor=`.
   An empty `next_cursor` is the last page. A cursor is **bound to the filter set
   that minted it** — changing a filter mid-walk fails the next page rather than

--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -105,7 +105,7 @@ justification, and `event_emitted` — which is `false` when the organization ha
 no live mail connection to ship the event on. Expand the `action_id` through
 `GET /actions/{action_id}` to read the justification back.
 
-!!! warning "This route is rate-limited, and deliberately the only one that is"
+!!! warning "This route carries the platform's only hard download quota"
     Two budgets apply, both per rolling hour:
 
     | Budget | Limit |
@@ -120,14 +120,31 @@ no live mail connection to ship the event on. Expand the `action_id` through
     These budgets **fail closed**: if they cannot be evaluated, the download is
     refused with a `503` and `refused_reason: quota_unavailable` rather than
     served. A budget that cannot be counted is not a budget, and this is the one
-    route that hands original message bytes out of the platform. No other Email
-    Security route is rate-limited, so none is affected.
+    route that hands original message bytes out of the platform — and the only
+    one that fails closed.
 
     Every other Email Security route returns the product's *view* of a message —
     the index row, the verdict, the parsed model — and reading those in bulk is
     what a dashboard does. This one returns the message, so a legitimate key
     doing it in bulk is exfiltration. There is no bulk EML export route, and the
     limits are sized for an analyst working a queue rather than for a scrape.
+
+!!! note "Two reads are *governed* rather than quota'd"
+    Two read shapes make the platform recompute rather than look up, so they are
+    counted per organization per read class — **7,200 per rolling hour** each —
+    and answer `429` past it:
+
+    | Governed read | When it is counted |
+    |---|---|
+    | `GET /messages` | Only when it carries a `q` that nothing but time bounds |
+    | `GET /coverage` | Only when it names an explicit window (`since`/`until`, or `window_days`) |
+
+    A search that also names a `mailbox`, `sender_email`, `campaign_id`,
+    `link_domain` or `attachment_sha256` is an index lookup and is **not**
+    counted, and neither is the default `GET /coverage` call with no window,
+    which is the one the console makes. Unlike the download budgets above, this
+    one **fails open**: if it cannot be evaluated the read is served, because a
+    counting outage should not black out a dashboard.
 
 ### `DELETE /tenant`
 

--- a/docs/email-security/messages.md
+++ b/docs/email-security/messages.md
@@ -25,7 +25,7 @@ about the rows a browser happened to have loaded.
 | `attachment_sha256` | Messages carrying an attachment with this hash |
 | `user_reported` | Tri-state — see below |
 | `min_score` | Messages scoring at least this much |
-| `q` | Free-text over the message's identifying fields |
+| `q` | Free-text over the message's subject and sender address. **Literal** — see below |
 | `since` / `until` | RFC3339 or unix seconds |
 
 Repeatable filters **OR within a key and AND across keys**: `verdict=suspicious`
@@ -41,6 +41,21 @@ limacharlie mailsec message list --verdict suspicious --verdict malicious \
     Omitting `user_reported` means the dimension is *unconstrained*. Setting it
     to `false` selects mail **nobody reported**, which is a different and much
     larger set than "all mail".
+
+!!! info "`q` is a literal substring, not a pattern"
+    The search text is matched **literally** and case-insensitively against the
+    subject and the sender address. `%` and `_` are ordinary characters rather
+    than wildcards, so searching for `50% off` returns mail whose subject
+    contains `50% off` — not mail whose subject contains `50` followed later by
+    ` off`. Surrounding whitespace is ignored, and text that is only whitespace
+    is not a filter at all. There is no wildcard or regular-expression syntax.
+
+    Because it is matched row by row rather than looked up, a `q` has to be
+    accompanied by something that bounds the read: a `since`, or one of
+    `mailbox`, `sender_email`, `campaign_id`, `link_domain`,
+    `attachment_sha256`, or a single `verdict`. On its own it is refused. It is
+    also capped at 512 characters — search for a distinctive fragment of a
+    subject rather than the whole of it.
 
 ### The two IOC pivots
 

--- a/docs/email-security/messages.md
+++ b/docs/email-security/messages.md
@@ -47,8 +47,9 @@ limacharlie mailsec message list --verdict suspicious --verdict malicious \
     subject and the sender address. `%` and `_` are ordinary characters rather
     than wildcards, so searching for `50% off` returns mail whose subject
     contains `50% off` — not mail whose subject contains `50` followed later by
-    ` off`. Surrounding whitespace is ignored, and text that is only whitespace
-    is not a filter at all. There is no wildcard or regular-expression syntax.
+    `off`, which is what a wildcard would have matched. Surrounding whitespace
+    is ignored, and text that is only whitespace is not a filter at all. There
+    is no wildcard or regular-expression syntax.
 
     Because it is matched row by row rather than looked up, a `q` has to be
     accompanied by something that bounds the read: a `since`, or one of


### PR DESCRIPTION
Publishes the contract that go-mailsec#163 and lc_api-go#947 implement.

**What was wrong.** The API reference lists `q` among the message-index filters and says
nothing about how the text is matched. It was matched as a SQL pattern, so `%` and `_` were
wildcards and a backslash was an escape character: a search for `50% off` also returned
`50 percent off`, a search for `invoice_2026` also returned `invoiceX2026`, a lone `%`
returned every message in the index, and `c:\temp` returned the row *without* the backslash
and missed the one with it. None of that was documented, taught or refused — it was an
accident of the query, and the fix is to match literally rather than to document wildcards
nobody asked for.

**What this adds.** One bullet under "Shared behaviours": `q` is a literal, case-insensitive
substring over the message's subject and sender address; `%` and `_` are ordinary characters;
surrounding whitespace is ignored and whitespace-only text is not a filter.

It is placed in the shared-behaviours list rather than in the `GET /messages` row on purpose:
the held read-budget PR (#389) rewrites that row, and two PRs editing the same line would
collide at merge time. The two statements compose — that one is about what a search must be
accompanied by, this one about what the text means.

**Hold.** This describes behaviour that is not in production until the Email Security gateway
and collector ship there, and Email Security's prod rollout is on hold. Do not merge until
the prod release.
