### PR TITLE
docs(email-security): an interrupted campaign sweep and how to finish it

### DIFF
--- a/docs/email-security/api-reference.md
+++ b/docs/email-security/api-reference.md
@@ -318,7 +318,11 @@ A campaign sweep returns `attempted`, `succeeded`, `skipped` (a subset of
 `succeeded`: members already in the target state, which cost no provider write),
 `alert_only`, a per-member `failed` map, and `action_id` — the sweep's own audit
 row, readable through `GET /actions/{action_id}`, carrying the operator's
-justification and the counts. It does not abort on the first error.
+justification and the counts. It does not abort on the first error. If the
+collector begins shutting down mid-sweep (or the caller's request ends), the
+sweep stops between members and returns a retryable error carrying `attempted`,
+`selected`, `action_id` and `interrupted_by` (`drain` or `caller`); the audit row
+settles `pending`, and re-running the same confirmation finishes it.
 
 ## Telemetry event contract
 

--- a/docs/email-security/campaigns.md
+++ b/docs/email-security/campaigns.md
@@ -324,6 +324,15 @@ message's placement, so a member that is already where the action wanted it come
 back `skipped`. This is the supported repair for a sweep that partly failed —
 re-run the same action and the members that failed are attempted again.
 
+The same repair covers a sweep that was **interrupted**. A collector that begins
+shutting down during a sweep (a deploy, a rebalance) stops between two members —
+the member in flight is always finished and recorded — and answers a retryable
+error naming how far it got (`N of M members were actioned`) and the sweep's
+`action_id`; the same happens when the caller's own request ends first. The
+sweep's audit row then reads `pending` rather than `ok`, so a partial
+campaign-wide action can never look complete. Re-run the same confirmation:
+members already actioned come back `skipped`, the rest are attempted.
+
 When you want the retry **recorded separately** — a re-run after a provider
 outage, where the record of what failed matters as much as the record of the
 retry — pass an `attempt` token:


### PR DESCRIPTION
Documents the interrupted-sweep contract shipped by legion_mailsec#116: a collector that begins shutting down (or a caller whose request ends) stops the sweep between members, answers a retryable error with the counts and the sweep's action_id, settles the audit row as pending, and the repair is re-running the same confirmation.

Held until the runtime reaches production; merge with the prod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)