### PR TITLE
email-security: engine_version names the rule pack and the library build it ran with

### DIFF
--- a/docs/email-security/automation.md
+++ b/docs/email-security/automation.md
@@ -47,7 +47,7 @@ of them.
 | `event/revision/mode` | `auto`, `analyst`, `ai` or `detonation` |
 | `event/revision/verdict`, `event/revision/score` | The decision |
 | `event/revision/rationale` | The reasons, strongest first. For an override these are what the analyst or agent wrote; for `seq 0` they are the names of the signals that fired — so it is **absent** on a benign message that matched nothing, which is the common case |
-| `event/revision/top_signals`, `event/revision/engine_version` | `seq 0` only — the rule ids that fired and the pack version that decided. An override has neither: nothing *matched*, somebody decided |
+| `event/revision/top_signals`, `event/revision/engine_version` | `seq 0` only — the rule ids that fired and the engine that decided (rule-pack version plus the library build it ran with). An override has neither: nothing *matched*, somebody decided |
 | `event/revision/actor` | Who decided. Empty on `seq 0`: the rule pack is not a person, and `engine_version` is what identifies it |
 | `event/revision/prior` | What the override displaced — verdict, score, mode and engine version. On `seq 0` it is present but empty (`verdict: ""`, `score: 0`), because the engine's first call displaced nothing — so match on `revision/seq` or `revision/mode` to tell the two apart, not on `prior` |
 

--- a/docs/email-security/detections.md
+++ b/docs/email-security/detections.md
@@ -26,7 +26,7 @@ The verdict object on a message carries:
 | `top_signals` | Up to five contributing rules, heaviest first, each with `rule_id`, `name` and `weight`. This is the "why this verdict" block |
 | `matched_signals` | Every rule id that matched, including suppressed ones — the hunting surface |
 | `tags` | The deduplicated, sorted tags of the rules that actually contributed |
-| `engine_version` | The rule-pack version that decided it |
+| `engine_version` | The engine that decided it: the rule-pack version plus the build of the parsing and enrichment library it ran with (`mailsec-pack-0.5.1+v0.1.55`). Two verdicts with the same value came from the same engine; a parser change alone changes it |
 | `decided_at` | When |
 | `mode` | Who last decided: `auto` (the rule pack), `analyst` (a person), `ai` (a triage agent) or `detonation` ([link detonation](#link-detonation)). See [Revising a verdict](#revising-a-verdict) |
 | `campaign_id` | The campaign this message was clustered into, if any |
@@ -258,7 +258,9 @@ makes a history rule an amplifier of *other* evidence and never of itself.
 ## The managed rule pack
 
 A packaged, versioned set of rules ships with the product and its version is
-stamped into every verdict as `engine_version`. The current pack:
+the first half of every verdict's `engine_version` (the second half names the
+build of the parsing and enrichment library the rules ran with, because what a
+rule reads is decided there). The current pack:
 
 | Rule id | Class | Weight | What it says |
 |---|---|:--:|---|


### PR DESCRIPTION
Wording for `engine_version`: it now carries the rule-pack version plus the build of the parsing and enrichment library the rules ran with, so two verdicts with the same value came from the same engine. Three lines across detections.md and automation.md. Held for the production release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)